### PR TITLE
Fix: block_state answers well-formedness, not completeness

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.70.0",
+  "plugin_version": "0.70.1",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.70.0"
+      "version": "0.70.1"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.70.1 — 2026-08-11
+
+### Fix: `block_state` answers well-formedness, not completeness
+
+S1 defined `malformed` as "mandatory clause **or required key** missing" and
+only the clause half was ever implemented. S4 exposed the gap; the resolution
+is that the **definition** was the defect, not the code.
+
+- **No pact key is required.** `/mast tune` deliberately offers a two-line
+  pact, so a `Session WIP` block carrying only `stale_after_hours` is exactly
+  what somebody meant to write. Calling that `malformed` would say it was
+  broken. It is not broken — it is partial, on purpose — and no key was ever
+  truly required, since a person may declare that block solely to tune the
+  registry lease.
+- **`block_has_key`** answers the completeness question separately, per key, so
+  a consumer can say *what* is absent instead of inventing a value. An empty
+  value is not a declaration: `- max_concurrent_sessions:` with nothing after
+  it is someone who started typing and stopped.
+- The WIP Warden now asks rather than inferring a missing limit from an empty
+  string.
+- S1's spec and the pacts reference page are amended, and the reference now
+  tells adopters plainly that a short pact is a complete one.
+
+Closes #503.
+
 ## 0.70.0 — 2026-08-11
 
 ### Cadence Sentinels S4 — the WIP Warden

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.70.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.70.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-40-2E8B57?style=flat-square)](#skills-40)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.70.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **40 skills, 19 agents, 31 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.70.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **40 skills, 19 agents, 31 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.70.0",
+  "version": "0.70.1",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/hooks/scripts/lib/pact-blocks.sh
+++ b/ai-literacy-superpowers/hooks/scripts/lib/pact-blocks.sh
@@ -116,6 +116,43 @@ block_key() {
   if [ -n "$val" ]; then printf '%s' "$val"; else printf '%s' "$def"; fi
 }
 
+# block_has_key <heading> <key> — true when the human actually declared a value
+# for that key. Exit 0 when present, 1 when not. Never an error.
+#
+# WHY THIS IS SEPARATE FROM block_state. S1 defined `malformed` as "mandatory
+# clause **or required key** missing", and only the clause half was ever
+# implemented. When S4 exposed the gap (#503), the decision was that the
+# DEFINITION was the defect.
+#
+# `/mast tune` deliberately offers a two-line pact — a number invented to move
+# the dialogue along is not more authored than one the human declined to give —
+# so a `Session WIP` block carrying only `stale_after_hours` is exactly what
+# somebody meant to write. Calling it `malformed` would say it is broken. It is
+# not broken; it is partial, on purpose, and no key is truly required: a person
+# may declare that block solely to tune the registry lease.
+#
+# So `block_state` answers **well-formedness** — does this block carry its
+# governing clause — and this answers **completeness**, per key, for whichever
+# consumer needs one. That is what lets the WIP Warden say "you have not
+# declared a limit" instead of inventing one, which is the failure that matters:
+# an imposed limit is precisely the pact the clear-weather rule says does not
+# hold.
+#
+# An empty value is not a declaration. `- max_concurrent_sessions:` with nothing
+# after it is someone who started typing and stopped — and the sentinel catches
+# that case for free, because `block_key` returns the caller's default when the
+# extracted value is empty. One comparison covers both "no such key" and "key
+# with no value". A separate `[ -n "$val" ]` guard was written here first and a
+# mutation test showed it could never fire.
+block_has_key() {
+  local heading="$1" key="$2" sentinel val
+  # A sentinel no human would type, so an absent key is distinguishable from a
+  # declared one without a second parse.
+  sentinel=$'\x01__pact_absent__'
+  val="$(block_key "$heading" "$key" "$sentinel")"
+  [ "$val" != "$sentinel" ]
+}
+
 # _mandatory_clause <heading> — the literal sentence a block must carry, or
 # empty when the block has none.
 #

--- a/ai-literacy-superpowers/hooks/scripts/wip-check.sh
+++ b/ai-literacy-superpowers/hooks/scripts/wip-check.sh
@@ -55,7 +55,13 @@ source_field="$(printf '%s' "$input" \
 read -r count flag <<<"$(registry_count 2>/dev/null || printf '0 observed')"
 case "$count" in ''|*[!0-9]*) exit 0 ;; esac
 
-limit="$(block_key 'Session WIP' 'max_concurrent_sessions' '')"
+# Ask whether the human declared a limit, rather than inferring it from an
+# empty string. `block_state` answers well-formedness; this answers
+# completeness (#503). A partial pact is a complete pact — just a short one.
+limit=""
+if block_has_key 'Session WIP' 'max_concurrent_sessions'; then
+  limit="$(block_key 'Session WIP' 'max_concurrent_sessions' '')"
+fi
 enforcement="$(block_key 'Session WIP' 'enforcement' 'advisory')"
 
 # `at least` rather than a bare number whenever the count is inferred. S1 was

--- a/docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md
@@ -122,12 +122,21 @@ the clear-weather rule says does not hold.
 - enforcement: advisory | strict
 ```
 
-| Key | Grammar | Required |
+| Key | Grammar | Consumer |
 | --- | --- | --- |
-| `max_concurrent_sessions` | single integer | yes |
-| `max_switches_per_hour` | single integer | no |
-| `stale_after_hours` | single integer | no (defaults 12) |
-| `enforcement` | one of `advisory`, `strict` | no (defaults `advisory`) |
+| `max_concurrent_sessions` | single integer | the WIP Warden's comparison |
+| `max_switches_per_hour` | single integer | none — nothing observes a switch |
+| `stale_after_hours` | single integer | the registry lease (defaults 12) |
+| `enforcement` | one of `advisory`, `strict` | the WIP Warden (defaults `advisory`) |
+
+**No key is required** (amended 2026-08-11, issue #503). The first revision
+marked `max_concurrent_sessions` required, which was never true: a person may
+declare this block solely to tune the registry lease. `/mast tune` deliberately
+offers a partial pact, so a block carrying one key is exactly what somebody
+meant to write.
+
+A consumer that needs a particular value asks `block_has_key` and says what is
+absent — it never invents one.
 
 `stale_after_hours` is the registry lease length (§4.2). It is declared rather
 than compiled in because every other threshold in this harness — the whole
@@ -267,7 +276,7 @@ A block is in exactly one of three states.
 | State | Test | Consumer behaviour |
 | --- | --- | --- |
 | **Absent** | no pact file, or no heading of that name | observe-only note, continue |
-| **Malformed** | heading present, mandatory clause or required key missing | observe-only note **plus** a line naming what is missing, continue |
+| **Malformed** | heading present, mandatory clause missing | observe-only note **plus** a line naming what is missing, continue |
 | **Declared** | heading present and well-formed | read it |
 
 The observe-only note is a fixed sentence, emitted by the library so every
@@ -281,6 +290,12 @@ in S2–S5 runs one code path whether or not the block exists; the library
 supplies the null behaviour. This is why absent and malformed collapse to the
 same behaviour rather than that collapse being a coincidence, and it is the
 library's real contract to the later slices.
+
+**`block_state` answers well-formedness, not completeness** (amended
+2026-08-11, #503). It asks whether the block carries its governing clause.
+Whether a *value* the consumer needs is present is a separate question, per
+key, answered by `block_has_key` — because a deliberately partial pact is not
+broken, and calling it malformed would say it was.
 
 **Malformed degrades to observe-only, never to a gate.** This is the reachable
 case: someone edits their pact file, deletes prose they read as boilerplate,

--- a/tdad_tests/layer0_deterministic/fixtures/cadence-pacts/empty-value.md
+++ b/tdad_tests/layer0_deterministic/fixtures/cadence-pacts/empty-value.md
@@ -1,0 +1,12 @@
+# Pacts
+
+Fixture: a key typed but never given a value — someone started and stopped.
+That is not a declaration, and `block_has_key` must not report it as one.
+
+## Session WIP
+
+- max_concurrent_sessions:
+- stale_after_hours: 12
+
+This is a gate on sessions, never on the person. It counts; it does not
+assess.

--- a/tdad_tests/layer0_deterministic/fixtures/cadence-pacts/partial-wip.md
+++ b/tdad_tests/layer0_deterministic/fixtures/cadence-pacts/partial-wip.md
@@ -1,0 +1,15 @@
+# Pacts
+
+Fixture: a deliberately partial pact. The human declared `Session WIP` to tune
+the registry lease and nothing else — which `/mast tune` explicitly supports,
+because it asks the stop hour first and then offers rather than marches.
+
+Nothing here is broken. `block_state` must call it `declared`, and a consumer
+that needs `max_concurrent_sessions` must ask for it rather than assume.
+
+## Session WIP
+
+- stale_after_hours: 6
+
+This is a gate on sessions, never on the person. It counts; it does not
+assess.

--- a/tdad_tests/layer0_deterministic/test-pact-blocks.sh
+++ b/tdad_tests/layer0_deterministic/test-pact-blocks.sh
@@ -183,4 +183,42 @@ val=$(block_key 'Session WIP' 'hard_stop_hour' 'NOT-MINE')
 [ "$val" = "NOT-MINE" ] \
   || fail "B11: Session WIP must not absorb Budgets' keys, got '$val'"
 
+# --- B12: block_state answers well-formedness, not completeness -------------
+# S1 defined malformed as "mandatory clause OR required key missing" and only
+# the clause half was ever implemented. The gate that found it (#503) decided
+# the DEFINITION was the defect, not the code.
+#
+# /mast tune deliberately offers a two-line pact — "a number invented to move
+# the dialogue along is not more authored than one they declined to give" — so
+# a human who declares Session WIP with only stale_after_hours authored exactly
+# what they meant. Calling that malformed says it is broken. It is not; it is
+# partial, on purpose.
+export CLAUDE_PACTS_FILE="$FIX/partial-wip.md"
+[ "$(block_state 'Session WIP')" = "declared" ] \
+  || fail "B12: a deliberately partial block is well-formed, not malformed"
+
+# --- B13: block_has_key answers the completeness question separately ---------
+# This is what a consumer asks instead of trusting `declared` to mean "the
+# values I need are here". It is what lets the WIP Warden say "you have not
+# declared a limit" rather than inventing one.
+declare -F block_has_key >/dev/null || fail "B13: lib must define block_has_key"
+
+block_has_key 'Session WIP' 'stale_after_hours' \
+  || fail "B13: a declared key must report present"
+if block_has_key 'Session WIP' 'max_concurrent_sessions'; then
+  fail "B13: an undeclared key must report absent"
+fi
+
+# Absent block, absent key — never an error, and never a claim of presence.
+export CLAUDE_PACTS_FILE="$SCRIPT_DIR/fixtures/cadence-pacts/does-not-exist.md"
+set +e; block_has_key 'Session WIP' 'anything'; rc=$?; set -e
+[ "$rc" -eq 1 ] || fail "B13: an absent block must report the key absent, exit 1 (got $rc)"
+
+# A key whose value is empty is not declared. `- max_concurrent_sessions:` with
+# nothing after it is a human who started typing and stopped, not a limit.
+export CLAUDE_PACTS_FILE="$FIX/empty-value.md"
+if block_has_key 'Session WIP' 'max_concurrent_sessions'; then
+  fail "B13: a key with an empty value must not report as declared"
+fi
+
 echo "PASS: pact-block reader — template well-formed, three states honoured, values survive extraction, keys scoped to their block"


### PR DESCRIPTION
Closes #503.

S1 defined `malformed` as *"mandatory clause **or required key** missing"* and only the clause half was ever implemented. S4 exposed the gap. **The definition was the defect, not the code.**

## Why

`/mast tune` deliberately offers a two-line pact — *"a number invented to move the dialogue along is not more authored than one they declined to give."* So a `Session WIP` block carrying only `stale_after_hours` is exactly what somebody meant to write.

Calling that `malformed` says it's **broken**. It isn't. It's partial, on purpose. And "Required: yes" was never true either — you may declare that block solely to tune the registry lease.

So the states stay about **well-formedness** (does the block carry its governing clause), and a new `block_has_key` answers **completeness**, per key, for whichever consumer needs one.

That separation is what lets the WIP Warden say *"you have not declared a limit"* instead of inventing one — which is the failure that actually matters, since an imposed limit is precisely the pact the clear-weather rule says does not hold.

## What changed

- **`block_has_key`** in `lib/pact-blocks.sh`. An empty value is not a declaration.
- **The WIP Warden asks** rather than inferring a missing limit from an empty string.
- **S1's spec amended** — the "Required" column becomes "Consumer", with the amendment dated and attributed to this issue.
- **`reference/pacts-format.md`** now tells adopters plainly: *a short pact is a complete one*, and a sentinel that needs a value you didn't declare will name it rather than supply one.
- **B12/B13** and two fixtures.

## A mutation test earned its keep twice

It killed a `block_state` that called a partial block `malformed` — the regression this fix exists to prevent.

And it **survived** removal of an `[ -n "$val" ]` guard in `block_has_key`, which turned out to be dead code: `block_key` already collapses an empty value to the caller's default, so one comparison covers both "no such key" and "key with no value". The line is deleted and the reason recorded, because that property lives in `block_key` and isn't visible from the call site.

Version: 0.70.0 → 0.70.1 (fix plus an additive helper; no behaviour removed).