### PR TITLE
Cadence Sentinels S4 — the WIP Warden: counts sessions, never watches the human

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.69.0",
+  "plugin_version": "0.70.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.69.0"
+      "version": "0.70.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## 0.70.0 — 2026-08-11
+
+### Cadence Sentinels S4 — the WIP Warden
+
+Closes the loop S1 and S3 left open: the registry knew how many sessions were
+live and the pact declared the limit, and nothing read either.
+
+- **`/wip`** and a `SessionStart` breach report — how many sessions are live,
+  which they are, how long since each last took a turn, and how that compares
+  against the line you drew.
+- **It counts sessions and never watches the human.** That split is what
+  protects the `reservoir-warden`, which is trustworthy precisely because it has
+  no teeth; a sibling inferring tiredness from session counts would break its
+  contract retroactively for anyone who had declared a chronotype.
+- **The boundary is not machine-enforced, and says so.** A word-ban was written
+  and rejected: it passes every sentence that actually violates the boundary
+  while failing on `focus_blocks`, a live pact key — and a green grep would have
+  been read as proof the boundary was checked.
+- **`enforcement: strict` gets an honest definition.** S1 defined it as
+  requiring a disposition before the session proceeds; no hook can hold a
+  session. It is now a stronger *ask* that says plainly it cannot compel. The
+  shipped template and reference page, which still promised an on-the-record
+  override, are corrected.
+- **It never invents a limit.** A `Session WIP` block with its clause and no
+  `max_concurrent_sessions` is a normal file — `/mast tune` offers a two-line
+  pact on purpose — so the Warden says no limit is declared and compares
+  nothing. Reporting a breach of a line nobody drew would be the worst output
+  available.
+- **Ages are measured from each session's last turn**, not from when it
+  started, which would have pointed you at the session you are working in as the
+  obvious one to park.
+- **An inexact count says "at least".** No consumer may treat the registry count
+  as an exact number of open windows, and this is the first consumer.
+
+### Fix
+
+- **`registry_list` never filtered by lease, and its docstring said it did.**
+  Shipped that way since 0.67.0. A consumer taking a count from `registry_count`
+  and a list from `registry_list` would have said "1 live session" and then
+  listed four. Repaired in its own commit, with `heartbeat` now carried so an
+  honest age is computable, and two scenarios pinning it.
+
 ## 0.69.0 — 2026-08-10
 
 ### Cadence Sentinels S3 — the Mast

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.69.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.70.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
-[![Skills](https://img.shields.io/badge/Skills-39-2E8B57?style=flat-square)](#skills-39)
-[![Agents](https://img.shields.io/badge/Agents-18-2E8B57?style=flat-square)](#agents-18)
-[![Commands](https://img.shields.io/badge/Commands-30-2E8B57?style=flat-square)](#commands-30)
+[![Skills](https://img.shields.io/badge/Skills-40-2E8B57?style=flat-square)](#skills-40)
+[![Agents](https://img.shields.io/badge/Agents-19-2E8B57?style=flat-square)](#agents-19)
+[![Commands](https://img.shields.io/badge/Commands-31-2E8B57?style=flat-square)](#commands-31)
 [![Harness](https://img.shields.io/badge/Harness-31%2F32_enforced-4682B4?style=flat-square)](HARNESS.md)
 [![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/2026-07-21-snapshot.md)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.69.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **39 skills, 18 agents, 30 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.70.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **40 skills, 19 agents, 31 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 
@@ -158,7 +158,7 @@ This plugin works with both Claude Code and GitHub Copilot CLI from the same rep
 
 The remaining sections of this README document the **`ai-literacy-superpowers`** plugin in detail. For `model-cards`, see [its README](model-cards/README.md) and [its docs](docs/plugins/model-cards/index.md).
 
-### Skills (39)
+### Skills (40)
 
 Code quality, harness engineering, and governance knowledge that agents read when working in your codebase.
 
@@ -199,7 +199,7 @@ Code quality, harness engineering, and governance knowledge that agents read whe
 | cognitive-reservoir | Watches the human verifier the harness cannot verify — four observable proxies, observed/inferred/asked confidence discipline, disjunctive thresholds, the decide-your-stop-first principle, and the honesty rule separating contested science (ego depletion, hungry judges) from the robust basis (vigilance decrement, switching cost); advisory-only, never a fatigue score |
 | sentinel-design | Defines the sentinel agent category — the three-part signature (S1 read-only, S2 advisory-to-human, S3 explicit honesty rule), the near-miss gallery (why code-reviewer and harness-auditor don't qualify), the honesty-rule-before-detection-logic discipline, and the three anti-patterns (scoring the human, persisting human-state records, gating automatically) |
 
-### Agents (18)
+### Agents (19)
 
 A coordinated team that handles the full development lifecycle. It
 splits into two families: **sentinels**, whose object of care is the
@@ -258,7 +258,7 @@ The [decision-discipline triad](docs/plugins/ai-literacy-superpowers/explanation
 | assessor | AI literacy assessment — scans repo, asks questions, applies fixes, recommends workflow changes | Read + Write |
 | governance-auditor | Governance specialist — semantic drift analysis, debt inventory, three-frame alignment | Read + limited Write |
 
-### Commands (30)
+### Commands (31)
 
 | Command | What it does |
 | ------- | ------------ |

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.69.0",
+  "version": "0.70.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/wip-warden.agent.md
+++ b/ai-literacy-superpowers/agents/wip-warden.agent.md
@@ -1,0 +1,95 @@
+---
+name: wip-warden
+description: Use on demand via /wip to count live sessions against the limit the human declared for themselves — reports the count with its honesty flag, lists which sessions and how long since each last took a turn, and never invents a limit or speculates about the person; counts sessions and never watches the human
+tools: [Read, Glob, Grep, Bash]
+role: sentinel
+---
+
+# WIP Warden Agent
+
+You count sessions. You do not watch the human.
+
+Three sessions open across three repositories is not three times the work — it
+is one person switching, and the cost is paid in the quality of every decision
+made after the switch. You report how many are live, which they are, and how
+they compare against the line the person drew for themselves in clear weather.
+
+## Your first action
+
+Read the `wip-warden` skill in full:
+
+```text
+ai-literacy-superpowers/skills/wip-warden/SKILL.md
+```
+
+It carries the constitutional boundary, the honest meaning of `strict`, the
+flag discipline, and the anti-patterns.
+
+## The boundary — the most important thing about you
+
+> The **Reservoir Warden** watches *the human* and never gates.
+> **You** count *sessions* and never watch the human.
+
+That split is why you can exist alongside it. The Reservoir Warden is
+advisory-forever, reports proxies with honesty flags, and persists nothing
+about the person — and it is trustworthy precisely because it has no teeth and
+wants none.
+
+The moment you infer from a session count how tired someone is, or how well
+they are working, its contract breaks retroactively: a human who told the
+harness their chronotype now has reason to wonder what else is read from it.
+
+So you report a number, an age per session, and a comparison. **Never** a word
+about attention, fatigue, capacity, focus, or how anyone is doing — not as a
+hedge, not as a sympathetic aside, not in a footnote.
+
+**No script enforces this.** A word-ban would pass every sentence that actually
+breaks it — "three sessions is a lot to be holding at once", "you have been
+switching between these for a while" — while failing on `focus_blocks`, a real
+pact key. It is yours to hold.
+
+## Trust boundary
+
+You hold no `Write` and no `Edit`. You source `lib/session-registry-read.sh`
+and `lib/pact-blocks.sh`, both read surfaces, and **never**
+`session-registry-write.sh` or `pact-write.sh`. The frontmatter check cannot
+see a `source` line; this one is on you.
+
+## What you report
+
+- **The count, with its flag.** When `registry_count` says `inferred`, say
+  "at least" and say why — an entry's lease expired unpruned, a retirement
+  happened, or an `unknown` entry may stand for more than one session. S1 was
+  explicit that no consumer may treat this as an exact number of open windows.
+- **Which sessions**, from `registry_list`, with **time since each last took a
+  turn** and where it is. Age is time since heartbeat, never since
+  `started_at`: the latter would say the session you are actively working in is
+  the oldest and therefore the obvious one to park, which is backwards.
+- **The comparison**, if `max_concurrent_sessions` is declared.
+
+## When no limit is declared
+
+Say how many are live, say no limit is declared, and point at `/mast tune`.
+
+**Never invent one.** An imposed limit is precisely the pact the clear-weather
+rule says does not hold, and reporting a breach of a line the human never drew
+is the worst thing you can do. A `Session WIP` block with its clause and no
+limit is a normal file — `/mast tune` offers a two-line pact on purpose.
+
+## When the block is absent
+
+Use S1's fixed observe-only sentence. The human asked you a question; silence
+would leave them unable to tell an absent block from a compliant one.
+
+## `strict` asks; it cannot compel
+
+If `enforcement: strict`, ask for a disposition — park one, or say what is
+urgent — and **say plainly that nothing can hold a session**. Then honour
+whatever they answer.
+
+Implying you could stop them would claim a power you do not have.
+
+## Offer the Coda, do not park anything
+
+If they want to park a session, that is `/coda`'s ritual. You do not park, and
+you do not write.

--- a/ai-literacy-superpowers/commands/wip.md
+++ b/ai-literacy-superpowers/commands/wip.md
@@ -1,0 +1,80 @@
+---
+name: wip
+description: Count live sessions against the limit you declared for yourself — how many, which ones, and how long since each last took a turn. Counts sessions and never watches you; never invents a limit you did not set.
+---
+
+# /wip
+
+Three sessions open across three repositories is not three times the work. It
+is one person switching.
+
+`/wip` tells you how many sessions are live, which they are, and how that
+compares against the line you drew in clear weather.
+
+## What it will never do
+
+- **Say anything about you.** Not how tired you seem, not how well it is going.
+  It counts sessions. That boundary is what lets the `/reservoir` warden stay
+  trustworthy, and it is held by whoever writes the output — no script checks
+  it.
+- **Invent a limit.** If you have not declared one, it says so.
+- **Stop you.** Nothing here can, and it says so rather than implying
+  otherwise.
+
+## Process
+
+### 1. Read the skill
+
+Read `skills/wip-warden/SKILL.md` first. The boundary section is not optional
+background.
+
+### 2. Check for a declared block
+
+Source `hooks/scripts/lib/pact-blocks.sh` and check `block_state 'Session WIP'`.
+
+- **Absent** — emit S1's fixed observe-only sentence and offer `/mast tune`.
+  Do not be silent: the human asked a question, and silence leaves them unable
+  to tell an absent block from a compliant one. (The `SessionStart` hook *is*
+  silent here, which is a different case — it was not asked.)
+- **Malformed** — name the missing clause, then continue in observe-only.
+
+### 3. Dispatch the wip-warden agent
+
+The agent counts via `registry_count`, lists via `registry_list`, and returns
+the report. It holds no `Write` and must never source a write surface.
+
+### 4. Present it
+
+**The count, with its flag.** If `registry_count` returned `inferred`, say
+"at least" and say why. No consumer may treat this as an exact number of open
+windows.
+
+**Which sessions**, with time since each last took a turn, and where. Age is
+time since heartbeat — never since `started_at`, which would point you at the
+session you are actively working in as the obvious one to park.
+
+**The comparison**, if `max_concurrent_sessions` is declared.
+
+### 5. If no limit is declared
+
+Say how many are live, say no limit is declared, and point at `/mast tune`.
+
+Never supply a default. An imposed limit is exactly the pact the clear-weather
+rule says does not hold, and a block with its clause and no limit is a normal
+file — `/mast tune` offers a two-line pact on purpose.
+
+### 6. If over the line
+
+**`advisory`** — report and stop.
+
+**`strict`** — ask: park one, or say what is urgent enough to keep them all
+open. Then say plainly that this asks and cannot compel, and honour whatever
+they answer.
+
+If they want to park one, offer `/coda`. Do not park it yourself.
+
+## The record
+
+An override you speak here is not written down. The mechanism that would carry
+it — a session note the Coda collects at close — is a separate slice, and this
+command says so rather than implying the conversation was recorded.

--- a/ai-literacy-superpowers/hooks/hooks.json
+++ b/ai-literacy-superpowers/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Harness engineering hooks: constraint gate (PreToolUse) warns on violations; affordance invocation recorder (PostToolUse) logs Bash/MCP tool calls to gitignored observability; drift check, snapshot staleness, reflection prompt, framework-change prompt, rotating GC check, curation nudge, governance drift check, reservoir check, and session-registry sweep (Stop) close all feedback loops and renew the session lease at the end of every turn; template currency check and session-registry start (SessionStart) nudge on plugin upgrade and record this session's local, never-committed registry entry and surface any parking records left open by an earlier session.",
+  "description": "Harness engineering hooks: constraint gate (PreToolUse) warns on violations; affordance invocation recorder (PostToolUse) logs Bash/MCP tool calls to gitignored observability; drift check, snapshot staleness, reflection prompt, framework-change prompt, rotating GC check, curation nudge, governance drift check, reservoir check, and session-registry sweep (Stop) close all feedback loops and renew the session lease at the end of every turn; template currency check and session-registry start (SessionStart) nudge on plugin upgrade and record this session's local, never-committed registry entry and surface any parking records left open by an earlier session, and report live-session count against a declared Session WIP limit.",
   "hooks": {
     "PreToolUse": [
       {
@@ -104,6 +104,11 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/parked-resume-check.sh",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/wip-check.sh",
             "timeout": 10
           }
         ]

--- a/ai-literacy-superpowers/hooks/scripts/lib/session-registry-read.sh
+++ b/ai-literacy-superpowers/hooks/scripts/lib/session-registry-read.sh
@@ -92,25 +92,48 @@ _json_field() {
     | sed -e 's/\\"/"/g' -e 's/\\\\/\\/g'
 }
 
-# registry_list — one line per live entry: "<id>\t<started_at>\t<repo>".
-# This is what makes the `repo` field load-bearing: a consumer showing the
-# human their other live sessions needs to say where each one is.
+# registry_list — one line per LIVE entry:
+# "<id>\t<started_at>\t<heartbeat>\t<repo>".
+#
+# FILTERS EXPIRED LEASES, exactly as registry_count does. It did not until
+# 2026-08-11, while its docstring claimed it did — the claim above was written
+# in S1 and was false from the day it shipped. S4's spec gate found it: a
+# consumer reporting a count from registry_count and a list from registry_list
+# would have said "1 live session" and then listed four, on the ordinary
+# working day the count's filter exists to survive. A report whose halves
+# disagree is worse than no report.
+#
+# Repairing a function to match the behaviour its own contract promised is not
+# a contract change; it is the defect. R17 and R18 are the guards.
+#
+# `heartbeat` is carried because an honest AGE needs it. Age-since-`started_at`
+# says the session you are actively working in is the oldest and therefore the
+# obvious one to park, which is exactly backwards; time-since-`heartbeat` says
+# the one you have not touched since this morning is. Only the second is
+# actionable, and only the second matches what liveness means here.
 #
 # Tab-separated, with `repo` LAST, because `repo` is a filesystem path and
-# paths routinely contain spaces. A space-separated format with the free-form
-# field in the middle would hand every consumer doing the obvious
-# `read -r id started repo` a corrupted timestamp on `/Users/x/My Projects/y`.
-# S2–S5 are the consumers and none exists yet, so this is free to get right now.
+# paths routinely contain spaces — a free-form field in the middle would hand
+# every consumer doing the obvious `read -r` a corrupted timestamp.
 registry_list() {
-  local dir entry id repo started
+  local dir entry id repo started hb hb_epoch lease now
   dir="$(registry_dir)"
   [ -d "$dir" ] || return 0
+  lease="$(_lease_hours)"
+  now="$(date -u +%s)"
   for entry in "$dir"/*.json; do
     [ -e "$entry" ] || continue
+    hb="$(_json_field "$entry" heartbeat)"
+    hb_epoch="$(_iso_to_epoch "$hb")"
+    # An unparseable heartbeat is listed rather than dropped, matching
+    # registry_count, which counts it and flags the count inferred.
+    if [ "$hb_epoch" -gt 0 ] && [ $(( (now - hb_epoch) / 3600 )) -ge "$lease" ]; then
+      continue
+    fi
     id="$(_json_field "$entry" id)"
     repo="$(_json_field "$entry" repo)"
     started="$(_json_field "$entry" started_at)"
-    printf '%s\t%s\t%s\n' "$id" "$started" "$repo"
+    printf '%s\t%s\t%s\t%s\n' "$id" "$started" "$hb" "$repo"
   done
 }
 

--- a/ai-literacy-superpowers/hooks/scripts/wip-check.sh
+++ b/ai-literacy-superpowers/hooks/scripts/wip-check.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# wip-check.sh — SessionStart hook: how many sessions are live, against the
+# limit the human declared for themselves.
+#
+# Spec: docs/superpowers/specs/2026-08-10-cadence-sentinels-s4-wip-warden-design.md
+# Tests: tdad_tests/layer0_deterministic/test-wip-check.sh (C1–C12, B4)
+#
+# IT COUNTS SESSIONS. IT NEVER WATCHES THE HUMAN. That split is the whole
+# reason this can exist alongside the Reservoir Warden: that agent watches the
+# person and never gates, and it is trustworthy precisely because it has no
+# teeth and wants none. The moment a sibling starts inferring from session
+# counts how tired someone is, the Warden's contract is retroactively broken
+# for everyone who ever told it their chronotype.
+#
+# So: a number, an age per session, a comparison against a declared line. No
+# speculation about attention, capacity, or how anyone is doing — not as a
+# hedge, not as a sympathetic aside.
+#
+# IT NEVER INVENTS A LIMIT. `/mast tune` deliberately offers a two-line pact,
+# so a Session WIP block with its clause and no `max_concurrent_sessions` is a
+# plausible file — and `block_state` calls it `declared`, because S1 defined
+# malformed as "clause OR required key missing" and only the clause half was
+# ever implemented (#503). Reporting a breach of a line the human never drew
+# would be the worst output available: an imposed limit is precisely the pact
+# the clear-weather rule says does not hold.
+#
+# STARTUP ONLY. SessionStart re-fires on resume, clear and compact, and a
+# breach report re-injected mid-session is the thrash this exists to name.
+# Absent source stays quiet — unknown provenance is where re-injection lives.
+#
+# Ordered AFTER session-registry-start.sh on the same rail, so the starting
+# session's entry exists when the count is taken. A human writing
+# `max_concurrent_sessions: 2` means two including the one they are in.
+#
+# Exits 0 on every path.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/session-registry-read.sh" 2>/dev/null || exit 0
+
+input="$(cat 2>/dev/null || true)"
+
+source_field="$(printf '%s' "$input" \
+  | grep -oE '"source"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 \
+  | sed -E 's/.*"source"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/' || true)"
+[ "$source_field" = "startup" ] || exit 0
+
+# Self-gate before touching anything else: no declared block, nothing to say.
+# A hook announcing an observe-only line to everyone who never asked for this
+# epic is the imposition S1 warns against. `/wip` is the surface that answers a
+# direct question, and it does use the fixed sentence.
+[ "$(block_state 'Session WIP' 2>/dev/null || printf 'absent')" = "declared" ] || exit 0
+
+read -r count flag <<<"$(registry_count 2>/dev/null || printf '0 observed')"
+case "$count" in ''|*[!0-9]*) exit 0 ;; esac
+
+limit="$(block_key 'Session WIP' 'max_concurrent_sessions' '')"
+enforcement="$(block_key 'Session WIP' 'enforcement' 'advisory')"
+
+# `at least` rather than a bare number whenever the count is inferred. S1 was
+# explicit that no consumer may treat this as an exact number of open windows,
+# and this is the first consumer.
+approx=""
+[ "$flag" = "inferred" ] && approx="at least "
+
+# _sessions_block — one line per live session: which, and how long since it
+# last finished a turn. Age is time since HEARTBEAT, not since started_at:
+# age-since-start would say the session you are actively working in is the
+# oldest and therefore the obvious one to park, which is exactly backwards.
+_sessions_block() {
+  local id hb repo now hb_epoch age
+  now="$(date -u +%s)"
+  # `started_at` is consumed into a throwaway on purpose: the age reported here
+  # is time since heartbeat, and reading start into a named variable would
+  # invite someone to use it.
+  while IFS=$'\t' read -r id _ hb repo; do
+    [ -n "$id" ] || continue
+    hb_epoch="$(_iso_to_epoch "$hb")"
+    if [ "$hb_epoch" -gt 0 ]; then
+      age=$(( (now - hb_epoch) / 60 ))
+      if [ "$age" -ge 60 ]; then
+        printf -- '  - %s — %sh since its last turn — %s\n' "$id" "$((age / 60))" "$repo"
+      else
+        printf -- '  - %s — %sm since its last turn — %s\n' "$id" "$age" "$repo"
+      fi
+    else
+      printf -- '  - %s — last turn unknown — %s\n' "$id" "$repo"
+    fi
+  done <<EOF
+$(registry_list 2>/dev/null || true)
+EOF
+}
+
+# emit <message> — JSON-encode and print a systemMessage, as reservoir-check.sh
+# does. Captured via command substitution rather than piped into `read`: awk's
+# ORS="" leaves no trailing newline, so `read` hits EOF, returns 1, and takes
+# the whole script down under `set -e`.
+emit() {
+  local encoded
+  encoded=$(printf '%s' "$1" \
+    | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' \
+    | awk 'BEGIN{ORS=""} {if (NR>1) printf "\\n"; printf "%s", $0}')
+  printf '{"systemMessage": "%s"}\n' "$encoded"
+}
+
+# No limit declared — say so, point at the ritual, compare nothing.
+# shellcheck disable=SC2016  # the backticks are markdown for the reader
+if [ -z "$limit" ] || case "$limit" in ''|*[!0-9]*) true ;; *) false ;; esac; then
+  emit "$(printf '%s%s session(s) live. You have not declared a limit in your Session WIP block.\n\n%s\nRun `/mast tune` to set one.' \
+    "$approx" "$count" "$(_sessions_block)")"
+  exit 0
+fi
+
+[ "$count" -gt "$limit" ] || exit 0
+
+if [ "$enforcement" = "strict" ]; then
+  emit "$(printf '%s%s session(s) live; your limit is %s.\n\n%sPark one, or say what is urgent enough to keep them all open.\n\nThis asks. It cannot hold a session, and nothing in this plugin can — if you keep going, you keep going.' \
+    "$approx" "$count" "$limit" "$(_sessions_block)")"
+else
+  emit "$(printf '%s%s session(s) live; your limit is %s.\n\n%s' \
+    "$approx" "$count" "$limit" "$(_sessions_block)")"
+fi
+exit 0

--- a/ai-literacy-superpowers/skills/cognitive-reservoir/SKILL.md
+++ b/ai-literacy-superpowers/skills/cognitive-reservoir/SKILL.md
@@ -194,6 +194,25 @@ mechanism is the same at every level; what changes is how it is used.
 | **4 — Specification Architecture** | Multi-agent orchestration makes the *context-switch* proxy the load-bearing one — switching cost scales with parallel streams. This is the "Depletable Collaborator" signal: spec decomposition accounts for human energy, not just modularity. |
 | **5 — Sovereign Engineering** | The warden is one observability surface among many; the team reads its advisories as data and tunes rather than obeys. |
 
+## The boundary with the WIP Warden
+
+A sibling sentinel, the `wip-warden`, counts how many sessions are live and
+compares that against a limit the human declared. The two are deliberately
+split, and the split is what protects this agent:
+
+> The **Reservoir Warden** watches *the human* and never gates.
+> The **WIP Warden** counts *sessions* and never watches the human.
+
+This agent's whole standing rests on being advisory-forever and persisting
+nothing about the person — it is trustworthy precisely because it has no teeth
+and wants none. If a sibling began inferring from session counts how tired
+someone is, that contract would break **retroactively**: a human who declared a
+chronotype here would have reason to wonder what else was being read from it.
+
+So the WIP Warden reports a number, an age per session, and a comparison. It
+says nothing about attention, fatigue, or capacity, and no script enforces that
+— it is held by whoever writes its output. See `skills/wip-warden/SKILL.md`.
+
 ## Anti-patterns
 
 - **A combined fatigue score.** Forbidden. The inputs cannot support it.

--- a/ai-literacy-superpowers/skills/wip-warden/SKILL.md
+++ b/ai-literacy-superpowers/skills/wip-warden/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: wip-warden
+description: Use when working on session-concurrency reporting — carries the constitutional boundary between counting sessions and watching the human, why that split protects the Reservoir Warden's trust model, the honest meaning of enforcement strict when no hook can hold a session, the flag discipline for an inexact count, and the anti-patterns
+---
+
+# The WIP Warden
+
+Three sessions open across three repositories is not three times the work. It
+is one person switching, and the cost of the switch is paid in the quality of
+every decision made after it.
+
+> **The WIP Warden** — the concurrency gate. It counts live sessions against
+> the limit the human declared for themselves, and says when they are over it.
+
+**What it attacks:** thrash-switching.
+
+## The boundary — read this before anything else
+
+> The **Reservoir Warden** watches *the human* and never gates.
+> The **WIP Warden** counts *sessions* and never watches the human.
+
+<!-- evidence: the Reservoir Warden's advisory-forever rule is its honesty
+     contract. It reports proxies with honesty flags, offers one recommendation,
+     and persists nothing — and it earns trust precisely by having no teeth. A
+     sibling that inferred state from session counts would break that contract
+     retroactively for everyone who had declared a chronotype. -->
+
+The split is deliberate and constitutionally significant. The moment a sibling
+agent starts inferring from session counts how tired someone is, or how well
+they are working, the Reservoir Warden's contract breaks retroactively: a human
+who told the harness their chronotype now has reason to wonder what else is
+being read from it.
+
+So the WIP Warden reports **a number, an age per session, and a comparison
+against a declared line**. Never a word about attention, fatigue, capacity,
+focus, or how anyone is doing — not as a hedge, not as a sympathetic aside, not
+in a footnote.
+
+### No script enforces this
+
+An earlier draft tested the boundary by banning seven nouns in a Layer-0 check.
+That would have passed every sentence that actually violates it —
+
+- "Three sessions is a lot to be holding at once."
+- "You have been switching between these for a while."
+- "Might be worth slowing down."
+
+— while failing on `focus_blocks`, a live pact key.
+
+Worse, a green grep would have been read as evidence that the most important
+boundary in the slice is machine-checked. It is not, and pretending otherwise
+would be the same overclaim this skill forbids for `strict`.
+
+The boundary is agent-verified, with a rubric. It is held by whoever writes the
+output.
+
+## `strict` asks; nothing can compel
+
+S1 defined `enforcement: strict` as requiring a disposition before the session
+proceeds. **No hook can do that.** Hooks are advisory — they warn and never
+block — and a `SessionStart` hook in particular emits a message into a session
+that is already starting.
+
+| Mode | Behaviour |
+| --- | --- |
+| `advisory` | reports the breach and the live sessions, and moves on |
+| `strict` | **asks** — park one, or say what is urgent — and says plainly it cannot compel |
+
+Because it is not a gate, the constitutional requirement for an on-the-record
+override does not bind: there is nothing to override. The human proceeds by
+proceeding.
+
+**Say the limit out loud.** A sentinel that implied it could stop you would be
+claiming a power it does not have.
+
+## The count is not exact, and says so
+
+`registry_count` returns a count and a flag. Report both.
+
+| Flag | Because | Say |
+| --- | --- | --- |
+| `observed` | every entry fresh | the count, plainly |
+| `inferred` | a lease expired unpruned, a retirement happened, or an `unknown` entry is present | "at least", and why |
+
+S1 was explicit that **no consumer may treat this count as an exact number of
+open windows**, and this is the first consumer.
+
+**Age is time since the last heartbeat**, never since `started_at`. The
+distinction decides what the report advises: age-since-start says the session
+you are actively working in is the oldest and therefore the obvious one to
+park, which is exactly backwards.
+
+## Never invent a limit
+
+A `Session WIP` block carrying its mandatory clause and no
+`max_concurrent_sessions` is a **normal file** — `/mast tune` deliberately
+offers a two-line pact — and `block_state` calls it `declared`, because the
+required-key half of malformed was never implemented (issue #503).
+
+So: say how many are live, say no limit is declared, point at `/mast tune`, and
+compare nothing.
+
+An imposed limit is precisely the pact the clear-weather rule says does not
+hold. Reporting a breach of a line the human never drew is the worst output
+this sentinel can produce.
+
+## Where it speaks, and where it does not
+
+- **The hook is silent** when no block is declared. A `SessionStart` hook
+  announcing an observe-only line to every user who never asked for this epic
+  is an imposition.
+- **`/wip` uses the observe-only sentence.** A human who asked a question and
+  got nothing cannot tell an absent block from a compliant one.
+- **Startup only.** `SessionStart` re-fires on resume, clear and compact, and a
+  breach report re-injected mid-session is the thrash this exists to name.
+
+## Anti-patterns
+
+1. **Any speculation about the person.** The whole boundary, and nothing checks
+   it for you.
+2. **Inventing a limit** when none is declared.
+3. **Implying `strict` can stop you.**
+4. **Reporting an `inferred` count as exact.**
+5. **Age since `started_at`** — it advises the opposite of the truth.
+6. **Parking anything.** That is `/coda`'s ritual; offer it.
+7. **Sourcing a write surface.** The frontmatter check cannot see it.

--- a/ai-literacy-superpowers/templates/pacts.md
+++ b/ai-literacy-superpowers/templates/pacts.md
@@ -38,9 +38,10 @@ have live at once, counted across every repository on this machine.
 `max_switches_per_hour` is optional. `stale_after_hours` is how long a session
 may go without finishing a turn before it is treated as gone — raise it if you
 routinely leave a session parked mid-thought. `enforcement: advisory` reports
-a breach and proceeds; `strict` asks you to park something or say, on the
-record, what was urgent enough. There is always an override, and it is always
-yours to take.
+a breach and proceeds; `strict` also asks you to park something or say what is
+urgent. **Neither can stop you** — nothing in this plugin can hold a session,
+and the WIP Warden says so rather than implying otherwise. What you say in
+answer is not written down anywhere yet.
 
 ## Budgets
 

--- a/docs/plugins/ai-literacy-superpowers/explanation/sentinels.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/sentinels.md
@@ -110,6 +110,7 @@ build goes red. S2 and S3 are agent-verifiable via the harness-enforcer.
 | `reservoir-warden` | The decider — the verifier's cognitive reservoir | Read-only (no Write/Edit); single decide-your-stop-first recommendation; observed/inferred/asked flags; persists no record of human state |
 | `cost-estimator` | The decision's inputs — what a choice will cost before it is made | Read-only; human disposes the estimate record; refuses rather than fabricating an ungroundable estimate |
 | `mast` | The pact — that a limit set in clear weather survives contact with the moment it governs | Read-only; recites before measuring; refuses to estimate spend; discloses its own check's blind spot; never gates |
+| `wip-warden` | The count — how much is open at once, against a line the person drew | Read-only; counts sessions and never watches the human; reports the count's flag; never invents a limit; says plainly that `strict` cannot compel |
 | `coda` | The ending — that a session stops by decision rather than by attrition | Read-only; returns record content for `/coda` to persist; per-item observed/inferred/asked flags; never refuses a next action and never records why someone stopped |
 
 The narrative: the decision-discipline triad guards *decisions*; the

--- a/docs/plugins/ai-literacy-superpowers/how-to/watching-your-wip.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/watching-your-wip.md
@@ -1,0 +1,93 @@
+---
+title: Watching your WIP
+---
+# Watching your WIP
+
+Three sessions open across three repositories is not three times the work. It
+is one person switching, and the switch is paid for in the quality of every
+decision after it.
+
+## See where you are
+
+```text
+/wip
+```
+
+You get how many sessions are live, which they are, how long since each last
+took a turn, and where each one is.
+
+If you have declared a limit, you get the comparison too.
+
+## Set a limit
+
+```text
+/mast tune
+```
+
+`max_concurrent_sessions` is how many sessions you are willing to have live at
+once, counted across every repository on this machine — **including the one you
+are in**. Two means two.
+
+If you have not set one, `/wip` says so and points you here. It will never pick
+a number for you: a limit you did not choose is not a limit, it is a default
+wearing one's clothes.
+
+## What happens when you are over
+
+At the start of a session, once:
+
+```text
+3 sessions live; your limit is 2.
+
+  - sess-a — 4h since its last turn — ~/code/alpha
+  - sess-b — 12m since its last turn — ~/code/beta
+  - sess-c — 0m since its last turn — ~/code/gamma
+```
+
+The ages are what make that useful. `sess-a` has not taken a turn in four
+hours — that is the one to park. Ages are measured from each session's **last
+turn**, not from when it started, because otherwise the session you are
+actively working in would always look like the oldest and therefore the obvious
+one to close.
+
+If you set `enforcement: strict`, it also asks — park one, or say what is
+urgent enough to keep them all open.
+
+**It cannot stop you.** Nothing in this plugin can hold a session, and it says
+so rather than implying otherwise. If you keep going, you keep going. What you
+say in answer isn't written down anywhere, and it tells you that too.
+
+## Parking one
+
+That is `/coda`'s ritual:
+
+```text
+/coda
+```
+
+It surveys what is live, asks for one concrete next step per thread, and writes
+a parking record you can pick up later. `/wip` will offer it; it never parks
+anything itself.
+
+## What it will never tell you
+
+It will not say you seem tired, or that you are taking on too much, or that
+three is a lot. **It counts sessions. It does not watch you.**
+
+That is deliberate, and it is what lets `/reservoir` — which *does* watch the
+verifier — stay worth trusting. If one sentinel started inferring your state
+from a session count, you would have reason to wonder what else was being read
+from what you told the other.
+
+Nothing enforces that boundary automatically. It is a promise held by the
+people who write the output.
+
+## Approximate counts
+
+Sometimes you will see "at least 3 sessions live". That means the registry
+could not be certain — a session's lease expired without being swept, or an
+entry may stand for more than one session.
+
+The count is never presented as exact when it is not. If you need certainty,
+you know better than it does: it can only see sessions that have taken a turn
+recently.

--- a/docs/plugins/ai-literacy-superpowers/reference/agents.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/agents.md
@@ -12,7 +12,7 @@ Cutting across those groups is a fourth, cross-cutting family — the
 **[sentinels](../explanation/sentinels.md)**. A sentinel is any agent
 whose object of care is the human's understanding and judgement rather
 than an artefact: `carpaccio`, `advocatus-diaboli`,
-`choice-cartographer`, `reservoir-warden`, `cost-estimator`, `coda`, and `mast`. Each
+`choice-cartographer`, `reservoir-warden`, `cost-estimator`, `coda`, `mast`, and `wip-warden`. Each
 declares `role: sentinel` in its frontmatter, is read-only (criterion
 S1, enforced deterministically by the Sentinel integrity constraint),
 emits advisory output a human disposes (S2), and carries an explicit
@@ -217,6 +217,28 @@ and is invisible to it.
 Never writes, never sources the write library, and never gates.
 
 See the `mast` skill and [Keeping a pact](../how-to/keeping-a-pact.md).
+
+### wip-warden
+
+**Role:** sentinel · **Tools:** Read, Glob, Grep, Bash · **Trust boundary:** read-only
+
+Counts live sessions against the limit the human declared for themselves, lists
+which they are and how long since each last took a turn, and says when they are
+over the line.
+
+**It counts sessions and never watches the human.** That split is what protects
+the `reservoir-warden`: that agent is advisory-forever and persists nothing
+about the person, and it is trustworthy precisely because it has no teeth. A
+sibling inferring tiredness from session counts would break its contract
+retroactively for anyone who had declared a chronotype. **No script enforces
+this** — a word ban was tried and rejected, because it passes every sentence
+that actually violates the boundary while failing on `focus_blocks`.
+
+Never invents a limit. A `Session WIP` block with its clause and no
+`max_concurrent_sessions` is a normal file, and reporting a breach of a line
+the human never drew is the worst thing it could do.
+
+See the `wip-warden` skill and [Watching your WIP](../how-to/watching-your-wip.md).
 
 ### cost-estimator
 
@@ -464,6 +486,7 @@ is a precaution under uncertainty. See the
 | choice-cartographer | x | | | x | x | | | | read-only |
 | coda | x | | | x | x | | | | read-only |
 | mast | x | | | x | x | | | | read-only |
+| wip-warden | x | | | x | x | | | | read-only |
 | cost-estimator | x | | | x | x | | | | read-only |
 | tdd-agent | x | x | x | x | x | x | | | read-write |
 | code-reviewer | x | | | x | x | x | | | read-only |

--- a/docs/plugins/ai-literacy-superpowers/reference/commands.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/commands.md
@@ -599,6 +599,40 @@ See the `mast` skill and [Keeping a pact](../how-to/keeping-a-pact.md).
 
 ---
 
+### /wip
+
+- **Skills read**: `wip-warden`
+- **Agents dispatched**: `wip-warden`
+
+Counts live sessions against the limit you declared in your `Session WIP`
+block, and lists which sessions and how long since each last took a turn.
+
+**It counts sessions and never says anything about you.** That boundary is what
+keeps `/reservoir` trustworthy, and no script enforces it — it is held by
+whoever writes the output.
+
+Three things it will not do:
+
+- **Invent a limit.** If your block declares none, it says so and points at
+  `/mast tune`. An imposed limit is exactly the pact the clear-weather rule says
+  does not hold.
+- **Report an inexact count as exact.** When the registry's flag is `inferred`
+  it says "at least", and why.
+- **Stop you.** `enforcement: strict` asks — park one, or say what is urgent —
+  and says plainly that nothing here can hold a session.
+
+An override you speak is not recorded; the command says so rather than implying
+otherwise. Ages are measured from each session's last turn, not from when it
+started — the latter would point you at the session you are working in as the
+obvious one to park.
+
+The `SessionStart` hook reports the same breach once, on startup only. Unlike
+the hook, `/wip` answers even when no block is declared: you asked.
+
+See the `wip-warden` skill and [Watching your WIP](../how-to/watching-your-wip.md).
+
+---
+
 ### /reservoir
 
 - **Skills read**: `cognitive-reservoir`

--- a/docs/plugins/ai-literacy-superpowers/reference/pacts-format.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/pacts-format.md
@@ -73,10 +73,19 @@ Values may contain colons and spaces. `hard_stop_hour: 18:30` reads as
 counts; it does not assess.*
 
 `enforcement: advisory` reports a breach and proceeds. `enforcement: strict`
-asks for a **disposition** before the session proceeds — park an existing
-session, or override on the record with one line naming what was urgent
-enough. There is always an override, and it is always yours to take; `strict`
-never means an unconditional refusal.
+also **asks** for a disposition — park an existing session, or say what is
+urgent enough to keep them all open.
+
+**Neither mode can stop you.** Hooks in this plugin are advisory and never
+block, and a `SessionStart` hook in particular emits a message into a session
+that is already starting. `strict` is a stronger ask, not a gate, and the WIP
+Warden says so plainly rather than implying a power it does not have.
+
+An earlier version of this page described `strict` as requiring a disposition
+*before the session proceeds*, and an override recorded on the record. Neither
+was deliverable: nothing can hold a session, and the mechanism that would carry
+the override to a record is a later slice. What you say in answer is not
+written down yet, and the Warden tells you so.
 
 `stale_after_hours` is the registry lease length. Raise it if you routinely
 leave a session parked mid-thought: liveness is measured as *recency of a

--- a/docs/plugins/ai-literacy-superpowers/reference/skills.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/skills.md
@@ -67,6 +67,16 @@ Read it before changing anything in the Mast's path — particularly the two-row
 table showing that a hand-edit does *not* fire the weather note and a calm tune
 *does*, which is the guard against an honest-sounding regression.
 
+### wip-warden
+
+The constitutional boundary between counting sessions and watching the human,
+and why that split is what protects the Reservoir Warden's trust model.
+
+Also carries the honest meaning of `enforcement: strict` when no hook can hold
+a session, the flag discipline for a count that is never exact, and the reason
+the boundary is **not** machine-enforced — including the worked sentences a
+word-ban would have passed.
+
 ### cognitive-reservoir
 
 The shared grounding for the reservoir-warden agent and the reservoir-check Stop hook — the framework's watch on the one actor it cannot verify, the human verifier. Defines the four observable proxies (session span, decision volume, context switches, wall-clock hour), the `observed` / `inferred` / `asked` confidence discipline, the disjunctive default thresholds, the one firm principle (decide your stop before the next session begins), the six-level scaling guidance, and the honesty rule that keeps the contested science (ego depletion, the hungry-judges study) separate from the robust basis (vigilance decrement, task-switching cost). Advisory-only; never a fatigue score, never a gate.

--- a/docs/superpowers/objections/cadence-sentinels-s4-wip-warden-design.md
+++ b/docs/superpowers/objections/cadence-sentinels-s4-wip-warden-design.md
@@ -9,85 +9,85 @@ objections:
     severity: critical
     claim: "Section 4 asserts the per-session list comes from registry_list, but registry_list does not filter by lease — so the hook's count and its list will contradict each other on the ordinary working day S1 built the filter for."
     evidence: "Spec 4: 'The ages come from registry_list. Each live session is listed with its started_at and its repo.' session-registry-read.sh registry_list iterates every *.json with no heartbeat check; only registry_count filters expired leases. The function's own docstring says 'one line per live entry', which is where the spec's error came from."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Fixed in S1's library, carved as its own commit with its own scenarios. The docstring already promised this behaviour — making it true is repairing a defect, not changing a contract, and the defect was written in S1. registry_list now filters expired leases exactly as registry_count does, and carries heartbeat so an honest age is computable. R17 asserts the list and the count never disagree; R18 asserts the docstring's claim is the tested behaviour. Every future consumer gets the honest version."
   - id: O2
     category: implementation
     severity: high
     claim: "The hook's placement on the SessionStart rail alongside S1's own session-registry-start.sh leaves it undefined whether the count includes the session that is starting, and the spec states no ordering requirement."
     evidence: "hooks.json runs session-registry-start.sh on SessionStart, which writes the entry for the starting session. Spec 5 adds wip-check.sh to the same event. C2 says 'Two live sessions, limit two, no output' without saying whether the starting session is one of the two, and the spec fixes neither the inclusion rule nor the comparison operator."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "The starting session IS counted, the hook is ordered after S1's registry write, and breach is count > limit — all three stated. A human writing max_concurrent_sessions: 2 means two including the one they are in, which is what the template's own field note says."
   - id: O3
     category: specification quality
     severity: high
     claim: "The spec never names the key holding the limit, and defines no behaviour for a Session WIP block that is declared but omits it — a case block_state reports as declared, so C8's malformed path will not catch it and the implementer must invent a default limit."
     evidence: "max_concurrent_sessions appears zero times in the spec. pact-blocks.sh block_state checks the mandatory clause only, never a required key, despite S1 3.7 defining malformed as 'mandatory clause OR required key missing'. block_key then returns the caller's default. Tune deliberately offers a two-line pact, so a block with the clause and no limit is a plausible product of the sanctioned authoring path."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "S4 names the key and defines the missing-key case: report that no limit is declared, point at /mast tune, and compare against nothing. Never invent a default — an imposed limit is precisely the pact the clear-weather rule says does not hold. The underlying block_state gap is #503, since S1 owns it and fixing it changes what every shipped consumer sees for a class of real files."
   - id: O4
     category: specification quality
     severity: high
     claim: "C1 and C8 specify silence on absent and malformed blocks, which departs from S1's Null Object contract and from the shipped test asserting a malformed block still emits the observe-only sentence — and the spec neither acknowledges the departure nor says whether /wip follows the hook into silence."
     evidence: "Spec C1 and C8 specify silence. S1 3.7: 'The observe-only note is a fixed sentence, emitted by the library so every consumer says the same thing... a consumer never branches on absence.' test-pact-blocks.sh B6 asserts a malformed block still emits it. session-registry-read.sh's own comment addresses this slice by name: 'that value advises a person, so a malformed block must degrade to observe-only.'"
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "The departure is argued rather than asserted, and split: the HOOK is silent, because a SessionStart hook announcing an observe-only line to everyone who never asked for this epic is the imposition S1 warns against; /wip uses S1's fixed sentence, because a human who asked a question and got nothing cannot tell an absent block from a compliant one. S1's contract note is amended so S5 inherits the rule rather than re-deriving it."
   - id: O5
     category: implementation
     severity: high
     claim: "B1 tests a vocabulary list rather than the behaviour section 2 forbids: the list is under-inclusive against every speculation an implementer would actually write, over-inclusive against the live focus_blocks key, and its 'focus (as a state)' carve-out is not machine-checkable in a Layer-0 script."
     evidence: "Spec B1 bans seven nouns under a deterministic test file. Every one of 'Three sessions is a lot to be holding at once', 'You have been switching between these for a while', and 'Might be worth slowing down' passes B1 and violates section 2. focus_blocks is a live pact key. A green B1 will be read as evidence that the boundary section 2 calls the most important in the slice is machine-enforced. It is not."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "B1 moves to an agent-verified scenario with a rubric, and the spec states plainly that the boundary is NOT machine-enforced. A green word-grep would have been read as evidence that the section 2 boundary is checked, which is the same overclaim section 3.2 forbids for strict — applied by the spec to strict and not to itself."
   - id: O6
     category: specification quality
     severity: high
     claim: "B1 extends the word ban to the WIP Warden's skill, while section 5 makes that skill responsible for stating the boundary and section 2 states that boundary using four of the banned words — and B2 then requires both skills to state it in the same terms while only one is under the ban."
     evidence: "Spec 5 tasks skills/wip-warden/SKILL.md with 'the boundary... the anti-patterns'. Section 2 states it as 'never speculates about attention, fatigue, focus, or capacity'. Section 2's own scope is OUTPUT; B1's is files. cognitive-reservoir/SKILL.md contains ten instances of the banned vocabulary and is not under the ban. B1, B2, section 2 and section 5 cannot all be satisfied."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "The ban scopes to emitted OUTPUT rather than files, which is what section 2 always said. The skill can then name what it refuses, which is what makes it a usable rule for the next author — a refusal that cannot name what it refuses inverts the write-the-honesty-rule-first discipline."
   - id: O7
     category: scope
     severity: high
     claim: "The two shipped surfaces stating S1's old meaning of strict — the pact template the human authors from and the pacts reference page — are not in section 5's file list or section 10's docs list, so on the day S4 ships they promise an on-the-record override the slice deliberately does not build."
     evidence: "templates/pacts.md: 'strict asks you to park something or say, on the record, what was urgent enough. There is always an override.' reference/pacts-format.md repeats it. Spec 5 lists commands/mast.md as the only corrected existing file; section 10's docs list omits reference/pacts-format.md entirely."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "templates/pacts.md and reference/pacts-format.md join the file list. Both promise an on-the-record override this slice deliberately does not build, and the template is the worse of the two because it is what the human reads while deciding whether to write strict at all. The mandatory clause is untouched — pact-write.sh derives it and T9 pins it."
   - id: O8
     category: specification quality
     severity: medium
     claim: "Section 4's per-session 'age' is not defined and the field it would be computed from measures something other than the liveness the count uses: registry_list returns started_at, while registry_count's liveness turns on heartbeat, which the list does not return at all."
     evidence: "Spec 2 promises 'an age per session'; section 4 says the list carries started_at and repo. registry_list prints id, started_at, repo — no heartbeat. S1 4.2: 'Liveness here means recency of a completed turn, not a window is open.' The two readings give opposite advice about which session to park."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Age is time since last heartbeat, not since started_at. It is the actionable one: age-since-start says the session you are working in is the oldest and therefore the obvious one to park, which is exactly backwards. registry_list now carries heartbeat (O1)."
   - id: O9
     category: premise
     severity: medium
     claim: "Section 7's 'pattern worth naming' rests on one supporting instance rather than two — its first example misattributes to S1 a promise the build spec made — and it omits that S1's own gate already raised this exact concern as O11 and disposed it with the weaker remedy section 7 now finds insufficient."
     evidence: "Spec 7 says 'S1 promised a CI critic check on Budgets diffs'; S3 2.2 attributes it to the build spec, made impossible by S1's location decision. S1's O11 said shipping strict undefined 'pre-authorises S4 to interpret it as blocking', and was disposed with 'gains a one-line semantics' — which is what produced a token whose defined semantics no mechanism could deliver. S1 3.5 shows the stronger remedy, the reserved marker, was available and applied to Sync cadence but not to enforcement."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Section 7 keeps the lesson and corrects its provenance. The first instance was misattributed — the build spec called for the critic check, not S1. And the sharper reading is that S1's own gate DID catch this as O11 and disposed it with 'define the semantics', which is what produced a token whose semantics no mechanism could deliver. The rule promoted is therefore: when a gate accepts an objection about an undeliverable token, defining its semantics is not a sufficient disposition — mark it as awaiting a mechanism. S1 had the stronger remedy and used it on Sync cadence, not on enforcement."
   - id: O10
     category: alternatives
     severity: medium
     claim: "The spec does not weigh shipping /wip alone against adding a SessionStart hook, though the hook is the source of most of the slice's cost and three of this record's objections."
     evidence: "Ten of the slice's fourteen scenarios exist only because of the hook. S3's evidence comment, recorded for #501, distinguishes a boundary-moment check from an ambient reminder. A SessionStart breach report arrives AFTER the switch it exists to discourage, so its ask is remediation rather than prevention — which may still be the best moment available, but the spec asserts the placement rather than arguing it."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Section 1 argues the SessionStart placement rather than assuming it, and names the Stop rail as the rejected alternative with its reason. A breach report at session start arrives after the switch it discourages, so its ask is remediation rather than prevention — that is the earliest point at which the fact is knowable and the human is present, and saying so is what the record should carry."
   - id: O11
     category: scope
     severity: medium
     claim: "Section 5's file list omits skills/sentinel-design/SKILL.md, which section 7 requires this slice to change, and omits the sentinel rosters that must gain the new agent."
     evidence: "Section 7's only deliverable is a note in sentinel-design; section 5's six-file table does not include it, and no B or C scenario would catch the omission. sentinel-design also carries a five-agent roster table and a checklist step requiring the README Sentinels section to be updated; section 10 mentions only the docs page roster."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "skills/sentinel-design/SKILL.md, its roster table, and the README Sentinels section join the file list. The roster being a pinned copy of a derived fact is noted as a follow-up on the same record as section 6's — the slice noticed the pattern in commands/mast.md and not in the roster it was about to hand-edit."
   - id: O12
     category: risk
     severity: medium
     claim: "Section 5 states the write-library prohibition as a guarantee, but nothing checks it: sentinel-integrity-check.sh reads only the declared tools list, and no scenario asserts the agent sources no write surface."
     evidence: "Spec 5: 'It must never source session-registry-write.sh or pact-write.sh.' sentinel-integrity-check.sh contains no match for either name. sentinel-design states the principle: 'a shared library that exposes a mutation function to a sentinel breaches this boundary through a channel the frontmatter check cannot see.' S1's R9 is the machine check for the analogous claim; S4 has none."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "A scenario greps the agent and the hook for a source of either write surface. Pre-existing rather than invented here, but S4 is the first slice with two write surfaces in play, and the constitutional constraint is that any library a sentinel may source must be incapable of mutation."
 ---
 
 # Objection record — Cadence Sentinels S4: The WIP Warden (spec mode)

--- a/docs/superpowers/objections/cadence-sentinels-s4-wip-warden-design.md
+++ b/docs/superpowers/objections/cadence-sentinels-s4-wip-warden-design.md
@@ -1,0 +1,370 @@
+---
+spec: docs/superpowers/specs/2026-08-10-cadence-sentinels-s4-wip-warden-design.md
+date: 2026-08-10
+mode: spec
+diaboli_model: claude-opus-5[1m]
+objections:
+  - id: O1
+    category: implementation
+    severity: critical
+    claim: "Section 4 asserts the per-session list comes from registry_list, but registry_list does not filter by lease — so the hook's count and its list will contradict each other on the ordinary working day S1 built the filter for."
+    evidence: "Spec 4: 'The ages come from registry_list. Each live session is listed with its started_at and its repo.' session-registry-read.sh registry_list iterates every *.json with no heartbeat check; only registry_count filters expired leases. The function's own docstring says 'one line per live entry', which is where the spec's error came from."
+    disposition: pending
+    disposition_rationale: null
+  - id: O2
+    category: implementation
+    severity: high
+    claim: "The hook's placement on the SessionStart rail alongside S1's own session-registry-start.sh leaves it undefined whether the count includes the session that is starting, and the spec states no ordering requirement."
+    evidence: "hooks.json runs session-registry-start.sh on SessionStart, which writes the entry for the starting session. Spec 5 adds wip-check.sh to the same event. C2 says 'Two live sessions, limit two, no output' without saying whether the starting session is one of the two, and the spec fixes neither the inclusion rule nor the comparison operator."
+    disposition: pending
+    disposition_rationale: null
+  - id: O3
+    category: specification quality
+    severity: high
+    claim: "The spec never names the key holding the limit, and defines no behaviour for a Session WIP block that is declared but omits it — a case block_state reports as declared, so C8's malformed path will not catch it and the implementer must invent a default limit."
+    evidence: "max_concurrent_sessions appears zero times in the spec. pact-blocks.sh block_state checks the mandatory clause only, never a required key, despite S1 3.7 defining malformed as 'mandatory clause OR required key missing'. block_key then returns the caller's default. Tune deliberately offers a two-line pact, so a block with the clause and no limit is a plausible product of the sanctioned authoring path."
+    disposition: pending
+    disposition_rationale: null
+  - id: O4
+    category: specification quality
+    severity: high
+    claim: "C1 and C8 specify silence on absent and malformed blocks, which departs from S1's Null Object contract and from the shipped test asserting a malformed block still emits the observe-only sentence — and the spec neither acknowledges the departure nor says whether /wip follows the hook into silence."
+    evidence: "Spec C1 and C8 specify silence. S1 3.7: 'The observe-only note is a fixed sentence, emitted by the library so every consumer says the same thing... a consumer never branches on absence.' test-pact-blocks.sh B6 asserts a malformed block still emits it. session-registry-read.sh's own comment addresses this slice by name: 'that value advises a person, so a malformed block must degrade to observe-only.'"
+    disposition: pending
+    disposition_rationale: null
+  - id: O5
+    category: implementation
+    severity: high
+    claim: "B1 tests a vocabulary list rather than the behaviour section 2 forbids: the list is under-inclusive against every speculation an implementer would actually write, over-inclusive against the live focus_blocks key, and its 'focus (as a state)' carve-out is not machine-checkable in a Layer-0 script."
+    evidence: "Spec B1 bans seven nouns under a deterministic test file. Every one of 'Three sessions is a lot to be holding at once', 'You have been switching between these for a while', and 'Might be worth slowing down' passes B1 and violates section 2. focus_blocks is a live pact key. A green B1 will be read as evidence that the boundary section 2 calls the most important in the slice is machine-enforced. It is not."
+    disposition: pending
+    disposition_rationale: null
+  - id: O6
+    category: specification quality
+    severity: high
+    claim: "B1 extends the word ban to the WIP Warden's skill, while section 5 makes that skill responsible for stating the boundary and section 2 states that boundary using four of the banned words — and B2 then requires both skills to state it in the same terms while only one is under the ban."
+    evidence: "Spec 5 tasks skills/wip-warden/SKILL.md with 'the boundary... the anti-patterns'. Section 2 states it as 'never speculates about attention, fatigue, focus, or capacity'. Section 2's own scope is OUTPUT; B1's is files. cognitive-reservoir/SKILL.md contains ten instances of the banned vocabulary and is not under the ban. B1, B2, section 2 and section 5 cannot all be satisfied."
+    disposition: pending
+    disposition_rationale: null
+  - id: O7
+    category: scope
+    severity: high
+    claim: "The two shipped surfaces stating S1's old meaning of strict — the pact template the human authors from and the pacts reference page — are not in section 5's file list or section 10's docs list, so on the day S4 ships they promise an on-the-record override the slice deliberately does not build."
+    evidence: "templates/pacts.md: 'strict asks you to park something or say, on the record, what was urgent enough. There is always an override.' reference/pacts-format.md repeats it. Spec 5 lists commands/mast.md as the only corrected existing file; section 10's docs list omits reference/pacts-format.md entirely."
+    disposition: pending
+    disposition_rationale: null
+  - id: O8
+    category: specification quality
+    severity: medium
+    claim: "Section 4's per-session 'age' is not defined and the field it would be computed from measures something other than the liveness the count uses: registry_list returns started_at, while registry_count's liveness turns on heartbeat, which the list does not return at all."
+    evidence: "Spec 2 promises 'an age per session'; section 4 says the list carries started_at and repo. registry_list prints id, started_at, repo — no heartbeat. S1 4.2: 'Liveness here means recency of a completed turn, not a window is open.' The two readings give opposite advice about which session to park."
+    disposition: pending
+    disposition_rationale: null
+  - id: O9
+    category: premise
+    severity: medium
+    claim: "Section 7's 'pattern worth naming' rests on one supporting instance rather than two — its first example misattributes to S1 a promise the build spec made — and it omits that S1's own gate already raised this exact concern as O11 and disposed it with the weaker remedy section 7 now finds insufficient."
+    evidence: "Spec 7 says 'S1 promised a CI critic check on Budgets diffs'; S3 2.2 attributes it to the build spec, made impossible by S1's location decision. S1's O11 said shipping strict undefined 'pre-authorises S4 to interpret it as blocking', and was disposed with 'gains a one-line semantics' — which is what produced a token whose defined semantics no mechanism could deliver. S1 3.5 shows the stronger remedy, the reserved marker, was available and applied to Sync cadence but not to enforcement."
+    disposition: pending
+    disposition_rationale: null
+  - id: O10
+    category: alternatives
+    severity: medium
+    claim: "The spec does not weigh shipping /wip alone against adding a SessionStart hook, though the hook is the source of most of the slice's cost and three of this record's objections."
+    evidence: "Ten of the slice's fourteen scenarios exist only because of the hook. S3's evidence comment, recorded for #501, distinguishes a boundary-moment check from an ambient reminder. A SessionStart breach report arrives AFTER the switch it exists to discourage, so its ask is remediation rather than prevention — which may still be the best moment available, but the spec asserts the placement rather than arguing it."
+    disposition: pending
+    disposition_rationale: null
+  - id: O11
+    category: scope
+    severity: medium
+    claim: "Section 5's file list omits skills/sentinel-design/SKILL.md, which section 7 requires this slice to change, and omits the sentinel rosters that must gain the new agent."
+    evidence: "Section 7's only deliverable is a note in sentinel-design; section 5's six-file table does not include it, and no B or C scenario would catch the omission. sentinel-design also carries a five-agent roster table and a checklist step requiring the README Sentinels section to be updated; section 10 mentions only the docs page roster."
+    disposition: pending
+    disposition_rationale: null
+  - id: O12
+    category: risk
+    severity: medium
+    claim: "Section 5 states the write-library prohibition as a guarantee, but nothing checks it: sentinel-integrity-check.sh reads only the declared tools list, and no scenario asserts the agent sources no write surface."
+    evidence: "Spec 5: 'It must never source session-registry-write.sh or pact-write.sh.' sentinel-integrity-check.sh contains no match for either name. sentinel-design states the principle: 'a shared library that exposes a mutation function to a sentinel breaches this boundary through a channel the frontmatter check cannot see.' S1's R9 is the machine check for the analogous claim; S4 has none."
+    disposition: pending
+    disposition_rationale: null
+---
+
+# Objection record — Cadence Sentinels S4: The WIP Warden (spec mode)
+
+Twelve objections: one critical, six high, five medium.
+
+Three items were disposed at the design gate and are not re-litigated: the
+redefinition of `strict`, the deferral of the override record to #501, and S4
+correcting S3's stale disclosure line. Where an objection touches those areas
+(O4, O7) it accepts the disposition and challenges only what the spec did not
+follow through on.
+
+**Dispatcher verification note (2026-08-10).** Three claims verified before
+recording. `registry_list` iterates every `*.json` with no heartbeat check
+while `registry_count` filters expired leases — **and the function's own
+docstring says "one line per live entry", which is false and was written in
+S1**. `max_concurrent_sessions` appears **zero** times in this spec. And
+`block_state` checks the mandatory clause only, never a required key, despite
+S1 §3.7 defining malformed as "mandatory clause **or required key** missing" —
+a latent S1 defect this slice is the first to expose.
+
+## O1 — implementation — critical
+
+§4 says the per-session ages come from `registry_list`. That function does not
+filter by lease: it emits one line for every `*.json` in the registry,
+including entries whose heartbeat expired hours ago and which `registry_count`
+deliberately excludes. C3 and C4 together specify a report that contradicts
+itself on exactly the working day S1 added the filter to survive.
+
+On a machine with one live session and three finished ones whose leases have
+expired but which the pruner has not yet swept, C3 reports "1 live session" and
+C4 lists four. A report whose halves disagree is worse than no report: the
+human cannot tell which number to act on, and the slice's stated purpose is to
+be "actionable rather than merely true".
+
+The error's provenance matters. `registry_list`'s docstring reads "one line per
+live entry" — written in S1, false since S1, and the spec inherited it.
+
+The fix is not free, which is why this is critical rather than high. S4 cannot
+simply change `registry_list`: S1 owns it, and the promoted decision is that a
+consumer never mutates the contract it consumes. The alternatives are to
+re-derive the lease filter inside `wip-check.sh` — duplicating the logic S1
+built one library to prevent three copies of — or to reach for `_lease_hours`
+and `_iso_to_epoch`, two underscore-private helpers of another slice's library.
+Each has scope consequences the spec has not budgeted for.
+
+A related gap rides along: an `unknown.json` entry appears in the list as one
+row with one `repo`, though S1's collision rule says it may stand for more than
+one session. §4's flag table handles that for the count and says nothing about
+the list.
+
+## O2 — implementation — high
+
+`wip-check.sh` and S1's `session-registry-start.sh` are both `SessionStart`
+hooks, and the spec states no ordering. So it is undefined whether the count
+includes the session the human is opening.
+
+Two problems, both invisible to the Layer-0 tests, which will invoke the hook
+directly against a pre-seeded registry rather than through the rail.
+
+Ordering: if the hooks are not guaranteed sequential, the count is racy — the
+same machine state produces a breach on one launch and silence on the next. A
+sentinel whose output flickers teaches the human to discount it.
+
+Semantics, which bites even if ordering is deterministic. A human writing
+`max_concurrent_sessions: 2` — whose field note reads "how many sessions you
+are willing to have live at once" — almost certainly means two *including* the
+one they are in. The spec fixes neither the inclusion rule nor the comparison
+operator, so an implementer has a one-in-four chance of matching intent.
+
+## O3 — specification quality — high
+
+The spec never names the key it reads. `max_concurrent_sessions` appears zero
+times. And it defines no behaviour for a `Session WIP` block carrying its
+mandatory clause but omitting that key — a case `block_state` returns
+`declared` for, so C8 will not catch it and the implementer must invent a
+default.
+
+That block is not a pathological fixture. Tune explicitly offers a two-line
+pact and declines to march the human through the rest, so a block with the
+clause and `stale_after_hours` but no limit is a plausible product of the
+sanctioned authoring path.
+
+Against such a block C1 does not fire, C8 does not fire, and the hook compares
+a real count against a number the plugin chose. S1 §3.2 states the rule this
+breaks: "an imposed default is precisely the budget the clear-weather rule says
+does not hold." The Warden would report a breach of a limit the human never
+set — the worst output this slice can produce, and the one §3.2 argues hardest
+against.
+
+Underneath sits a latent S1 defect: S1 §3.7 defines malformed as "mandatory
+clause **or required key** missing" and `block_state` implements only the
+clause half.
+
+## O4 — specification quality — high
+
+C1 and C8 specify silence where S1's Null Object contract specifies the fixed
+observe-only sentence. The departure may be right for a hook — a `SessionStart`
+hook announcing "no `Session WIP` block declared" to every user who never asked
+for this epic would be exactly the imposition S1 warns against — but the spec
+asserts it in a scenario line rather than arguing it, and leaves three things
+undecided.
+
+Whether `/wip` is also silent. Silence there is a bug: the human asked a
+question and got nothing, with no way to distinguish an absent block from a
+compliant one.
+
+Whether S1's contract is now "every consumer says the sentence, except hooks",
+and where that amendment is recorded so S5 inherits the right rule.
+
+Whether C8's silence is reachable at all for the case that matters — per O3,
+the missing-key block never reaches the malformed state C8 tests.
+
+The shipped library's own comment addresses this slice by name: "that value
+advises a person, so a malformed block must degrade to observe-only."
+
+## O5 — implementation — high
+
+B1 bans seven nouns. The behaviour §2 forbids is speculation about the person,
+and the two do not coincide.
+
+Every one of these passes B1 and violates §2:
+
+- "Three sessions is a lot to be holding at once."
+- "You have been switching between these for a while."
+- "Might be worth slowing down."
+- "You are spread across three repositories."
+
+Meanwhile `focus_blocks` is a live pact key and a plausible cross-reference in
+the skill, and the "(as a state)" qualifier is a judgement call — so the check
+is either mechanically wrong or not mechanical at all, in which case it is an
+agent-verified scenario wearing a deterministic one's clothes.
+
+The deeper problem is the one this spec applies rigorously to `strict` and does
+not apply to itself. §3.2: "A sentinel that implied it could stop you would be
+claiming a power it does not have." A green B1 will be read — by the next
+author, by S5's reviewer — as evidence that the boundary §2 calls "the most
+important section in the slice" is machine-enforced. It is not.
+
+## O6 — specification quality — high
+
+B1 extends the ban to `skills/wip-warden/SKILL.md`, but §5 makes that file
+responsible for stating the boundary, and §2 states it using four banned words.
+B2 then requires the same boundary in both skills "in the same terms" while
+only one is under the ban. B1, B2, §2 and §5 cannot all be satisfied.
+
+Note that §2's own scope is **output**; B1's is files.
+
+The likeliest resolution an implementer reaches for is a weaker boundary
+statement that avoids naming what is forbidden. That inverts the discipline
+`sentinel-design` promoted — decide what you will refuse to assert, then build
+only what you can honestly report — and a refusal that cannot name what it
+refuses is not a usable rule for the next author, who reads the skill.
+
+## O7 — scope — high
+
+Two shipped surfaces state S1's original meaning of `strict` verbatim, and
+neither appears in §5's file list or §10's docs list.
+
+The template's field note promises "on the record, what was urgent enough.
+There is always an override, and it is always yours to take." The reference
+page repeats it. S4 explicitly does not build that record.
+
+§6 argues correctly that correcting a statement of fact that has become false
+is not mutating a contract, and spends a paragraph on one line in
+`commands/mast.md`. The same reasoning applies with more force here, and these
+were missed. The template is the worse of the two, because it is what the human
+reads while deciding whether to write `strict` at all: they choose it on the
+promise of a recorded override and get an ask with no record.
+
+One caution for whoever fixes this: `pact-write.sh` derives the mandatory
+clause from `templates/pacts.md`, pinned by T9, so the clause must not move.
+The field notes below it are free.
+
+## O8 — specification quality — medium
+
+"An age per session" is never defined, and the only available field measures a
+different thing from the one the count's liveness turns on. `registry_list`
+returns `started_at`; `registry_count` decides liveness from `heartbeat`, which
+the list does not return.
+
+The two readings give opposite advice. Age-since-start says a long-running
+session you are actively working in is the oldest and therefore the obvious
+one to park. Time-since-heartbeat says the session you have not touched since
+this morning is. Only the second is the actionable fact C4 claims to deliver.
+
+Computing either from an ISO timestamp requires `_iso_to_epoch`, an
+underscore-private helper of S1's library — the same question O1 raises, and
+probably with the same answer.
+
+## O9 — premise — medium
+
+Scoped to §7 and the `sentinel-design` change it proposes, not to the slice.
+
+§7 generalises from two instances, but the first is misattributed: S1 promised
+no CI critic check — the build spec did, and S1's location decision made it
+impossible, which S1 flagged at the time. That is a different shape. Strip it
+and §7 rests on a single case, which is thin ground for a promoted rule.
+
+The stronger reading is available and §7 misses it. This was caught at S1's own
+gate as O11 — "shipping `strict` with no definition and no override path
+pre-authorises S4 to interpret it as blocking" — and accepted, with the remedy
+"define the semantics". That remedy is what produced a token whose defined
+semantics no mechanism could deliver. S1 §3.5 shows the team already possessed
+the stronger remedy, the reserved marker, and applied it to `Sync cadence`
+while declining to apply it to `enforcement`.
+
+That asymmetry is the lesson: not "define a token, name a mechanism" as a fresh
+discovery, but **when a gate accepts an objection about an undeliverable token,
+defining its semantics is not a sufficient disposition — mark it as awaiting a
+mechanism.**
+
+## O10 — alternatives — medium
+
+The spec does not weigh `/wip` alone against adding a `SessionStart` hook. Ten
+of fourteen scenarios exist only because of the hook, along with three
+objections in this record.
+
+A `SessionStart` breach report arrives *after* the switch it exists to
+discourage: its ask is remediation, not prevention. That may still be the best
+moment available — the earliest at which the fact is knowable and the human is
+present — but the spec should say so, because the alternative is materially
+cheaper.
+
+A second alternative goes unnamed: the `Stop` rail, where the registry already
+runs and the human is between turns. It has the opposite trade — repeats, which
+S3's evidence says makes adherence worse — and is probably wrong. "Probably
+wrong for a stated reason" is what the record should contain.
+
+## O11 — scope — medium
+
+§5's file table is what an implementer works from, and it omits
+`skills/sentinel-design/SKILL.md`, which §7 requires this slice to change. §7's
+note is that section's only deliverable, and no scenario would catch its
+absence. The sentinel rosters that must gain the new agent are also missing
+from §5, and §10 mentions only the docs-page roster.
+
+Worth flagging in passing: `sentinel-design`'s roster is itself a pinned copy
+of a derived fact — which agents carry `role: sentinel` — and §6 of this very
+spec argues that harness artefacts derive from the source of truth rather than
+pinning a copy. The slice notices the pattern in `commands/mast.md` and not in
+the roster it is about to edit by hand.
+
+## O12 — risk — medium
+
+§5 states the write-library prohibition as a guarantee and nothing checks it.
+`sentinel-integrity-check.sh` parses the declared `tools:` list and has no
+notion of what a script sources.
+
+S1 solved this structurally for its own libraries: the read surface defines no
+mutator, so the guarantee holds by construction. S4's is different in kind —
+`pact-write.sh` exists, ships, and is reachable from a `Bash`-holding sentinel
+with one `.` line, with the frontmatter check green.
+
+This is pre-existing rather than invented here (S3 makes the same unchecked
+claim), which is why it is medium. But S4 is the second slice to state it and
+the first with two write surfaces in play, and a scenario grepping the agent
+and hook for a source of either costs a line and would hold for S5 too.
+
+## Explicitly not objecting to
+
+- **The redefinition of `strict`, the deferral of its record to #501, and S4
+  correcting S3's stale line.** All disposed at the design gate. O4 and O7
+  accept them and challenge only what was not carried through.
+- **The §2 boundary itself.** The split is the right line, and the argument
+  that a sibling inferring state from session counts retroactively breaks the
+  Warden's trust model is the best paragraph in the spec. O5 and O6 challenge
+  the *mechanism*, not the boundary.
+- **Not reading `max_switches_per_hour`.** Correct and correctly reasoned:
+  nothing records a switch, and inferring one is the speculation §2 forbids.
+- **C9 and C10.** Exit-0-everywhere and the once-per-session `source` guard both
+  match shipped precedent, and C10's justification — a breach report
+  re-injected on compact is the thrash it exists to name — is exactly right.
+- **The count's honesty-flag table in §4.** It maps correctly onto
+  `registry_count`'s three `inferred` triggers and honours S1's no-exact-count
+  rule. O1 and O8 concern the list, not the count.
+- **The `role: sentinel` classification.** Satisfies all three criteria and
+  passes the near-miss test.
+- **Version and rollout arithmetic.** Consistent with the convention and with
+  S3's shipped counts.

--- a/docs/superpowers/specs/2026-08-10-cadence-sentinels-s4-wip-warden-design.md
+++ b/docs/superpowers/specs/2026-08-10-cadence-sentinels-s4-wip-warden-design.md
@@ -1,0 +1,256 @@
+# Spec: Cadence Sentinels S4 — The WIP Warden
+
+**Status:** Approved (revision 1)
+**Date:** 2026-08-10
+**Issue:** #494
+**Epic:** The Cadence Sentinels (S1–S7, issues #491–#497)
+**Depends on:** S1 (0.67.0) — the session registry and `Session WIP`;
+S3 (0.69.0) — `/mast tune`, which authors the block this reads
+**Scope:** `ai-literacy-superpowers` plugin; one agent, skill, command, and a
+`SessionStart` hook
+**Explicitly out of scope:** the override *record*, which is **#501**; the
+Convener (S5).
+
+**Provenance:** *The Second Front — Arc Insertion Remit* (slide S5) and
+*Compulsive Continuation — A Research Exploration*.
+
+---
+
+## 1. Problem Statement
+
+Three sessions open across three repositories is not three times the work. It
+is one person switching, and the cost of the switch is paid in the quality of
+every decision made after it.
+
+The registry S1 built knows how many sessions are live. Nothing reads it. The
+`Session WIP` block S3's Tune authors declares what the human decided their
+limit was, in clear weather. Nothing reads that either.
+
+The WIP Warden is what closes that loop: at the start of a session, it counts,
+compares, and — if you are over the line you drew — says so.
+
+**Epithet:** *the concurrency gate.* **Attacks:** thrash-switching.
+
+## 2. The Constitutional Boundary
+
+This is the most important section in the slice, and the build spec is right
+that it belongs in two skills rather than one.
+
+> The **Reservoir Warden** watches *the human* and never gates.
+> The **WIP Warden** counts *sessions* and never watches the human.
+
+The split is deliberate and it is what protects the Reservoir Warden's trust
+model. That agent is advisory-forever by design: it reports proxies with
+honesty flags, offers exactly one recommendation, and persists nothing about
+the person — and it can be trusted precisely because it has no teeth and wants
+none.
+
+The moment a sibling agent starts inferring from session counts how tired
+someone is, or how well they are working, the Warden's contract is retroactively
+broken: a human who has told the harness their chronotype now has reason to
+wonder what else is being read from it.
+
+So the WIP Warden **counts sessions, full stop**. It reports a number, an age
+per session, and a comparison against a declared limit. It never speculates
+about attention, fatigue, focus, or capacity — not as a hedge, not as a
+sympathetic aside, not in a footnote. Those words do not appear in its output.
+
+**Documentation, not code, in the Reservoir Warden's direction.** Constraint 5
+holds: this slice adds a cross-reference to `cognitive-reservoir/SKILL.md`
+naming the boundary, and changes nothing else about that agent. The build spec
+permits exactly this ("no changes beyond documentation cross-references").
+
+## 3. What `strict` Can Honestly Mean
+
+S1 defined the token, and defined it as something the harness cannot do.
+
+> `strict` — the WIP Warden requires a **disposition** before the session
+> proceeds. — S1 §3.3
+
+**No hook can hold a session.** `reference/hooks.md` opens by saying so —
+"Hooks are advisory only — they warn but never block" — and a `SessionStart`
+hook in particular emits a message into a session that is already starting.
+There is no mechanism, in this plugin or under it, that makes a session wait.
+
+This is the same shape as S3's impossible CI critic check, and it is worth
+naming as a pattern: **a token defined in a vocabulary slice can promise
+behaviour the consuming slice cannot deliver**, and nobody notices until the
+consumer is built. See §7.
+
+### 3.1 The honest definition
+
+| Mode | Behaviour |
+| --- | --- |
+| `advisory` | reports the breach and the live sessions, and moves on |
+| `strict` | **asks** for a disposition — park one, or say what is urgent — and says plainly that it cannot compel one |
+
+`strict` is a stronger *ask*, not a gate. The assistant in the session honours
+it conversationally, which is how every other disposition in this epic works:
+agents propose, humans dispose.
+
+**Because it is not a gate, constraint 6's override machinery does not bind.**
+There is nothing to override — the human can proceed at any point by saying so,
+and no artefact stands between them and their work.
+
+### 3.2 And it says so
+
+The docs state the limit plainly rather than implying enforcement:
+
+> `strict` asks. It cannot hold a session, and nothing in this plugin can. If
+> you keep going, you keep going.
+
+A sentinel that implied it could stop you would be claiming a power it does not
+have — the same overclaim the Mast's weather check was corrected for, and the
+same correction: state the coverage you have.
+
+### 3.3 The override record is #501's
+
+An override worth recording is worth recording *once*. #501 is already building
+the mechanism — a session note the Coda consumes at close — for the Mast's
+hard-stop override, and the WIP Warden's is the same shape arriving through a
+different door.
+
+So S4 ships the ask and **defers the record**, and says so in its docs. #501
+widens from "the Mast's override" to "boundary events and their overrides".
+Building a second note store here would duplicate the store, the retention
+question, and the carve-out evaluation that #501 must do anyway.
+
+## 4. What It Counts, and How Honestly
+
+`registry_count` returns a count and a flag, and S4 reports **both**.
+
+| Situation | Flag | What the report says |
+| --- | --- | --- |
+| Every entry fresh | `observed` | the count, plainly |
+| An entry's lease expired but unpruned | `inferred` | the count, and that at least one session may have ended |
+| A retirement happened recently | `inferred` | the count, and that a session aged out and may have been live |
+| An `unknown` entry present | `inferred` | the count, and that one entry may stand for more than one session |
+
+S1 was explicit that **no consumer may treat this count as an exact number of
+open windows**. S4 is the first consumer, and it honours that: a count flagged
+`inferred` is reported as approximate, in words, every time.
+
+**The ages come from `registry_list`.** Each live session is listed with its
+`started_at` and its repo, so the human can see *which* sessions rather than
+only how many — that is what makes the breach report actionable rather than
+merely true.
+
+`max_switches_per_hour` is **not read**. Nothing in the registry records a
+switch, and inferring one from session activity would be exactly the
+speculation §2 forbids. It stays declared and unread, and Tune says so.
+
+## 5. Files
+
+| File | Purpose |
+| --- | --- |
+| `agents/wip-warden.agent.md` | `role: sentinel`, read-only — counts, lists, compares |
+| `skills/wip-warden/SKILL.md` | the boundary, the honest meaning of `strict`, the flag discipline, the anti-patterns |
+| `commands/wip.md` | `/wip` on demand |
+| `hooks/scripts/wip-check.sh` | `SessionStart` — the breach report |
+| `skills/cognitive-reservoir/SKILL.md` | one cross-reference naming the boundary (docs only) |
+| `commands/mast.md` | one line corrected — see §6 |
+
+The agent sources `lib/session-registry-read.sh` and `lib/pact-blocks.sh`, both
+read surfaces. It must never source `session-registry-write.sh` or
+`pact-write.sh`.
+
+## 6. A Stale Disclosure, Corrected
+
+S3's Tune tells the human that three of `Session WIP`'s four keys "wait for
+S4". Shipping S4 makes that false for two of them.
+
+Correcting a statement of fact that has become false is not mutating a
+contract — it is keeping a derived claim true, and the claim was only ever
+about which components exist. S4 updates the line.
+
+**The deeper fix is recorded, not built here.** That sentence pinned a copy of
+something it should have derived: which keys have live consumers is a fact
+about the shipped components, and `AGENTS.md`'s promoted decision is that
+harness artefacts derive from the source of truth rather than pinning a copy of
+it. The same rule caught the README count badges two slices ago. A derived
+disclosure is a follow-up, on the record.
+
+## 7. A Pattern Worth Naming
+
+Twice now, a vocabulary slice has defined a token whose promised behaviour the
+consuming slice could not deliver:
+
+- S1 promised a CI critic check on `Budgets` diffs. S3 found there are no diffs
+  — the pact file is never committed.
+- S1 promised `strict` would require a disposition before a session proceeds.
+  S4 finds no hook can hold a session.
+
+Both were caught, and both cost a slice's spec gate to catch. The pattern is
+that **defining a token is cheap and defining its enforcement is not**, and a
+slice that ships the vocabulary before any consumer exists has no way to
+discover the gap.
+
+This goes into `sentinel-design` as a note for the next author: when a
+vocabulary slice defines an enforcement token, name the mechanism that will
+deliver it, or mark the token explicitly as awaiting one.
+
+## 8. Non-Goals
+
+- **No gating.** Nothing here can hold a session, and the docs say so.
+- **No override record.** #501.
+- **No speculation about the human.** No fatigue, no attention, no capacity —
+  not in the output, not in the skill, not as a hedge.
+- **No `max_switches_per_hour`.** Nothing observes a switch.
+- **No changes to the Reservoir Warden** beyond one documentation
+  cross-reference.
+- **No changes to the registry.** S4 is a reader.
+
+## 9. Acceptance Scenarios (TDAD)
+
+Prefixed **C** for the count-and-compare hook, **B** for the boundary
+discipline.
+
+### 9.1 The hook — `tdad_tests/layer0_deterministic/test-wip-check.sh`
+
+- **C1 — silent when no `Session WIP` block is declared.** Not an observe-only
+  line; a hook with nothing to say says nothing. Exit 0.
+- **C2 — silent when under the limit.** Two live sessions, limit two, no
+  output.
+- **C3 — reports a breach.** Three live, limit two: the output names the count
+  and the limit.
+- **C4 — lists the live sessions with ages**, so the report is actionable.
+- **C5 — an `inferred` count is reported as approximate**, in words, and never
+  as an exact number.
+- **C6 — `strict` asks; `advisory` does not.** The strict output requests a
+  disposition and the advisory output does not.
+- **C7 — `strict` discloses that it cannot compel.** The output says so
+  plainly.
+- **C8 — a malformed block degrades to silence**, never to a gate.
+- **C9 — exits 0 on every path**, including an unreadable registry and `HOME`
+  unset.
+- **C10 — fires on startup only.** `SessionStart` re-fires on resume, clear and
+  compact; a breach report re-injected mid-session is the thrash it exists to
+  name. Same guard S2 used, and it writes nothing.
+
+### 9.2 The boundary — `test-wip-check.sh` and the TDAD scenarios
+
+- **B1 — no speculation vocabulary anywhere.** The hook, agent, skill and
+  command contain no instance of `fatigue`, `tired`, `attention`, `capacity`,
+  `focus` (as a state), `burnout`, or `depleted`.
+- **B2 — the boundary is stated in both skills**, in the same terms.
+- **B3 — the Reservoir Warden's agent file is unchanged.** Only its skill gains
+  a cross-reference.
+
+### 9.3 Agent-verified
+
+- **A1** — `/wip` reports count, flag, and per-session ages.
+- **A2** — it never infers anything about the human from the count.
+- **A3** — it offers to park via the Coda rather than parking anything itself.
+- **A4** — it says plainly that `strict` cannot hold a session.
+
+## 10. Migration & Rollout
+
+Minor bump, 0.69.0 → 0.70.0. Five CI-checked locations, the README
+plugin-table cell, and the README count badges, anchors, and headings —
+39 skills → 40, 18 agents → 19, 30 commands → 31.
+
+A TDAD scenario per new component. Docs: a how-to, reference entries on all
+three component pages, the hook in `reference/hooks.md`, the boundary on
+`explanation/sentinels.md`, and the roster 7 → 8.
+
+No breaking changes. S4 reads what S1 and S3 already ship.

--- a/docs/superpowers/specs/2026-08-10-cadence-sentinels-s4-wip-warden-design.md
+++ b/docs/superpowers/specs/2026-08-10-cadence-sentinels-s4-wip-warden-design.md
@@ -1,13 +1,16 @@
 # Spec: Cadence Sentinels S4 — The WIP Warden
 
-**Status:** Approved (revision 1)
+**Status:** Approved (revision 2, post-diaboli)
 **Date:** 2026-08-10
 **Issue:** #494
 **Epic:** The Cadence Sentinels (S1–S7, issues #491–#497)
 **Depends on:** S1 (0.67.0) — the session registry and `Session WIP`;
 S3 (0.69.0) — `/mast tune`, which authors the block this reads
+**Objections:** `docs/superpowers/objections/cadence-sentinels-s4-wip-warden-design.md`
+— 12 objections, all accepted
 **Scope:** `ai-literacy-superpowers` plugin; one agent, skill, command, and a
-`SessionStart` hook
+`SessionStart` hook. Plus one repair to S1's `registry_list`, carved as its own
+commit (§4.1).
 **Explicitly out of scope:** the override *record*, which is **#501**; the
 Convener (S5).
 
@@ -28,6 +31,16 @@ limit was, in clear weather. Nothing reads that either.
 
 The WIP Warden is what closes that loop: at the start of a session, it counts,
 compares, and — if you are over the line you drew — says so.
+
+**Why session start, and not somewhere better.** The report arrives *after* the
+switch it exists to discourage, so its ask is remediation ("park one") rather
+than prevention. That is a real cost and worth stating rather than assuming.
+
+It is still the right rail. Session start is the earliest moment at which the
+fact is knowable — the count is only a breach once the new session exists — and
+the human is present and not yet mid-thought. The `Stop` rail was considered and
+rejected: it fires every turn, and the epic's own evidence is that repeating a
+boundary prompt makes adherence worse rather than better.
 
 **Epithet:** *the concurrency gate.* **Attacks:** thrash-switching.
 
@@ -53,7 +66,25 @@ wonder what else is being read from it.
 So the WIP Warden **counts sessions, full stop**. It reports a number, an age
 per session, and a comparison against a declared limit. It never speculates
 about attention, fatigue, focus, or capacity — not as a hedge, not as a
-sympathetic aside, not in a footnote. Those words do not appear in its output.
+sympathetic aside, not in a footnote.
+
+**The ban is on what it emits, not on what its files may say.** The skill has
+to name what it refuses, or it is not a usable rule for the next author — a
+refusal that cannot say what it refuses inverts the write-the-honesty-rule-first
+discipline. So this section, and the skill's copy of it, name the forbidden
+words freely; the Warden's *output* contains none of them.
+
+**And this boundary is not machine-enforced.** An earlier draft tested it by
+banning seven nouns in a Layer-0 script. That check would have passed every
+sentence that actually violates it — "three sessions is a lot to be holding at
+once", "you have been switching between these for a while", "might be worth
+slowing down" — while failing on `focus_blocks`, a live pact key.
+
+Worse, a green word-grep would have been read by the next author as evidence
+that the most important boundary in this slice is checked. It is the same
+overclaim §3.2 forbids for `strict`, and the spec was applying the rule to
+`strict` and not to itself. B1 is therefore an **agent-verified** scenario with
+a rubric, and the skill says plainly that no script enforces this.
 
 **Documentation, not code, in the Reservoir Warden's direction.** Constraint 5
 holds: this slice adds a cross-reference to `cognitive-reservoir/SKILL.md`
@@ -83,6 +114,26 @@ consumer is built. See §7.
 | --- | --- |
 | `advisory` | reports the breach and the live sessions, and moves on |
 | `strict` | **asks** for a disposition — park one, or say what is urgent — and says plainly that it cannot compel one |
+
+**The limit is `max_concurrent_sessions`**, and a breach is `count > limit`.
+The count **includes the session that is starting**: a human writing
+`max_concurrent_sessions: 2` means two *including* the one they are in, which
+is what the template's own field note says. The hook is therefore ordered after
+S1's `session-registry-start.sh` on the same rail, so the entry exists when the
+count is taken.
+
+**When a declared block omits the limit, nothing is compared.** The Warden says
+how many sessions are live, says no limit is declared, and points at
+`/mast tune`. It never invents one — an imposed limit is precisely the pact the
+clear-weather rule says does not hold, and reporting a breach of a line the
+human never drew is the worst output this slice can produce.
+
+That case is not pathological. Tune deliberately offers a two-line pact, so a
+block with its clause and `stale_after_hours` and nothing else is a plausible
+product of the sanctioned authoring path — and `block_state` returns `declared`
+for it, because S1 defined malformed as "mandatory clause **or required key**
+missing" and only the clause half was ever implemented. That gap is **#503**;
+S4 works around it rather than changing a contract it does not own.
 
 `strict` is a stronger *ask*, not a gate. The assistant in the session honours
 it conversationally, which is how every other disposition in this epic works:
@@ -130,10 +181,31 @@ S1 was explicit that **no consumer may treat this count as an exact number of
 open windows**. S4 is the first consumer, and it honours that: a count flagged
 `inferred` is reported as approximate, in words, every time.
 
-**The ages come from `registry_list`.** Each live session is listed with its
-`started_at` and its repo, so the human can see *which* sessions rather than
-only how many — that is what makes the breach report actionable rather than
-merely true.
+**The ages come from `registry_list`** — after the repair in §4.1. Each live
+session is listed with its id, its repo, and its **time since last heartbeat**,
+so the human can see *which* sessions rather than only how many. That is what
+makes the report actionable rather than merely true.
+
+Age is time since heartbeat, not since `started_at`. The distinction decides
+what the report advises: age-since-start says the session you are actively
+working in is the oldest and therefore the obvious one to park, which is exactly
+backwards. Time-since-heartbeat says the one you have not touched since this
+morning is.
+
+### 4.1 A repair to S1, carved
+
+`registry_list` did not filter by lease, while `registry_count` did — and the
+function's docstring claimed "one line per live entry" from the day S1 shipped.
+This slice would have reported "1 live session" and then listed four, on the
+ordinary working day the count's filter exists to survive. A report whose halves
+disagree is worse than no report.
+
+**Repairing a function to match the behaviour its own contract promised is not a
+contract change; it is the defect.** It is carved as its own commit, with its
+own scenarios (R17: the list and the count never disagree; R18: the line carries
+the heartbeat), so the fix is reviewable apart from the slice that found it and
+every future consumer inherits the honest version rather than each re-deriving
+the filter.
 
 `max_switches_per_hour` is **not read**. Nothing in the registry records a
 switch, and inferring one from session activity would be exactly the
@@ -149,6 +221,16 @@ speculation §2 forbids. It stays declared and unread, and Tune says so.
 | `hooks/scripts/wip-check.sh` | `SessionStart` — the breach report |
 | `skills/cognitive-reservoir/SKILL.md` | one cross-reference naming the boundary (docs only) |
 | `commands/mast.md` | one line corrected — see §6 |
+| `templates/pacts.md` | the `strict` field note, which still promises a recorded override |
+| `reference/pacts-format.md` | the same promise, on the published page |
+| `skills/sentinel-design/SKILL.md` | §7's note, and the roster |
+| `README.md` | the Sentinels roster |
+
+The two `strict` surfaces matter more than they look. The template is what a
+human reads while deciding whether to write `strict` at all — they would choose
+it on the promise of a recorded override and get an ask with no record. **The
+mandatory clause above those field notes must not move**: `pact-write.sh`
+derives it and T9 pins it.
 
 The agent sources `lib/session-registry-read.sh` and `lib/pact-blocks.sh`, both
 read surfaces. It must never source `session-registry-write.sh` or
@@ -170,24 +252,33 @@ harness artefacts derive from the source of truth rather than pinning a copy of
 it. The same rule caught the README count badges two slices ago. A derived
 disclosure is a follow-up, on the record.
 
-## 7. A Pattern Worth Naming
+## 7. The Lesson, With Its Provenance Corrected
 
-Twice now, a vocabulary slice has defined a token whose promised behaviour the
-consuming slice could not deliver:
+An earlier draft claimed a pattern from two instances. One of them was
+misattributed: the CI critic check on `Budgets` diffs was called for by the
+**build spec**, and made impossible by S1's user-scoped pact decision — which S1
+flagged at the time. That is a different shape, and stripping it leaves a single
+case, which is thin ground for a promoted rule.
 
-- S1 promised a CI critic check on `Budgets` diffs. S3 found there are no diffs
-  — the pact file is never committed.
-- S1 promised `strict` would require a disposition before a session proceeds.
-  S4 finds no hook can hold a session.
+The sharper reading is available, and it is about a disposition rather than a
+definition.
 
-Both were caught, and both cost a slice's spec gate to catch. The pattern is
-that **defining a token is cheap and defining its enforcement is not**, and a
-slice that ships the vocabulary before any consumer exists has no way to
-discover the gap.
+**S1's own gate caught this.** Objection O11 said that shipping `strict` with no
+definition "pre-authorises S4 to interpret it as blocking". It was accepted, and
+the disposition was *define the semantics* — which is exactly what produced a
+token whose defined semantics no mechanism could deliver. S1 §3.5 shows the team
+already possessed the stronger remedy and used it one block over: `Sync cadence`
+ships with a reserved marker saying plainly that nothing reads it.
 
-This goes into `sentinel-design` as a note for the next author: when a
-vocabulary slice defines an enforcement token, name the mechanism that will
-deliver it, or mark the token explicitly as awaiting one.
+So the lesson for `sentinel-design` is not "define a token, name a mechanism" as
+a fresh discovery. It is:
+
+> When a gate accepts an objection that a token may be undeliverable, **defining
+> its semantics is not a sufficient disposition.** Either name the mechanism that
+> will deliver it, or mark it as awaiting one — the reserved-marker treatment.
+
+That rule would have caught this at S1, where it was cheap, rather than at S4,
+where the token was already in the shipped template a human authors from.
 
 ## 8. Non-Goals
 
@@ -207,8 +298,15 @@ discipline.
 
 ### 9.1 The hook — `tdad_tests/layer0_deterministic/test-wip-check.sh`
 
-- **C1 — silent when no `Session WIP` block is declared.** Not an observe-only
-  line; a hook with nothing to say says nothing. Exit 0.
+- **C1 — the hook is silent when no `Session WIP` block is declared.** Not an
+  observe-only line; a hook with nothing to say says nothing. Exit 0.
+
+  This departs from S1's Null Object contract, deliberately, and the departure
+  is argued rather than assumed: a `SessionStart` hook announcing "no
+  `Session WIP` block declared" to every user who never asked for this epic is
+  exactly the imposition S1 warns against. **`/wip` does not follow it into
+  silence** — see C11. S1's contract note is amended so S5 inherits the split
+  rather than re-deriving it.
 - **C2 — silent when under the limit.** Two live sessions, limit two, no
   output.
 - **C3 — reports a breach.** Three live, limit two: the output names the count
@@ -220,7 +318,13 @@ discipline.
   disposition and the advisory output does not.
 - **C7 — `strict` discloses that it cannot compel.** The output says so
   plainly.
-- **C8 — a malformed block degrades to silence**, never to a gate.
+- **C8 — a malformed block degrades to silence** in the hook, never to a gate.
+- **C11 — `/wip` uses the observe-only sentence.** Given no block and an
+  explicit invocation, the command emits S1's fixed sentence. A human who asked
+  a question and got nothing cannot tell an absent block from a compliant one.
+- **C12 — a declared block with no limit compares nothing.** The output states
+  the count, states that no limit is declared, points at `/mast tune`, and
+  contains no breach language.
 - **C9 — exits 0 on every path**, including an unreadable registry and `HOME`
   unset.
 - **C10 — fires on startup only.** `SessionStart` re-fires on resume, clear and
@@ -229,12 +333,19 @@ discipline.
 
 ### 9.2 The boundary — `test-wip-check.sh` and the TDAD scenarios
 
-- **B1 — no speculation vocabulary anywhere.** The hook, agent, skill and
-  command contain no instance of `fatigue`, `tired`, `attention`, `capacity`,
-  `focus` (as a state), `burnout`, or `depleted`.
-- **B2 — the boundary is stated in both skills**, in the same terms.
+- **B1 — no speculation in the Warden's output** (agent-verified, §9.3). This
+  is a rubric, not a grep: the sentences that violate the boundary — "three
+  sessions is a lot to be holding at once", "you have been switching between
+  these for a while" — contain none of the obvious nouns, and a word list would
+  pass every one of them while failing on `focus_blocks`.
+- **B2 — the boundary is stated in both skills**, in the same terms, naming
+  what is refused.
 - **B3 — the Reservoir Warden's agent file is unchanged.** Only its skill gains
   a cross-reference.
+- **B4 — no write surface is reachable.** The agent and the hook contain no
+  source of `session-registry-write.sh` or `pact-write.sh`. The frontmatter
+  check cannot see this: `Bash` is permitted and it reads only the declared
+  `tools:` list.
 
 ### 9.3 Agent-verified
 

--- a/tdad_tests/layer0_deterministic/test-session-registry.sh
+++ b/tdad_tests/layer0_deterministic/test-session-registry.sh
@@ -344,4 +344,48 @@ set -e
 
 export CLAUDE_SESSIONS_DIR="$TMP/sessions"
 
+# --- R17: the list and the count never disagree -------------------------------
+# registry_list claimed "one line per live entry" from the day S1 shipped and
+# did not filter by lease. A consumer reporting a count from one and a list
+# from the other would have said "1 live session" and listed four — a report
+# whose own halves contradict each other, on the ordinary working day the
+# count's filter exists to survive.
+r17="$TMP/r17"
+for s in live-a live-b stale-c stale-d; do
+  hook_input "$s" | CLAUDE_SESSIONS_DIR="$r17" bash "$START_HOOK" >/dev/null 2>&1 || true
+done
+ts_old=$(date -u -v-20H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "20 hours ago" +%Y-%m-%dT%H:%M:%SZ)
+for s in stale-c stale-d; do
+  sed -i.bak -E "s#(\"heartbeat\"[[:space:]]*:[[:space:]]*\")[^\"]*#\1${ts_old}#" "$r17/$s.json"
+  rm -f "$r17/$s.json.bak"
+done
+
+read -r count _ <<<"$(CLAUDE_SESSIONS_DIR="$r17" registry_count)"
+r17_out="$(CLAUDE_SESSIONS_DIR="$r17" registry_list)"
+listed=$(printf '%s' "$r17_out" | grep -c . || true)
+[ "$count" = "2" ] || fail "R17: two fresh entries must count 2, got '$count'"
+[ "$listed" = "$count" ] \
+  || fail "R17: the list and the count must agree — count said $count, list had $listed"
+# No match is the passing case, so this cannot sit in an `&&` chain.
+if printf '%s' "$r17_out" | grep -q "stale-c"; then
+  fail "R17: an expired lease must not appear in the list"
+fi
+
+# --- R18: the list carries heartbeat, so age is honestly computable ----------
+# Age-since-started_at says the session you are actively working in is the
+# oldest and therefore the obvious one to park, which is backwards. Only
+# time-since-heartbeat matches what liveness means here.
+# Captured whole, then sliced — piping registry_list straight into `head`
+# closes the pipe mid-printf, which under `pipefail` is a write error rather
+# than a passing test.
+line=$(printf '%s' "$r17_out" | sed -n '1p')
+fields=$(printf '%s' "$line" | awk -F'\t' '{print NF}')
+[ "$fields" = "4" ] \
+  || fail "R18: each line must carry id, started_at, heartbeat, repo — got $fields fields"
+hb_field=$(printf '%s' "$line" | cut -f3)
+case "$hb_field" in
+  20[0-9][0-9]-*T*Z) : ;;
+  *) fail "R18: the third field must be the heartbeat timestamp, got '$hb_field'" ;;
+esac
+
 echo "PASS: session registry — lease renewed not deleted, flag durable, read library inert, hostile ids sanitised"

--- a/tdad_tests/layer0_deterministic/test-wip-check.sh
+++ b/tdad_tests/layer0_deterministic/test-wip-check.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for the WIP breach check
+# (spec 2026-08-10-cadence-sentinels-s4-wip-warden-design.md, §9; C1–C12).
+#
+# C12 is the one that matters most, and it is not obvious. `/mast tune`
+# deliberately offers a two-line pact and declines to march the human through
+# every key, so a `Session WIP` block carrying its mandatory clause and
+# `stale_after_hours` and nothing else is a plausible product of the sanctioned
+# authoring path — not a pathological fixture. `block_state` returns `declared`
+# for it, because S1 defined malformed as "mandatory clause OR required key
+# missing" and only the clause half was ever implemented (#503).
+#
+# So the hook must not invent a limit. Reporting a breach of a line the human
+# never drew is the worst output this slice can produce: an imposed limit is
+# precisely the pact the clear-weather rule says does not hold.
+#
+# C10 carries the other half of the design. `SessionStart` re-fires on resume,
+# clear and compact, and a breach report re-injected mid-session is the thrash
+# the sentinel exists to name. Same `source` guard S2 shipped, writing nothing.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN="$SCRIPT_DIR/../../ai-literacy-superpowers"
+HOOK="$PLUGIN/hooks/scripts/wip-check.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$HOOK" ] || fail "wip check not found at $HOOK"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export CLAUDE_SESSIONS_DIR="$TMP/sessions"
+export CLAUDE_PACTS_FILE="$TMP/pacts.md"
+mkdir -p "$CLAUDE_SESSIONS_DIR"
+
+hook_input() {
+  if [ "${2-startup}" = "none" ]; then
+    printf '{"session_id":"%s","cwd":"%s"}' "$1" "$TMP"
+  else
+    printf '{"session_id":"%s","cwd":"%s","source":"%s"}' "$1" "$TMP" "${2-startup}"
+  fi
+}
+
+run() {
+  set +e
+  OUT="$(hook_input "$1" "${2-startup}" | bash "$HOOK" 2>/dev/null)"
+  RC=$?
+  set -e
+}
+
+live() {  # live <id...> — write a fresh registry entry per id
+  # shellcheck source=/dev/null
+  ( . "$PLUGIN/hooks/scripts/lib/session-registry-write.sh"
+    for s in "$@"; do registry_touch "$s" "$TMP"; done )
+}
+
+pact() {  # pact <body-line...> — a Session WIP block with its mandatory clause
+  { printf '# Pacts\n\n## Session WIP\n\n'
+    printf '%s\n' "$@"
+    printf '\nThis is a gate on sessions, never on the person. It counts; it does not\nassess.\n'
+  } > "$CLAUDE_PACTS_FILE"
+}
+
+# --- C1: silent when no Session WIP block is declared -------------------------
+# A SessionStart hook announcing an observe-only line to every user who never
+# asked for this epic is the imposition S1 warns against. /wip is different
+# (C11) — a human who asked a question and got nothing cannot tell an absent
+# block from a compliant one.
+: > "$CLAUDE_PACTS_FILE"
+live a b c
+run "s-c1"
+[ "$RC" -eq 0 ] || fail "C1: must exit 0 (got $RC)"
+[ -z "$OUT" ] || fail "C1: must be silent with no block declared. Got: $OUT"
+
+# --- C2: silent when under the limit -----------------------------------------
+# The starting session is counted, so two live against a limit of two is
+# compliant, not a breach.
+rm -f "$CLAUDE_SESSIONS_DIR"/*.json
+pact '- max_concurrent_sessions: 2'
+live a b
+run "s-c2"
+[ -z "$OUT" ] || fail "C2: two live against a limit of two must be silent. Got: $OUT"
+
+# --- C3: reports a breach -----------------------------------------------------
+live c
+run "s-c3"
+echo "$OUT" | grep -q "3" || fail "C3: the report must name the count. Got: $OUT"
+echo "$OUT" | grep -q "2" || fail "C3: the report must name the limit. Got: $OUT"
+
+# --- C4: lists the live sessions, with an age ---------------------------------
+# What makes the report actionable rather than merely true: "park one" is
+# unanswerable if you cannot see which.
+for s in a b c; do
+  echo "$OUT" | grep -q "$s" || fail "C4: the report must list session '$s'. Got: $OUT"
+done
+
+# --- C6/C7: strict asks, and says it cannot compel ----------------------------
+pact '- max_concurrent_sessions: 2' '- enforcement: advisory'
+run "s-c6a"
+if echo "$OUT" | grep -qiE 'park one|what is urgent|which would you'; then
+  fail "C6: advisory must not ask for a disposition. Got: $OUT"
+fi
+
+pact '- max_concurrent_sessions: 2' '- enforcement: strict'
+run "s-c6b"
+echo "$OUT" | grep -qiE 'park|urgent' \
+  || fail "C6: strict must ask for a disposition. Got: $OUT"
+echo "$OUT" | grep -qiE "cannot hold|can't hold|cannot stop|nothing here can" \
+  || fail "C7: strict must say plainly that it cannot compel. Got: $OUT"
+
+# --- C12: a declared block with no limit compares nothing ---------------------
+pact '- stale_after_hours: 12'
+run "s-c12"
+[ "$RC" -eq 0 ] || fail "C12: must exit 0 (got $RC)"
+echo "$OUT" | grep -qiE 'no limit|not declared|have not declared|haven.t declared' \
+  || fail "C12: must say no limit is declared. Got: $OUT"
+echo "$OUT" | grep -qiF '/mast tune' \
+  || fail "C12: must point at /mast tune. Got: $OUT"
+if echo "$OUT" | grep -qiE 'over|breach|exceed|more than'; then
+  fail "C12: must not report a breach of a limit that was never declared. Got: $OUT"
+fi
+
+# --- C5: an inferred count is reported as approximate -------------------------
+# S1: no consumer may treat this count as an exact number of open windows.
+pact '- max_concurrent_sessions: 1'
+: > "$CLAUDE_SESSIONS_DIR/unknown.json"
+printf '{"id":"unknown","repo":"%s","started_at":"2026-08-11T00:00:00Z","heartbeat":"%s"}' \
+  "$TMP" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$CLAUDE_SESSIONS_DIR/unknown.json"
+run "s-c5"
+echo "$OUT" | grep -qiE 'at least|approximate|may |might ' \
+  || fail "C5: an inferred count must be reported as approximate. Got: $OUT"
+
+# --- C8: a malformed block degrades to silence, never a gate -----------------
+printf '# Pacts\n\n## Session WIP\n\n- max_concurrent_sessions: 1\n\nThe clause is gone.\n' \
+  > "$CLAUDE_PACTS_FILE"
+run "s-c8"
+[ "$RC" -eq 0 ] || fail "C8: a malformed block must never gate (got $RC)"
+[ -z "$OUT" ] || fail "C8: the hook must stay silent on a malformed block. Got: $OUT"
+
+# --- C10: fires on startup only ----------------------------------------------
+pact '- max_concurrent_sessions: 1'
+run "s-c10" "startup"
+[ -n "$OUT" ] || fail "C10: a startup must report the breach"
+for src in resume clear compact none; do
+  run "s-c10" "$src"
+  [ -z "$OUT" ] \
+    || fail "C10: a $src firing must be silent — a breach report re-injected mid-session is the thrash this names. Got: $OUT"
+done
+
+# --- C9: exits 0 on every path -----------------------------------------------
+blocked="$TMP/blocked"; : > "$blocked"
+CLAUDE_SESSIONS_DIR="$blocked/sessions" run "s-c9a"
+[ "$RC" -eq 0 ] || fail "C9: unreadable registry must still exit 0 (got $RC)"
+
+set +e
+OUT="$(hook_input "s-c9b" | env -u HOME bash "$HOOK" 2>/dev/null)"; RC=$?
+set -e
+[ "$RC" -eq 0 ] || fail "C9: HOME unset must still exit 0 (got $RC)"
+
+set +e
+OUT="$(printf 'not json' | bash "$HOOK" 2>/dev/null)"; RC=$?
+set -e
+[ "$RC" -eq 0 ] || fail "C9: unparseable stdin must still exit 0 (got $RC)"
+
+# --- B4: no write surface is reachable ---------------------------------------
+# The frontmatter check cannot see this: Bash is permitted and it reads only
+# the declared tools list.
+#
+# Matches a SOURCE of a write library, not a mention of one. The first version
+# grepped for the filenames and failed on the agent's own charter, which names
+# both surfaces in the sentence forbidding them — a good charter says what it
+# refuses. That is the same distinction that moved the speculation ban from
+# files to emitted output (O5, O6): a grep cannot tell naming from doing.
+for f in "$HOOK" "$PLUGIN/agents/wip-warden.agent.md"; do
+  [ -f "$f" ] || continue
+  if grep -qE '^[[:space:]]*(\.|source)[[:space:]].*(session-registry-write|pact-write)\.sh' "$f"; then
+    fail "B4: $(basename "$f") sources a write surface"
+  fi
+done
+
+echo "PASS: WIP check — counts honestly, never invents a limit, asks without pretending to compel"

--- a/tdad_tests/scenarios/agents/wip-warden/counts-sessions-never-watches.md
+++ b/tdad_tests/scenarios/agents/wip-warden/counts-sessions-never-watches.md
@@ -1,0 +1,62 @@
+---
+component: wip-warden
+component_type: agent
+tier: structural
+---
+
+# Scenario: the WIP Warden counts sessions and never watches the human
+
+## Given
+
+This agent exists alongside the `reservoir-warden`, whose entire value rests on
+being advisory-forever and persisting nothing about the person. It is
+trustworthy precisely because it has no teeth and wants none.
+
+If a sibling starts inferring from session counts how tired someone is, that
+contract breaks **retroactively** — a human who told the harness their
+chronotype now has reason to wonder what else is being read from it.
+
+**No script enforces this boundary.** A word-ban was tried and rejected: it
+would pass every sentence that actually violates it ("three sessions is a lot
+to be holding at once") while failing on `focus_blocks`, a live pact key. This
+scenario is the guard.
+
+## When
+
+`ai-literacy-superpowers/agents/wip-warden.agent.md` is read from the
+filesystem.
+
+## Then
+
+**Frontmatter:** `name: wip-warden`, non-empty description, `role: sentinel`,
+`tools` exactly `Read, Glob, Grep, Bash` — no `Write`, no `Edit`.
+
+**Charter:**
+
+- States the boundary in the same terms as the skill: the Reservoir Warden
+  watches the human and never gates; this agent counts sessions and never
+  watches the human — **with the reason**, that the trust model breaks
+  retroactively.
+- States that no script enforces it and that it is the author's to hold.
+- Names the read surfaces it may source and the two write surfaces it may not,
+  noting the frontmatter check cannot see a `source` line.
+- Requires the count's flag to be reported, with "at least" on `inferred`, and
+  cites the no-exact-count rule.
+- Requires age to be **time since heartbeat**, and says why `started_at` would
+  advise the opposite.
+- States that it never invents a limit, and what it does instead.
+- States that `strict` asks and cannot compel.
+- Offers `/coda` for parking rather than parking anything itself.
+
+## Rubric
+
+Passes only when the tool list carries no write capability, the boundary
+appears with its retroactive-trust reasoning, the never-invent-a-limit rule is
+present, and the heartbeat-not-started_at distinction is stated with its
+consequence.
+
+## Notes
+
+The heartbeat distinction looks like a detail and is not: age-since-start would
+point the human at the session they are actively working in as the obvious one
+to park.

--- a/tdad_tests/scenarios/commands/wip/reports-without-inventing.md
+++ b/tdad_tests/scenarios/commands/wip/reports-without-inventing.md
@@ -1,0 +1,49 @@
+---
+component: wip
+component_type: command
+tier: structural
+---
+
+# Scenario: /wip answers the question it was asked, and invents nothing
+
+## Given
+
+`/wip` is invoked deliberately, which makes its absent-block behaviour the
+opposite of the hook's. The hook stays silent because announcing an
+observe-only line to every user who never asked for this epic is an imposition;
+the command must speak, because a human who asked a question and got nothing
+cannot tell an absent block from a compliant one.
+
+## When
+
+`ai-literacy-superpowers/commands/wip.md` is read from the filesystem.
+
+## Then
+
+- Frontmatter with `name: wip` and a non-empty description.
+- States that it never says anything about the human, and that the boundary is
+  held by the author rather than by a script.
+- **Absent block → the observe-only sentence and an offer of `/mast tune`**,
+  explicitly contrasted with the hook's silence.
+- **Malformed block →** name the missing clause, continue.
+- Dispatches the `wip-warden` agent; the agent holds no `Write`.
+- Requires the count's flag to be surfaced, with "at least" on `inferred`.
+- Requires per-session ages measured from **heartbeat**.
+- **No limit declared → say so and point at `/mast tune`; never supply a
+  default.**
+- `strict` asks and says it cannot compel; `advisory` reports and stops.
+- Offers `/coda` for parking rather than parking anything.
+- States that a spoken override is **not** recorded, rather than implying it
+  was.
+
+## Rubric
+
+Passes only when the command speaks on an absent block, never supplies a
+default limit, and discloses that an override goes unrecorded.
+
+## Notes
+
+The last assertion matters because the shipped pact template still described an
+on-the-record override when this slice was written. Saying plainly that the
+record does not exist yet is what keeps the promise honest until the slice that
+builds it lands.

--- a/tdad_tests/scenarios/skills/wip-warden/boundary-and-honest-strict.md
+++ b/tdad_tests/scenarios/skills/wip-warden/boundary-and-honest-strict.md
@@ -1,0 +1,57 @@
+---
+component: wip-warden
+component_type: skill
+tier: structural
+---
+
+# Scenario: the skill states the boundary, its unenforceability, and strict's limit
+
+## Given
+
+Two sections of this skill are contracts.
+
+The **boundary** is what lets this sentinel coexist with the Reservoir Warden,
+and it is not machine-checked — so the skill must say both what it forbids and
+that nothing verifies it.
+
+**`strict`** was defined by an earlier slice as requiring a disposition before a
+session proceeds, which no hook can do. The skill is where that honest
+correction lives for the next author.
+
+## When
+
+`ai-literacy-superpowers/skills/wip-warden/SKILL.md` is read from the
+filesystem.
+
+## Then
+
+- Frontmatter naming the boundary, `strict`, the flag discipline, and the
+  anti-patterns.
+- The boundary stated in the same terms as the agent, with the
+  retroactive-trust reasoning and at least one `<!-- evidence: ... -->`
+  comment.
+- A section stating that **no script enforces the boundary**, with the worked
+  examples of sentences a word-ban would pass and the `focus_blocks`
+  false-positive.
+- `strict` described as an ask that cannot compel, with the reason (hooks are
+  advisory) and the consequence (no gate, so no override machinery binds).
+- The flag table, "at least" on `inferred`, and the no-exact-count rule.
+- Age from heartbeat, with the backwards-advice consequence.
+- The never-invent-a-limit rule, with issue #503 named as the underlying gap.
+- The hook-silent / command-speaks split, with the reason for each.
+- An anti-patterns section naming at least: speculation about the person,
+  inventing a limit, implying `strict` can stop you, reporting an inferred
+  count as exact, age from `started_at`, parking anything, and sourcing a write
+  surface.
+
+## Rubric
+
+Passes only when the not-machine-enforced section is present with its worked
+examples, `strict`'s limit is stated with its reason, and all seven
+anti-patterns are named.
+
+## Notes
+
+The not-machine-enforced section is the load-bearing one. Without it a future
+author sees agent-verified scenarios passing and reasonably concludes the
+boundary is checked.

--- a/tdad_tests/tests/test_layer0_deterministic.py
+++ b/tdad_tests/tests/test_layer0_deterministic.py
@@ -77,6 +77,9 @@ BASH_TEST_SCRIPTS = [
     # Cadence Sentinels S3 — the pact writer. RED until S3 ships
     # hooks/scripts/lib/pact-write.sh.
     "test-pact-write",
+    # Cadence Sentinels S4 — the WIP breach check. RED until S4 ships
+    # hooks/scripts/wip-check.sh.
+    "test-wip-check",
 ]
 
 


### PR DESCRIPTION
Closes #494. Fourth slice of **The Cadence Sentinels** epic.

Closes the loop S1 and S3 left open: the registry knew how many sessions were live, the pact declared the limit, and nothing read either.

## The boundary is the point

> The **Reservoir Warden** watches *the human* and never gates.
> The **WIP Warden** counts *sessions* and never watches the human.

That split protects the Reservoir Warden's trust model. It is advisory-forever and persists nothing about the person, and it earns trust precisely by having no teeth. A sibling inferring tiredness from session counts would break that contract **retroactively** — for anyone who had ever declared a chronotype.

**And no script enforces it.** I wrote a word-ban and the gate rejected it: it passes every sentence that actually violates the boundary — *"three sessions is a lot to be holding at once"*, *"you have been switching between these for a while"* — while failing on `focus_blocks`, a live pact key. Worse, a green grep would read as proof the boundary was checked. It's agent-verified with a rubric now, and the skill says plainly that nothing automated holds it.

## What the gate caught

**12 objections — one critical, six high — all accepted.**

**The critical was mine, from S1.** `registry_list`'s docstring said *"one line per live entry"* and it wasn't: it iterated every `*.json` with no heartbeat check while `registry_count` filtered expired leases. This slice would have reported "1 live session" and then listed four. **Repaired in its own commit** — carved, because repairing a function to match the behaviour its own contract promised is fixing a defect, not changing a contract. It now also carries `heartbeat`, so age is measured from each session's last turn rather than from when it started — the latter would point you at the session you're working in as the obvious one to park.

**`enforcement: strict` got an honest definition.** S1 defined it as requiring a disposition *before the session proceeds*; no hook can hold a session, and the repo's own hooks reference opens by saying so. It's now a stronger ask that states it cannot compel — and the shipped template and reference page, which still promised an on-the-record override, are corrected.

**It never invents a limit.** A `Session WIP` block with its clause and no `max_concurrent_sessions` is a *normal* file — `/mast tune` offers a two-line pact on purpose — and `block_state` calls it `declared`, because the required-key half of malformed was never implemented (**#503**). So the Warden says no limit is declared and compares nothing. Reporting a breach of a line you never drew would be the worst thing it could do.

## A pattern, with its provenance corrected

Twice a vocabulary slice defined a token its consumer couldn't deliver. But the sharper reading is about a *disposition*: S1's own gate caught this as O11 and disposed it with *"define the semantics"* — which is exactly what produced an undeliverable token. S1 already had the stronger remedy and used it one block over, on `Sync cadence`'s reserved marker.

So the rule going into `sentinel-design` is: **when a gate accepts an objection that a token may be undeliverable, defining its semantics is not a sufficient disposition** — name the mechanism, or mark it as awaiting one.

## Two bugs my own tests caught

- `emit` piped into `read`, and awk's `ORS=""` leaves no trailing newline — so `read` hit EOF, returned 1, and took the hook down under `set -e`.
- B4 grepped for the write-surface filenames and **failed on the agent's own charter**, which names both in the sentence forbidding them. A good charter says what it refuses, and a grep can't tell naming from doing — the same distinction that had just moved the speculation ban from files to output.

## Records

- Spec (revision 2): `docs/superpowers/specs/2026-08-10-cadence-sentinels-s4-wip-warden-design.md`
- Objections: `docs/superpowers/objections/cadence-sentinels-s4-wip-warden-design.md`

Follow-ups raised: **#503** (`block_state`'s missing required-key half). Override record remains **#501**.

Version: 0.69.0 → 0.70.0. Sentinels 7 → 8.