### PR TITLE
Cadence Sentinels S3b — boundary notices, the advisory rail, and the hard stop

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.70.1",
+  "plugin_version": "0.71.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.70.1"
+      "version": "0.71.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## 0.71.0 — 2026-08-12
+
+### Cadence Sentinels S3b — boundary notices and the hard stop
+
+The seam three slices deferred into: S3's notices and override, S4's override,
+and a contract change to the Coda that shipped before either existed.
+
+- **Two notices against `hard_stop_hour`** — approaching (default 30 minutes,
+  tunable via `approaching_lead_minutes`) and reached — each once per session.
+  At the line, exactly one recommendation: `/coda`.
+- **A lead time, not a fraction.** The first design measured 80% of the way
+  from session start, which is not computable: `started_at` is UTC,
+  `hard_stop_hour` is local, and `started_at` is deliberately never reset across
+  resume — so the notice would have fired every morning with nothing approached.
+- **The advisory rail** arbitrates by **precedence**, not registration order. A
+  once-only advisory speaks; a repeating one defers to the turn it is going to
+  get anyway. `reservoir-check.sh` has no once-per-session guard and cannot
+  have one, so ordering it first would have preserved the message that repeats
+  and permanently spent the one designed to arrive once.
+- **The store records only what fired.** An earlier design carried
+  `continued past the 20:00 stop by choice`, timestamped identically to the
+  notice — written before the human had done anything. Nothing observes a
+  choice; continuing is the absence of stopping. What the human decided is
+  asked for at close, in their own words, or not recorded at all.
+- **Keyed by repo, not session**, because its writers include `/coda` and
+  `/wip` — commands, which have no channel to learn a session id.
+- **Consumption marks rather than deletes**, so the once-per-session notice
+  state survives a close that does not end the session.
+- **The prune runs unconditionally**, before the opt-in check: gating the
+  janitor behind the feature meant deleting your pact stranded every file
+  forever.
+- **Read/write library split**, so a sentinel can reach the notes without
+  reaching a mutator.
+- **One coordination line in `reservoir-check.sh`** — a coordination change,
+  not a behavioural one, recorded as a judgement in the spec.
+
+Closes #501.
+
 ## 0.70.1 — 2026-08-11
 
 ### Fix: `block_state` answers well-formedness, not completeness

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.70.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.71.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-40-2E8B57?style=flat-square)](#skills-40)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.70.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **40 skills, 19 agents, 31 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.71.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **40 skills, 19 agents, 31 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.70.1",
+  "version": "0.71.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/coda.agent.md
+++ b/ai-literacy-superpowers/agents/coda.agent.md
@@ -49,6 +49,18 @@ Every claim carries its flag:
 | Commits, working-tree state, dispositions in records | `observed` |
 | Merged PRs, open-PR check state | `observed` when `gh` succeeded; `inferred` when it did not |
 | Which files constitute one thread | `asked` |
+| Boundary events this session | `observed` |
+
+**Boundary events are `observed` because you are reading a log**, not
+inferring. `lib/mast-notes-read.sh` records what fired — a stop hour passed, a
+WIP limit was breached — and nothing else. It holds no account of what the
+human did about it, because nothing observed that: continuing is the absence of
+stopping, and reading intent into silence is not yours to do.
+
+So report the fact and **ask** whether they want to record anything about it.
+Whatever they say is the whole of the account. A blank answer records nothing,
+and that is a complete answer — the boundary was never a gate, so there is
+nothing that must be accounted for.
 
 If `gh` fails, say so. Reporting "no merged PRs" because the call errored,
 flagged `observed`, is the laundering of inference as observation that the

--- a/ai-literacy-superpowers/commands/coda.md
+++ b/ai-literacy-superpowers/commands/coda.md
@@ -83,6 +83,22 @@ per `reference/parking-record-format.md`. `next_action_flag` is always `asked`.
 then relocates the tree to `main`; without this commit the ritual would publish
 a summary describing records left behind uncommitted.
 
+### 5b. Ask about boundary events
+
+Source `hooks/scripts/lib/mast-notes-read.sh` and read this repo's notes.
+
+For each event — a stop hour passed, a WIP limit breached — say the fact and
+ask whether they want to record anything about it.
+
+**Offer nothing as a default.** The store holds only what fired; there is no
+machine sentence to accept, and there should not be. What reaches the
+reflection fragment is a line the person wrote and would recognise as theirs —
+`REFLECTION_LOG.md` is committed and permanently archived, so a hook-authored
+observation about someone's conduct would become a durable record of how often
+they work late.
+
+A blank answer records nothing, and is complete.
+
 ### 6. Ask about records already open
 
 For each record `records_open` returns from a previous session, ask whether it
@@ -91,10 +107,17 @@ now — see `/coda resume` below.
 
 ### 7. Closure summary and reflection
 
+Mark the boundary notes consumed **here**, with the reflection — so a human who
+stops the ritual before this step has consumed nothing. Source
+`hooks/scripts/lib/mast-notes-write.sh` (a command may; the agent may not) and
+call `notes_mark_consumed`. It marks rather than deletes: the once-per-session
+notice state lives in that file, and the session is still alive.
+
 Invoke `/reflect`, supplying the optional `Closed` field:
 
 ```text
-- **Closed**: [what landed this session; the filename of each record parked]
+- **Closed**: [what landed this session; the filename of each record parked;
+  any boundary events and what the human chose to say about them]
 ```
 
 Filenames rather than a count: a count asserts that three threads were parked
@@ -112,7 +135,8 @@ be withdrawn, and implying otherwise would be a lie about the artefacts.
 
 - Stopped during or before the survey: nothing was written.
 - Stopped after records exist: name each one and offer to supersede it.
-- Stopped after `/reflect`: the fragment is committed and merged. Say so.
+- Stopped after `/reflect`: the fragment is committed and merged. Say so, and
+  say that the boundary notes were marked consumed.
 
 A request for *new work* after the ritual starts is different — park it, do not
 execute it. That drift is what the ritual is for. A request to *abandon the

--- a/ai-literacy-superpowers/hooks/hooks.json
+++ b/ai-literacy-superpowers/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Harness engineering hooks: constraint gate (PreToolUse) warns on violations; affordance invocation recorder (PostToolUse) logs Bash/MCP tool calls to gitignored observability; drift check, snapshot staleness, reflection prompt, framework-change prompt, rotating GC check, curation nudge, governance drift check, reservoir check, and session-registry sweep (Stop) close all feedback loops and renew the session lease at the end of every turn; template currency check and session-registry start (SessionStart) nudge on plugin upgrade and record this session's local, never-committed registry entry and surface any parking records left open by an earlier session, and report live-session count against a declared Session WIP limit.",
+  "description": "Harness engineering hooks: constraint gate (PreToolUse) warns on violations; affordance invocation recorder (PostToolUse) logs Bash/MCP tool calls to gitignored observability; drift check, snapshot staleness, reflection prompt, framework-change prompt, rotating GC check, curation nudge, governance drift check, reservoir check, session-registry sweep, and the Mast's boundary notices (Stop) close all feedback loops and renew the session lease at the end of every turn; template currency check and session-registry start (SessionStart) nudge on plugin upgrade and record this session's local, never-committed registry entry and surface any parking records left open by an earlier session, and report live-session count against a declared Session WIP limit.",
   "hooks": {
     "PreToolUse": [
       {
@@ -72,6 +72,11 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/governance-drift-check.sh",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/mast-boundary-check.sh",
             "timeout": 10
           },
           {

--- a/ai-literacy-superpowers/hooks/scripts/lib/advisory-rail.sh
+++ b/ai-literacy-superpowers/hooks/scripts/lib/advisory-rail.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+# Strict mode when executed, never leaked into a sourcing shell.
+(return 0 2>/dev/null) || set -euo pipefail
+# advisory-rail.sh — one stop-advisory per turn, arbitrated by precedence.
+#
+# Spec: docs/superpowers/specs/2026-08-12-cadence-sentinels-s3b-boundary-notices-design.md §3
+# Tests: tdad_tests/layer0_deterministic/test-advisory-rail.sh (AR1–AR6)
+#
+# WHY PRECEDENCE AND NOT ORDER. Two sentinels counsel stopping on the Stop rail
+# and they operate on different periods. `reservoir-check.sh` has no
+# once-per-session guard and cannot have one — it persists nothing by charter,
+# recomputes an eight-hour window every turn, and re-emits whenever a threshold
+# is still crossed. The Mast's `reached` fires once, ever.
+#
+# The first design was first-claim-wins with the warden ordered first. That
+# preserved the message that repeats and permanently spent the one designed to
+# arrive once: the note was still logged on the suppressed turn, so the human
+# would never have received the boundary message at all. A rail built to reduce
+# accumulated pressure was protecting the source of it.
+#
+# So: a **once-only** advisory speaks and a **repeating** one defers. The warden
+# loses nothing — it fires again next turn, on the same conditions. The Mast's
+# notice has no next turn.
+#
+# WHAT A TURN IS. A Stop hook receives no turn identifier and every hook in one
+# firing sees the same session id, so a turn is scoped by the only thing
+# available: hooks in one firing run back-to-back, so a claim holds for a short
+# wall-clock window. Two disclosed failure modes, both bounded:
+#
+#   - two turns completing inside the window collapse into one, costing one
+#     skipped repeating advisory;
+#   - a rail slow enough to straddle it lets both emit, costing one duplicate.
+#
+# ATOMICITY. Claiming is `mkdir`, which is atomic on every POSIX filesystem. A
+# check-then-act would race, and a rail whose guarantee flickers teaches the
+# human to discount the sentinel — the failure it exists to prevent, arriving
+# by another door.
+#
+# Every function exits without error when it cannot write. An advisory rail
+# that broke a hook would be worse than one that let two messages through.
+
+_AR_WINDOW_SECONDS=10
+
+advisory_dir() {
+  printf '%s' "${CLAUDE_ADVISORY_DIR:-$HOME/.claude/advisory}"
+}
+
+# _ar_bucket — the current turn window, as an integer.
+#
+# The claim's NAME carries its window, which is what makes this race-free with
+# no cleanup step. An earlier version cleared a stale claim before claiming,
+# and AR5 caught the race on the first run: several concurrent callers each
+# found no claim, then each deleted the claim a previous one had just won —
+# three winners instead of one. Bucketing removes the cleanup entirely. Every
+# caller inside one window computes the same name, so `mkdir` arbitrates, and
+# an earlier window's claim is simply a name nobody looks at.
+_ar_bucket() { printf '%s' "$(( $(date -u +%s) / _AR_WINDOW_SECONDS ))"; }
+
+# _ar_claim_path <kind>
+_ar_claim_path() { printf '%s/%s.%s.claim' "$(advisory_dir)" "$1" "$(_ar_bucket)"; }
+
+# _ar_sweep <kind> — drop this kind's claims from earlier windows. Bounded by
+# construction: at most one directory per kind survives a sweep.
+_ar_sweep() {
+  local dir current
+  dir="$(advisory_dir)"
+  current="$(_ar_claim_path "$1")"
+  find "$dir" -maxdepth 1 -type d -name "$1.*.claim" ! -path "$current" \
+    -exec rm -rf {} + 2>/dev/null || true
+}
+
+# advisory_claim <class> <kind> — claim the turn for this kind.
+#
+# Exit 0 when the caller may speak. Only the `once-only` class claims; a
+# repeating caller uses advisory_defer_if_claimed instead.
+advisory_claim() {
+  local class="$1" kind="$2" dir
+  dir="$(advisory_dir)"
+  mkdir -p "$dir" 2>/dev/null || return 0   # cannot arbitrate: let it speak
+
+  if [ "$class" = "once-only" ]; then
+    # mkdir is the atomic operation: exactly one concurrent caller wins.
+    mkdir "$(_ar_claim_path "$kind")" 2>/dev/null || return 1
+    _ar_sweep "$kind"
+    return 0
+  fi
+
+  advisory_defer_if_claimed "$kind" && return 1
+  return 0
+}
+
+# advisory_defer_if_claimed <kind> — true when a once-only advisory has claimed
+# the current window, meaning a repeating caller stays silent.
+#
+# A turn straddling a window boundary lets both speak. That is one of the two
+# disclosed failure modes, and it costs one duplicate message.
+advisory_defer_if_claimed() {
+  [ -d "$(_ar_claim_path "$1")" ]
+}
+
+# advisory_reset — drop every claim. For tests, and for a caller that knows a
+# turn has ended.
+advisory_reset() {
+  local dir
+  dir="$(advisory_dir)"
+  [ -d "$dir" ] || return 0
+  rm -rf "${dir:?}"/*.claim 2>/dev/null || true
+  return 0
+}

--- a/ai-literacy-superpowers/hooks/scripts/lib/mast-notes-read.sh
+++ b/ai-literacy-superpowers/hooks/scripts/lib/mast-notes-read.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# Strict mode when executed, never leaked into a sourcing shell.
+(return 0 2>/dev/null) || set -euo pipefail
+# mast-notes-read.sh — the read surface of the boundary note store.
+#
+# Spec: docs/superpowers/specs/2026-08-12-cadence-sentinels-s3b-boundary-notices-design.md §4
+# Tests: tdad_tests/layer0_deterministic/test-mast-notes.sh (MN1, MN4, MN5)
+#
+# SOURCEABLE BY A SENTINEL. That is why it is separate from
+# mast-notes-write.sh, and it defines no function that writes, deletes, or
+# moves. The frontmatter check reads only an agent's declared `tools:` list and
+# cannot see a `source` line, so this boundary holds by what an agent can
+# reach.
+#
+# KEYED BY REPO, NOT SESSION. The store's writers include `/coda` and `/wip` —
+# commands, which have no channel to learn a session id. Every hook takes it
+# from stdin JSON; no command in this plugin can. Keying by session would have
+# left the commands guessing, and the obvious guess (newest file) fails in
+# exactly the multi-session world this epic exists for.
+#
+# WHAT IT HOLDS. Only what fired. There is no line recording that someone
+# continued past a boundary, because nothing observes a choice — continuing is
+# the absence of stopping, and reading intent into silence is what the boundary
+# between counting and watching forbids.
+
+notes_dir() { printf '%s' "${CLAUDE_MAST_DIR:-$HOME/.claude/mast}"; }
+
+# notes_slug <repo-path> — a filesystem-safe key for a repo.
+notes_slug() {
+  printf '%s' "${1:-$PWD}" | sed -e 's#[^A-Za-z0-9._-]#-#g' -e 's#^-*##' -e 's#-*$##' \
+    | cut -c1-120
+}
+
+notes_path() { printf '%s/%s.notes' "$(notes_dir)" "$(notes_slug "${1:-$PWD}")"; }
+
+# notes_read [repo] — every line for this repo, oldest first. Empty when none.
+notes_read() {
+  local f
+  f="$(notes_path "${1:-$PWD}")"
+  [ -f "$f" ] || return 0
+  cat "$f" 2>/dev/null || true
+}
+
+# notes_has <event> [repo] — true when an event of that kind was recorded.
+# This is the once-per-session notice state: `reached` is recorded when it
+# fires, and asking whether it was is how the hook stays silent afterwards.
+notes_has() {
+  local f
+  f="$(notes_path "${2:-$PWD}")"
+  [ -f "$f" ] || return 1
+  grep -q " $1" "$f" 2>/dev/null
+}

--- a/ai-literacy-superpowers/hooks/scripts/lib/mast-notes-write.sh
+++ b/ai-literacy-superpowers/hooks/scripts/lib/mast-notes-write.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+(return 0 2>/dev/null) || set -euo pipefail
+# mast-notes-write.sh — the mutation surface of the boundary note store.
+#
+# Spec: §4 · Tests: test-mast-notes.sh (MN2, MN3)
+#
+# HOOKS AND COMMANDS ONLY. A `role: sentinel` agent must never source this.
+# S1 made the same split for the registry and `sentinel-design` promoted the
+# rule out of it: a read surface a sentinel may source, a write surface it may
+# not.
+
+_MNW_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$_MNW_DIR/mast-notes-read.sh"
+# shellcheck source=/dev/null
+. "$_MNW_DIR/session-registry-read.sh"   # _lease_hours, _iso_to_epoch
+
+# notes_append <event-text> [repo] — record that something fired.
+#
+# Only facts. "reached hard_stop_hour=20:00" is a fact; "continued past the
+# stop by choice" is an attribution of intent by a hook, about a person, and
+# does not belong here.
+notes_append() {
+  local text="$1" repo="${2:-$PWD}" f
+  f="$(notes_path "$repo")"
+  mkdir -p "$(dirname "$f")" 2>/dev/null || return 0
+  printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$text" >> "$f" 2>/dev/null || true
+}
+
+# notes_touch [repo] — refresh the file's mtime while its repo has a live
+# session.
+#
+# This is what lets ONE lease do two jobs. The file both bounds the store and
+# holds the once-per-session notice state, and those pull opposite ways: a file
+# appended to only on a boundary event stops being renewed the moment the
+# notices are done, so under a 12-hour lease a session reaching its stop at
+# 20:00 and still alive at 08:00 would have its own hook prune its notice state
+# — and `reached` would fire again. A heartbeat is the shape S1 already proved.
+notes_touch() {
+  local f
+  f="$(notes_path "${1:-$PWD}")"
+  [ -f "$f" ] || return 0
+  touch "$f" 2>/dev/null || true
+}
+
+# notes_mark_consumed [repo] — the Coda has collected these events.
+#
+# MARKS, NEVER REMOVES. The notice state lives in this file and `/coda`'s final
+# step is a statement rather than a process ending — the session stays alive and
+# the Stop rail keeps firing. Deleting at close would take the notice state with
+# it and `reached` would fire again on the next turn, on exactly the sessions
+# where the human had already been told once. Marking also makes a second
+# `/coda` idempotent.
+notes_mark_consumed() {
+  notes_append "consumed-by-coda" "${1:-$PWD}"
+}
+
+# notes_prune — retire note files whose repo has had no live session for a
+# lease.
+#
+# UNCONDITIONAL, and called before any opt-in check. Gating the janitor behind
+# the feature meant that a human who used it for a month and then deleted their
+# Budgets block left every note file behind forever — and the one path where
+# someone has withdrawn consent is the one path where leftover state matters
+# most.
+notes_prune() {
+  local dir lease
+  dir="$(notes_dir)"
+  [ -d "$dir" ] || return 0
+  lease="$(_lease_hours)"
+  find "$dir" -maxdepth 1 -name '*.notes' -mmin +$(( lease * 60 )) \
+    -exec rm -f {} + 2>/dev/null || true
+  return 0
+}

--- a/ai-literacy-superpowers/hooks/scripts/mast-boundary-check.sh
+++ b/ai-literacy-superpowers/hooks/scripts/mast-boundary-check.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# mast-boundary-check.sh — Stop hook: the approaching and reached notices.
+#
+# Spec: docs/superpowers/specs/2026-08-12-cadence-sentinels-s3b-boundary-notices-design.md
+# Tests: tdad_tests/layer0_deterministic/test-mast-boundary.sh (MB1–MB9)
+#
+# ONE RECOMMENDATION, ONCE. A boundary-moment prompt improves adherence where
+# an ambient reminder does not — the mechanism is a prompt at the decision
+# point, not accumulated pressure. Repeating it would not make it work better;
+# it would make it work worse.
+#
+# It never blocks and never asks for a disposition. At the line it recommends
+# exactly one thing: /coda.
+#
+# A LEAD TIME, NOT A FRACTION. The first design said "80% of the way from
+# session start to hard_stop_hour", which is not computable: started_at is UTC
+# and hard_stop_hour is local, and started_at is deliberately never reset
+# across resume — so a session resumed the next morning is already past 80% at
+# breakfast and the notice fires on every resume with nothing approached.
+# A lead time needs one endpoint, in the same frame as the value it measures.
+#
+# THE PRUNE RUNS FIRST, unconditionally. Gating the janitor behind the opt-in
+# meant that deleting your Budgets block left every note file behind forever,
+# and the path where someone has withdrawn consent is the path where leftover
+# state matters most.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/mast-notes-write.sh" 2>/dev/null || exit 0
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/advisory-rail.sh" 2>/dev/null || exit 0
+
+input="$(cat 2>/dev/null || true)"
+repo="$(printf '%s' "$input" \
+  | grep -oE '"cwd"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 \
+  | sed -E 's/.*"cwd"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/' || true)"
+[ -n "$repo" ] || repo="$PWD"
+
+# Unconditional janitor, before any opt-in check.
+notes_prune
+
+# Self-gate: nothing is created for a human who declared no Budgets block.
+[ "$(block_state 'Budgets' 2>/dev/null || printf 'absent')" = "declared" ] || exit 0
+
+stop_hour="$(block_key 'Budgets' 'hard_stop_hour' '')"
+case "$stop_hour" in
+  [0-9][0-9]:[0-9][0-9]) : ;;
+  *) exit 0 ;;
+esac
+
+lead="$(block_key 'Session WIP' 'approaching_lead_minutes' '30')"
+case "$lead" in ''|*[!0-9]*) lead=30 ;; esac
+
+# Minutes from now until the line, in local time — the same frame the human
+# declared it in.
+now_min=$(( 10#$(date +%H) * 60 + 10#$(date +%M) ))
+stop_min=$(( 10#${stop_hour%%:*} * 60 + 10#${stop_hour##*:} ))
+remaining=$(( stop_min - now_min ))
+
+# A session that begins after the line gets the reached notice, not a negative
+# fraction. There is no day-rollover puzzle because there is no interval.
+emit() {
+  local encoded
+  encoded=$(printf '%s' "$1" \
+    | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' \
+    | awk 'BEGIN{ORS=""} {if (NR>1) printf "\\n"; printf "%s", $0}')
+  printf '{"systemMessage": "%s"}\n' "$encoded"
+}
+
+# The notes file is touched while its repo has a live session, so one lease can
+# both bound the store and preserve the notice state.
+notes_touch "$repo"
+
+# shellcheck disable=SC2016  # the backticks are markdown for the reader
+if [ "$remaining" -le 0 ]; then
+  notes_has "reached" "$repo" && exit 0
+  notes_append "reached hard_stop_hour=$stop_hour" "$repo"
+  # once-only: it speaks, and a repeating advisory defers to the next turn it
+  # is going to get anyway.
+  advisory_claim once-only stop || exit 0
+  emit "$(printf 'Your %s stop has passed.\n\nRun `/coda` to close out — it will survey what landed, park what is open with a concrete next step, and end the session.\n\nNothing here stops you. If you keep going, you keep going.' "$stop_hour")"
+  exit 0
+fi
+
+if [ "$remaining" -le "$lead" ]; then
+  notes_has "approaching" "$repo" && exit 0
+  notes_append "approaching hard_stop_hour=$stop_hour lead=${lead}m" "$repo"
+  advisory_claim once-only stop || exit 0
+  emit "$(printf '%s minutes to your %s stop.' "$remaining" "$stop_hour")"
+fi
+exit 0

--- a/ai-literacy-superpowers/hooks/scripts/reservoir-check.sh
+++ b/ai-literacy-superpowers/hooks/scripts/reservoir-check.sh
@@ -134,6 +134,23 @@ Decide your stop BEFORE the next session begins, while the judgment making the c
 
 The choice to continue is yours. Run /reservoir for a fuller read or to tune the thresholds."
 
+# One stop-advisory per turn. This is a COORDINATION change, not a behavioural
+# one: the proxies, thresholds, honesty flags, recommendation text, and the
+# advisory-forever standing above are all unchanged, and this still fires
+# whenever it would have fired — except on the at most one turn per session
+# when a once-only advisory has already claimed.
+#
+# It defers rather than wins because it will get another turn: this hook
+# persists nothing and re-emits while a threshold stays crossed, whereas the
+# Mast's boundary notice fires once, ever. Arbitrating the other way would have
+# permanently spent the message designed to arrive once.
+_RC_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/advisory-rail.sh"
+if [ -f "$_RC_LIB" ]; then
+  # shellcheck source=/dev/null
+  . "$_RC_LIB"
+  advisory_defer_if_claimed stop && exit 0
+fi
+
 # JSON-encode: escape backslash and quote, then join lines with \n (valid JSON).
 encoded=$(printf '%s' "$message" \
   | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' \

--- a/ai-literacy-superpowers/skills/coda/SKILL.md
+++ b/ai-literacy-superpowers/skills/coda/SKILL.md
@@ -65,6 +65,7 @@ tree it had just relocated.
 | Commits, working-tree state, dispositions in records | `observed` |
 | Merged PRs, open-PR check state | `observed` when `gh` succeeds; `inferred` when it does not |
 | Which files constitute one thread | `asked` |
+| Boundary events this session | `observed` |
 
 **Thread grouping is the central epistemic act.** Nine modified files are an
 observation; that they are *two* threads is a judgement, and it decides how

--- a/ai-literacy-superpowers/templates/pacts.md
+++ b/ai-literacy-superpowers/templates/pacts.md
@@ -28,6 +28,7 @@ an inline comment silently becomes part of the value.
 - max_concurrent_sessions: 2
 - max_switches_per_hour: 4
 - stale_after_hours: 12
+- approaching_lead_minutes: 30
 - enforcement: advisory
 
 This is a gate on sessions, never on the person. It counts; it does not
@@ -35,13 +36,15 @@ assess.
 
 Field notes. `max_concurrent_sessions` is how many sessions you are willing to
 have live at once, counted across every repository on this machine.
-`max_switches_per_hour` is optional. `stale_after_hours` is how long a session
+`max_switches_per_hour` is optional. `approaching_lead_minutes` is how long before your
+stop hour you want a heads-up. `stale_after_hours` is how long a session
 may go without finishing a turn before it is treated as gone — raise it if you
 routinely leave a session parked mid-thought. `enforcement: advisory` reports
 a breach and proceeds; `strict` also asks you to park something or say what is
 urgent. **Neither can stop you** — nothing in this plugin can hold a session,
-and the WIP Warden says so rather than implying otherwise. What you say in
-answer is not written down anywhere yet.
+and the WIP Warden says so rather than implying otherwise. If you want what you
+say in answer on the record, `/coda` asks at close and writes **your** words;
+nothing is written unless you ask for it.
 
 ## Budgets
 

--- a/docs/plugins/ai-literacy-superpowers/reference/hooks.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/hooks.md
@@ -160,6 +160,49 @@ staleness. Also flags when governance constraints exist in
 HARNESS.md but no audit has ever been run. Nudges
 `/governance-audit` or `/governance-health`.
 
+### Mast boundary check (command)
+
+- **Event**: Stop
+- **Matcher**: `*`
+- **Script**: `hooks/scripts/mast-boundary-check.sh`
+- **Timeout**: 10s
+
+Two notices against your declared `hard_stop_hour`: **approaching**, by default
+30 minutes before (tune with `approaching_lead_minutes`), and **reached**, at
+the line. Each fires **once per session**. At the line it recommends exactly
+one thing — `/coda` — and says plainly that it does not stop you.
+
+**What the store holds, and for how long.** One small file per repository under
+`~/.claude/mast/`, recording only what *fired*: `reached hard_stop_hour=20:00`.
+It holds **no record of what you decided** — nothing observes a choice, and
+continuing is simply the absence of stopping. If you want your decision on the
+record, `/coda` asks at close and writes your words.
+
+The file is refreshed while the repo has a live session and pruned after
+`stale_after_hours` without one. **The prune runs unconditionally**, before the
+opt-in check — so removing your `Budgets` block cleans up rather than stranding
+files forever.
+
+**To switch it off**, remove the `mast-boundary-check.sh` entry from
+`hooks/hooks.json`. `$CLAUDE_MAST_DIR` relocates the store and is test-only.
+
+### The advisory rail
+
+`lib/advisory-rail.sh` lets at most one stop-advisory speak per turn, because
+two messages about stopping arriving together is accumulated pressure — which
+the evidence says works *worse* than a single boundary prompt.
+
+It arbitrates by **precedence, not registration order**. A **once-only**
+advisory (the Mast's notices) speaks; a **repeating** one (the reservoir
+check, which re-emits every turn while a threshold stays crossed) defers to the
+next turn it is going to get anyway. Ordering it the other way would have
+permanently spent the message designed to arrive once.
+
+A "turn" has no identifier a hook can read, so a claim holds for a 10-second
+window. Two consequences, both bounded and neither hidden: two turns finishing
+inside 10 seconds collapse into one, costing a skipped repeating advisory; and
+a rail slow enough to straddle it lets both speak, costing one duplicate.
+
 ### Reservoir check (command)
 
 - **Event**: Stop
@@ -181,6 +224,12 @@ precaution under uncertainty; it does not assert ego depletion or the
 hungry-judges figure. See the `cognitive-reservoir` skill and the
 [Watching the Verifier](../explanation/watching-the-verifier.md)
 concept page.
+
+It now carries one coordination line: it defers when a once-only advisory has
+claimed the turn. This is a coordination change and not a behavioural one — its
+proxies, thresholds, flags, recommendation text and advisory-forever standing
+are unchanged, and it still fires whenever it would have fired, except on the
+at most one turn per session when the Mast's boundary notice has spoken.
 
 ### Session registry sweep (command)
 

--- a/docs/plugins/ai-literacy-superpowers/reference/pacts-format.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/pacts-format.md
@@ -64,10 +64,15 @@ Values may contain colons and spaces. `hard_stop_hour: 18:30` reads as
 
 | Key | Grammar | Required | Meaning |
 | --- | --- | --- | --- |
-| `max_concurrent_sessions` | integer | yes | How many live sessions you will accept, counted across every repository on this machine |
-| `max_switches_per_hour` | integer | no | |
+| `max_concurrent_sessions` | integer | no | How many live sessions you will accept, counted across every repository on this machine |
+| `max_switches_per_hour` | integer | no | Declared only — nothing observes a switch |
 | `stale_after_hours` | integer | no (default 12) | How long a session may go without finishing a turn before it is treated as gone |
+| `approaching_lead_minutes` | integer | no (default 30) | How long before `hard_stop_hour` you want a heads-up |
 | `enforcement` | `advisory` \| `strict` | no (default `advisory`) | See below |
+
+**No key is required.** A short pact is a complete one — declare only
+`stale_after_hours` if that is all you want. A sentinel that needs a value you
+did not declare will name it rather than supply one.
 
 **Mandatory clause:** *This is a gate on sessions, never on the person. It
 counts; it does not assess.*
@@ -82,10 +87,13 @@ that is already starting. `strict` is a stronger ask, not a gate, and the WIP
 Warden says so plainly rather than implying a power it does not have.
 
 An earlier version of this page described `strict` as requiring a disposition
-*before the session proceeds*, and an override recorded on the record. Neither
-was deliverable: nothing can hold a session, and the mechanism that would carry
-the override to a record is a later slice. What you say in answer is not
-written down yet, and the Warden tells you so.
+*before the session proceeds*. That was never deliverable — nothing can hold a
+session.
+
+**If you want your answer on the record, it is yours to put there.** `/coda`
+asks at close what you want to say about any boundary you passed, and writes
+your words. The plugin records that a boundary *fired*; it records nothing
+about what you decided unless you tell it to.
 
 `stale_after_hours` is the registry lease length. Raise it if you routinely
 leave a session parked mid-thought: liveness is measured as *recency of a

--- a/docs/superpowers/objections/cadence-sentinels-s3b-boundary-notices-design.md
+++ b/docs/superpowers/objections/cadence-sentinels-s3b-boundary-notices-design.md
@@ -1,0 +1,152 @@
+---
+spec: docs/superpowers/specs/2026-08-12-cadence-sentinels-s3b-boundary-notices-design.md
+date: 2026-08-12
+mode: spec
+diaboli_model: claude-opus-5[1m]
+objections:
+  - id: O1
+    category: implementation
+    severity: critical
+    claim: "The rail arbitrates at the wrong scope: reservoir-check.sh has no once-per-session guard and cannot have one, so it re-emits on every Stop firing while the Mast's notice is once-only — the rail therefore silences the single-prompt message in favour of the repeating one."
+    evidence: "reservoir-check.sh persists nothing by charter and carries no once-per-session guard; verified zero occurrences of marker/once/already/fired. Spec 3.1: 'the first hook to claim stop in a given turn emits.' MB6 logs the note on the suppressed turn and MB7 stops reached firing again, so the message never arrives at all."
+    disposition: accepted
+    disposition_rationale: "Precedence replaces registration order. A once-only advisory outranks a repeating one, on the honest ground that the Warden loses nothing by deferring — it fires again next turn — while the Mast's notice has no next turn. The rail's purpose was to reduce accumulated pressure and it was protecting the source of it."
+  - id: O2
+    category: implementation
+    severity: high
+    claim: "Section 3.2's justification for the Warden winning — that 'decide your stop' subsumes 'you have reached the stop you decided' — is falsified by the Warden's shipped message text, which asks the human to decide a FUTURE stop before the NEXT session."
+    evidence: "reservoir-check.sh: 'Decide your stop BEFORE the next session begins... do not negotiate the boundary with your tired self.' That is advice about a future session addressed to someone who has not drawn a line; the human who declared hard_stop_hour has already done it."
+    disposition: accepted
+    disposition_rationale: "Dissolved by O1's inversion. The subsumption argument was the stated reason for the Warden winning, and it was backwards at the moment that matters: the suppressed message was the one naming a line the person drew themselves. Precedence now runs the other way and the argument is withdrawn rather than repaired."
+  - id: O3
+    category: specification quality
+    severity: critical
+    claim: "'One claim per turn' is undefined: a Stop hook receives no turn identifier, every hook in one firing shares the same session_id, and the spec names neither the discriminator that scopes a claim nor the atomicity it requires."
+    evidence: "No shipped hook reads or derives a turn id. AR1-AR4 all describe a single process making sequential calls and pass for a non-atomic implementation."
+    disposition: accepted
+    disposition_rationale: "A turn is defined operationally rather than metaphysically: hooks in one Stop firing run back-to-back, so a claim is scoped by a short wall-clock window (10s) recorded in the claim file, and the window and its two failure modes — two very fast turns collapsing, one very slow rail straddling — are disclosed in the skill and the reference page. Claiming is made atomic with mkdir, which is atomic on every POSIX filesystem. A rail whose guarantee is a race would flicker, and a sentinel that flickers teaches the human to discount it."
+  - id: O4
+    category: scope
+    severity: high
+    claim: "Section 6's file table omits hooks/hooks.json, in which the entire ordering guarantee lives, and skills/coda/SKILL.md, which carries the survey flag table section 5.1 changes."
+    evidence: "hooks.json registers ten Stop hooks with reservoir-check ninth; the new hook does not run until registered there. skills/coda/SKILL.md carries the three-row survey table and advertises a four-step ritual. Third file-table omission in this epic after S3 O1 and S4 O11."
+    disposition: accepted
+    disposition_rationale: "Both added, and the ordering guarantee is stated where it lives. The Mast's hook is registered BEFORE reservoir-check so precedence and order agree rather than depending on precedence alone. Three file-table omissions in four slices is itself the finding: section 6 now lists every file the change cannot land without, including the ones only a scenario would have caught."
+  - id: O5
+    category: specification quality
+    severity: high
+    claim: "'80% of the way from session start to hard_stop_hour' is not computable as stated: started_at is UTC and hard_stop_hour is local, started_at is deliberately never reset across resume/clear/compact, and nothing is defined for a session starting after the line or a stop hour past midnight."
+    evidence: "registry_touch writes started_at with date -u and its comment says it never resets. templates/pacts.md documents hard_stop_hour as local 24-hour. A session resumed the next morning reports yesterday's start, so the fraction is already past 80% at breakfast."
+    disposition: accepted
+    disposition_rationale: "The fraction is replaced by a lead time: approaching fires 30 minutes before hard_stop_hour, declarable as approaching_lead_minutes. A fraction needs two endpoints and only one of them is honest — the line the human drew. The other was a UTC timestamp deliberately frozen across resume, which would have fired the notice on resume every morning. A lead time needs one endpoint, is in the same frame as the value it measures against, and has no behaviour to define for midnight or for a session that starts late."
+  - id: O6
+    category: risk
+    severity: critical
+    claim: "The note store's own worked example carries a machine-authored claim about the person's conduct — 'continued past the 20:00 stop by choice' — timestamped identically to the notice that fired, with no stated author or trigger."
+    evidence: "Spec 4's example shows both lines at 2026-08-12T20:00:00Z, so whatever wrote the second wrote it before the human had done anything. Section 4.4's judges-nothing condition and section 5.1's observed flag are both false of it. sentinel-design: 'Who authored the claim? If the agent did, it is about the person.'"
+    disposition: accepted
+    disposition_rationale: "The store records only what fired. There is no continued-by-choice line, because nothing observes a choice — continuing is the absence of stopping, and reading intent into silence is exactly what the boundary forbids. The Coda asks whether the human wants to record anything about the boundary, and their answer is the only account that exists. This also dissolves O10 entirely: there is no machine sentence left to accept by default."
+  - id: O7
+    category: risk
+    severity: high
+    claim: "The prune sits behind the same self-gate as everything else, so a human who deletes or breaks their Budgets block after using the feature leaves note files nothing will ever remove — the bounded condition fails precisely on the opt-out path."
+    evidence: "Spec 4.3 exits 0 before touching the filesystem; section 6 gives mast-boundary-check.sh as the only home of the prune. Contrast session-registry-sweep.sh, whose registry_prune is unconditional for every user. sentinel-design: 'A record with no expiry is an archive.'"
+    disposition: accepted
+    disposition_rationale: "The prune runs unconditionally, before the self-gate, exactly as the registry's does. The janitor is separable from the opt-in and must be: the one path where a human has withdrawn consent is the one path where leftover state matters most, and gating the cleanup behind the feature meant deleting your pact left your history behind forever."
+  - id: O8
+    category: implementation
+    severity: high
+    claim: "The same unspecified lease must be aggressive enough to bound the store and conservative enough to hold the once-only notice state for a whole session; on the default 12-hour lease a long session loses its notice state and re-fires reached."
+    evidence: "A notes file has no heartbeat and is appended to only on a boundary event, so whatever the lease measures from stops being renewed once the notices are done. S3's O3 named this door: 'if it is mtime under stale_after_hours, a long quiet session loses its notice state the same way.'"
+    disposition: accepted
+    disposition_rationale: "The notes file is touched on every Stop while its session is live, exactly as the registry entry is — the same heartbeat shape, for the same reason. A live session's notes never age out; a dead session's do. That makes one lease serve both jobs without compromise, and it is the mechanism S1 already proved rather than a second invention."
+  - id: O9
+    category: implementation
+    severity: high
+    claim: "The store is keyed by session id, but the two consumers are commands, and no channel exists by which a command learns the current session id."
+    evidence: "Every shipped reader extracts session_id from hook stdin JSON; verified no command in the plugin reads it and no session environment variable exists anywhere in the repo. The newest-file workaround fails in exactly the multi-session world this epic exists for."
+    disposition: accepted
+    disposition_rationale: "Keyed by repo rather than session. A command knows its working directory, so everything that touches the store can name it. Boundary events concern a pact that is machine-global and a person who is singular, and the Coda closes a session in a repo — which is the scope it can actually address. Per-session isolation is not lost so much as never achievable: the commands could not have honoured it."
+  - id: O10
+    category: specification quality
+    severity: high
+    claim: "Section 5.4 offers the note's machine-authored content as the starting point for a sentence that lands in a committed, permanently archived file, and defines no behaviour for the human accepting it verbatim."
+    evidence: "Spec 5.4 offers 'the note's plain content as a starting point'; section 4's plain content is 'continued past the 20:00 stop by choice'. Section 7 forbids a machine-authored sentence in a committed file; A2 does not distinguish authoring from accepting."
+    disposition: accepted
+    disposition_rationale: "Dissolved by O6. With no inference in the store there is no machine sentence to offer, so the accept-the-default path cannot exist. The Coda asks an open question about a fact — a boundary was passed — and whatever the human says is the whole of the record."
+  - id: O11
+    category: scope
+    severity: high
+    claim: "The two surfaces S4's O7 corrected to say the override is NOT recorded still say so, and neither appears in section 6 or section 9."
+    evidence: "templates/pacts.md: 'What you say in answer is not written down anywhere yet.' reference/pacts-format.md carries the matching correction. Both become false with this slice, and the template is where the human decides whether to write strict at all."
+    disposition: accepted
+    disposition_rationale: "Both corrected, and both added to the file list. The carve-out's fourth condition is disclosed-and-declinable, and the place a person actually decides is the pact template — not the hooks reference. S4's own reasoning applies unchanged and in reverse."
+  - id: O12
+    category: specification quality
+    severity: medium
+    claim: "Consumption semantics are undefined in three ways: what a second /coda reports for events appended after consumed-by-coda, where in the ritual the marking happens, and what marking means on the abandon path."
+    evidence: "Spec 4.1 claims idempotence without saying about what; section 5.3 names the actor and not the step; commands/coda.md's stopping section commits to naming everything written, and a consumption mark is a durable side effect it does not know about."
+    disposition: accepted
+    disposition_rationale: "Largely dissolved by O6 — with only fired-events in the store there is far less to reconcile — and the remainder is defined: marking happens at step 7, with the reflection, so a human who stops before it has consumed nothing; events after a mark are reported by the next close; and the abandon path names the mark among what was written, since it is now one of the few things that was."
+---
+# Objection record — Cadence Sentinels S3b (spec mode)
+
+Twelve objections: three critical, eight high, one medium. The concentration is
+a property of the slice rather than of the spec's care — this is the seam three
+slices deferred into, and it inherits eight adjudicated objections it must
+discharge rather than restate.
+
+**Dispatcher verification note (2026-08-12).** Three claims were checked against
+shipped code before recording, and all three held.
+
+`reservoir-check.sh` carries **zero** occurrences of any once-per-session guard
+and persists nothing by charter, so it re-emits on every `Stop` firing while a
+threshold stays crossed. No command in the plugin reads `session_id`, and no
+session environment variable exists anywhere in the repo. And §4's own worked
+example timestamps `continued past the 20:00 stop by choice` **identically** to
+the notice that fired — so whatever wrote it wrote it before the human had done
+anything at all.
+
+**The three that reshaped the slice.**
+
+**O1** inverted the rail's purpose. It was built to reduce accumulated pressure
+and, on the shipped code, it protected the source of it: the Warden repeats
+every turn, the Mast's notice arrives once, and first-claim-wins with the Warden
+ordered first meant the once-only message never arrived at all. Precedence now
+replaces registration order.
+
+**O6** is the sharpest finding in the epic so far, because the offending line
+was in the spec's own illustration of what the store may hold. Nothing observes
+a choice — continuing is the absence of stopping — and reading intent into
+silence is exactly what the boundary forbids. The store now records only what
+fired, which dissolves O10 entirely.
+
+**O9** blocked implementation outright. The store was keyed by something its
+own writers cannot know. Re-keyed by repo, which every participant can name.
+
+**Inheritance audit.** S3's O2 is discharged by §4.2, and MN4's
+transitive-source-closure assertion is stronger than S1's R9. S3's O11 is
+discharged by §4.3 — and the self-gate it installed created O7. S3's O4 is now
+discharged for both halves, the second by replacing the fraction outright. S3's
+O3 is discharged for the consumption path by §4.1 and for the pruning path by
+O8's heartbeat. S3's O8 is engaged by §3 and re-scoped by O1 and O2. S3's O9 is
+resolved for the reflection fragment and, after O6, no longer re-enters in the
+store. S4's deferred override is built and its two corrected surfaces are
+corrected back. Nothing inherited is silently dropped.
+
+## Explicitly not objecting to
+
+- **The shared advisory rail's existence, and the coordination line in
+  `reservoir-check.sh`.** Disposed at the design gate; O1 and O2 challenge the
+  rail's period and priority, not whether it should exist.
+- **Consumption marking rather than deleting.** Disposed, and §4.1's idempotence
+  argument is a genuine improvement on the first design.
+- **The two-library split.** Exactly S1's shape for S1's reason, and MN4 is
+  stronger than S1's R9.
+- **Only `hard_stop_hour` producing notices.** The right half of S3's O4,
+  correctly discharged.
+- **That the Coda writes the human's sentence rather than a machine verdict.**
+  The right resolution of S3's O9.
+- **Version and rollout arithmetic**, and the unchanged component counts.
+- **Language discipline.** No instance of "addiction" or "dopamine", no fatigue
+  claim, no score.

--- a/docs/superpowers/specs/2026-08-12-cadence-sentinels-s3b-boundary-notices-design.md
+++ b/docs/superpowers/specs/2026-08-12-cadence-sentinels-s3b-boundary-notices-design.md
@@ -1,12 +1,14 @@
 # Spec: Cadence Sentinels S3b — Boundary Notices and the Hard Stop
 
-**Status:** Approved (revision 1)
+**Status:** Approved (revision 2, post-diaboli)
 **Date:** 2026-08-12
 **Issue:** #501
 **Epic:** The Cadence Sentinels (S1–S7)
 **Depends on:** S1 (the pact file, the registry), S2 (the Coda, whose contract
 this changes), S3 (the Mast), S4 (the WIP Warden, whose override this carries)
-**Scope:** one hook, two libraries, a contract change to S2, and one
+**Objections:** `docs/superpowers/objections/cadence-sentinels-s3b-boundary-notices-design.md`
+— 12 objections, all accepted; three criticals reshaped the slice
+**Scope:** one hook, three libraries, a contract change to S2, and one
 coordination line in an existing hook
 
 ---
@@ -32,8 +34,22 @@ is the seam.
 
 | Notice | Fires | Says |
 | --- | --- | --- |
-| **approaching** | at 80% of the way from session start to `hard_stop_hour` | where you are, and what the line is |
+| **approaching** | `approaching_lead_minutes` before `hard_stop_hour` (default 30) | where you are, and what the line is |
 | **reached** | at `hard_stop_hour` | one recommendation: `/coda` |
+
+**A lead time, not a fraction.** Revision 1 said "80% of the way from session
+start to `hard_stop_hour`", which is not computable (O5). `started_at` is UTC
+and `hard_stop_hour` is local, so the naive arithmetic is silently wrong by the
+machine's offset. Worse, `registry_touch` deliberately never resets
+`started_at` across resume, clear and compact — so a session resumed the next
+morning reports yesterday's start, and the fraction is already past 80% at
+breakfast. The notice would fire on resume, every morning, with nothing
+approached.
+
+A fraction needs two endpoints and only one of them is honest: the line the
+human drew. A lead time needs one, sits in the same frame as the value it
+measures against, and has no behaviour to define for midnight or for a session
+that begins after the line.
 
 **One recommendation, once.** No repeats, no escalation, no second notice ten
 minutes later.
@@ -56,88 +72,170 @@ what each key can honestly support, and only one supports a line in time.
 
 ## 3. The Advisory Rail
 
-Two sentinels now counsel stopping on the same rail, and they can fire on the
-same turn: `reservoir-check.sh` puts a declared `lark` into its suboptimal band
-at hour ≥ 20, so a `hard_stop_hour: 20:00` produces two independent stop
-advisories saying essentially the same thing.
+Two sentinels counsel stopping on the same rail and can fire on the same turn:
+`reservoir-check.sh` puts a declared `lark` into its suboptimal band at hour
+≥ 20, so a `hard_stop_hour: 20:00` produces two independent stop advisories.
 
-That is not a cosmetic clash. The evidence this slice is built on says a single
-boundary-moment prompt works and accumulated pressure does not — and two
-messages about stopping, arriving together, **is** accumulated pressure. The
-Mast would be degrading the Reservoir Warden's effectiveness without editing
-one of its files.
+Two messages about stopping, arriving together, **is** accumulated pressure —
+which the evidence in §2 says makes the mechanism work worse.
 
-### 3.1 One claim per turn
+### 3.1 Precedence, not registration order
 
-`hooks/scripts/lib/advisory-rail.sh` exposes:
+Revision 1 said the first hook to claim wins, and ordered the Warden first. That
+inverted the rail's purpose (O1).
 
-```text
-advisory_claim <kind>   # true for the first claim of this kind this turn
-```
+`reservoir-check.sh` has **no once-per-session guard and cannot have one** — it
+persists nothing by charter, recomputes an eight-hour git window every `Stop`,
+and emits whenever a threshold is still crossed. Thresholds stay crossed for
+hours. So the Warden speaks on **every turn**, while the Mast's `reached` fires
+once, ever.
 
-The first hook to claim `stop` in a given turn emits; every later one stays
-silent about stopping. Nothing re-derives anyone else's logic — which is the
-point.
+First-claim-wins with the Warden first therefore preserved the message that
+repeats and permanently spent the one designed to arrive once — and because the
+note is still logged on the suppressed turn, the human would never have received
+the boundary message at all.
 
-**The alternative was worse.** Having the Mast stay quiet by re-deriving the
-Warden's chronotype band would pin a copy of logic another slice owns, which is
-the anti-pattern `AGENTS.md` has already caught twice in this epic (the README
-counts, and `registry_list`'s docstring). A shared rail costs one line in each
-participant and copies nothing.
+So the rail arbitrates by **precedence**:
 
-### 3.2 The one line in `reservoir-check.sh`
+| Class | Example | On a collision |
+| --- | --- | --- |
+| **once-only** | the Mast's `approaching` and `reached` | speaks |
+| **repeating** | the Warden's band advisory | defers to the next turn |
 
-`reservoir-check.sh` gains a single `advisory_claim stop` guard before it
-emits.
+The Warden loses nothing by deferring: it fires again next turn, on the same
+conditions. The Mast's notice has no next turn.
+
+Revision 1 also justified the old order by claiming *decide your stop* subsumes
+*you have reached the stop you decided*. The shipped sentence does not say that
+— it asks the human to decide a **future** stop before the **next** session
+(`reservoir-check.sh:133`), which is advice for someone who has not drawn a
+line. The person who declared `hard_stop_hour: 20:00` has already done it, and
+the suppressed message was the one naming their own line. The argument is
+withdrawn rather than repaired (O2).
+
+### 3.2 What a "turn" is, stated operationally
+
+A `Stop` hook receives no turn identifier, and every hook in one firing sees the
+same `session_id`. So a turn is defined by the only thing available (O3):
+
+**Hooks in one `Stop` firing run back-to-back**, so a claim is scoped by a
+short wall-clock window — **10 seconds**, recorded in the claim file.
+
+Its two failure modes are disclosed rather than hidden, in the skill and the
+reference page:
+
+- Two turns completing inside 10 seconds collapse into one, so a turn's
+  repeating advisory is suppressed. Costs one skipped Warden message.
+- A rail slow enough to straddle 10 seconds lets both emit. Costs one duplicate.
+
+Both are bounded and neither is silent to a reader of the docs. Claiming uses
+`mkdir`, which is atomic on every POSIX filesystem — a rail whose guarantee is a
+race would flicker, and a sentinel that flickers teaches the human to discount
+it.
+
+### 3.3 The one line in `reservoir-check.sh`
+
+It gains a single `advisory_defer_if_claimed` guard before it emits.
 
 This is a change to the Reservoir Warden's hook, and constraint 5 says that
-agent is untouched. The judgement, recorded here: **this is a coordination
-change, not a behavioural one.** The Warden's proxies, thresholds, honesty
-flags, recommendation text, and advisory-forever standing are all unchanged. It
-still fires whenever it would have fired — it simply claims the turn first, and
-by ordering it always wins the claim.
+agent is untouched. The judgement, recorded: **this is a coordination change,
+not a behavioural one.** Its proxies, thresholds, honesty flags, recommendation
+text and advisory-forever standing are all unchanged, and it still fires
+whenever it would have fired — except on the at most one turn per session when
+a once-only advisory has claimed.
 
-The Warden going first is deliberate. It is the older sentinel, it is
-advisory-forever by charter, and its advice is the more general — *decide your
-stop* subsumes *you have reached the stop you decided*.
+**The Mast's hook is registered before it** in `hooks.json`, so precedence and
+order agree rather than the guarantee resting on precedence alone.
 
-### 3.3 What the Mast does when it loses the claim
+### 3.4 What the Mast does when it defers
 
-It stays silent **and still logs the note** (§4). The human's boundary was
-still reached; the only thing suppressed is a second message saying so.
-
-A later reader of the session's record sees that the line was passed. They just
-were not told twice at the time.
+It never defers — it is the once-only class. When it speaks, it logs the note
+either way.
 
 ## 4. The Note Store
 
-`~/.claude/mast/<sanitised-session-id>.notes` — append-only within a session,
-one line per event.
+`~/.claude/mast/<sanitised-repo-slug>.notes` — append-only, one line per event.
 
 ```text
 2026-08-12T20:00:00Z reached hard_stop_hour=20:00
-2026-08-12T20:00:00Z continued past the 20:00 stop by choice
-2026-08-12T21:14:00Z wip-override 3 live against a limit of 2
+2026-08-12T21:14:00Z wip-breach 3 live against a limit of 2
 2026-08-12T23:10:00Z consumed-by-coda
 ```
 
-### 4.1 Marked consumed, never deleted
+### 4.0 It records what fired, never what it meant
+
+Revision 1's example carried a second line beside the first —
+`continued past the 20:00 stop by choice` — timestamped **identically** to the
+notice. Whatever wrote it wrote it before the human had done anything at all
+(O6).
+
+That is a hook attributing intent to a person. Nothing observes a choice:
+**continuing is the absence of stopping**, and reading intent into silence is
+exactly what the boundary between counting and watching forbids. It also
+falsified two of this spec's own claims — §4.4's judges-nothing condition, and
+§5.1's `observed` flag, which is true of `reached` and was false of the line
+beside it.
+
+So the store holds **only what fired**. There is no override line, because
+there is nothing to observe. What the human decided is asked for at close (§5.4)
+and their answer is the only account that exists — which also means there is no
+machine sentence left to accept by default, dissolving O10 entirely.
+
+### 4.1 Keyed by repo, because its writers are commands
+
+Revision 1 keyed the store by session id. Its two writers are `/coda` and
+`/wip` — **commands**, which have no channel to learn one. Every shipped reader
+takes `session_id` from hook stdin, and no command in this plugin reads it (O9).
+
+The obvious workaround — take the newest file — fails in exactly the world this
+epic exists for: `/coda` in one session would consume another's notes, silently,
+because the file it read contained plausible lines.
+
+So the key is the repo. A command knows its working directory, so everything
+that touches the store can name it. Per-session isolation is not lost so much as
+never achievable — and the scope fits: boundary events concern a pact that is
+machine-global and a person who is singular, and the Coda closes a session *in a
+repo*.
+
+### 4.1a Marked consumed, never deleted
 
 The Coda **marks** the file consumed rather than removing it.
 
-S3's O3 found the reason: the once-per-session notice state lives in this file,
-and `/coda`'s final step is a statement rather than a process termination — the
-session is still alive and the `Stop` rail keeps firing. A file deleted at close
-would take the notice state with it, and the reached notice would fire again on
-the next turn, on exactly the sessions where the human had already overridden
-once.
+S3's O3 found the reason: the once-per-session notice state lives here, and
+`/coda`'s final step is a statement rather than a process termination — the
+session is alive and the `Stop` rail keeps firing. A file deleted at close would
+take the notice state with it, and `reached` would fire again on the next turn,
+on exactly the sessions where the human had already been told once.
 
-Marking also makes a second `/coda` in the same session idempotent, which the
-first design would not have been.
+Marking also makes a second `/coda` idempotent, which deletion would not have
+been.
 
-**Boundedness is unchanged**: the file is lease-pruned on the same `Stop` rail,
-exactly as the registry is. That is what satisfies the operational-state
-carve-out's second condition, and it never depended on deletion-at-close.
+### 4.1b Bounded by a heartbeat, not by an event
+
+The notes file is **touched on every `Stop` while its repo has a live session**,
+exactly as a registry entry is — the same shape, for the same reason.
+
+Revision 1 said "lease-pruned, exactly as the registry is", which was not true
+of the mechanism it described: a notes file has no heartbeat and is appended to
+only on a boundary event, so under the default 12-hour lease a session reaching
+its stop at 20:00 and still alive at 08:00 would have its own hook prune its
+notice state — and `reached` would fire again (O8). That is S3's O3 arriving
+through the pruner instead of through consumption.
+
+Touching on every `Stop` makes one lease serve both jobs without compromise: a
+live repo's notes never age out, a dormant one's do.
+
+### 4.1c The prune runs unconditionally
+
+**Before the self-gate, for every user, exactly as `registry_prune` does.**
+
+Revision 1 put the prune behind the `block_state` check, which meant a human who
+used the feature for a month and then deleted their `Budgets` block left every
+note file behind forever (O7). The one path where someone has withdrawn consent
+is the one path where leftover state matters most, and gating the cleanup behind
+the feature is precisely backwards.
+
+The janitor is separable from the opt-in, and must be.
 
 ### 4.2 Two libraries, split on the trust boundary
 
@@ -212,9 +310,15 @@ S3's O9 asked the sharp question: the note file is bounded and local, but
 `grep` would return every night the human worked past their line.
 
 **So the Coda writes the human's own sentence, not the machine's.** At close it
-asks what to record — offering the note's plain content as a starting point —
-and what reaches the reflection fragment is a line the person authored and would
-recognise as theirs.
+says what fired — "your 20:00 stop passed at 20:00" — and asks whether they want
+to record anything about it. What reaches the reflection fragment is a line the
+person authored and would recognise as theirs.
+
+**Nothing is offered as a default.** Revision 1 proposed the note's own content
+as a starting point, which after §4.0 no longer exists — and would have been a
+machine-authored observation about conduct, accepted at the tiredest moment of
+the day, landing in a permanently archived file (O10). The question is open,
+and a blank answer records nothing.
 
 That is the same resolution S2 reached for the next-action override: the record
 carries the human's words, not a machine verdict, and it is what keeps a
@@ -235,6 +339,16 @@ never a gate, so there is nothing that must be accounted for.
 | `agents/coda.agent.md`, `commands/coda.md` | the survey row and the `Closed` field |
 | `agents/wip-warden.agent.md`, `commands/wip.md` | the override is now recorded |
 | `skills/mast/SKILL.md`, `skills/wip-warden/SKILL.md` | the notices, the rail |
+| `hooks/hooks.json` | registers the new hook **before** `reservoir-check.sh` |
+| `skills/coda/SKILL.md` | the survey table §5.1 amends, and the ritual's length |
+| `templates/pacts.md` | `approaching_lead_minutes`, and the override now *is* recorded |
+| `reference/pacts-format.md` | the same two corrections |
+
+The last three are the third file-table omission in four slices (S3's O1, S4's
+O11, and this). §6 now lists every file the change cannot land without — the
+ordering guarantee lives in `hooks.json` and nowhere else, and the two pact
+surfaces currently tell the human their answers are *not* written down, which
+this slice makes false.
 
 ## 7. Non-Goals
 

--- a/docs/superpowers/specs/2026-08-12-cadence-sentinels-s3b-boundary-notices-design.md
+++ b/docs/superpowers/specs/2026-08-12-cadence-sentinels-s3b-boundary-notices-design.md
@@ -1,0 +1,299 @@
+# Spec: Cadence Sentinels S3b — Boundary Notices and the Hard Stop
+
+**Status:** Approved (revision 1)
+**Date:** 2026-08-12
+**Issue:** #501
+**Epic:** The Cadence Sentinels (S1–S7)
+**Depends on:** S1 (the pact file, the registry), S2 (the Coda, whose contract
+this changes), S3 (the Mast), S4 (the WIP Warden, whose override this carries)
+**Scope:** one hook, two libraries, a contract change to S2, and one
+coordination line in an existing hook
+
+---
+
+## 1. Problem Statement
+
+Three slices have now deferred work here, and they deferred the same thing
+twice over: **something has to speak at the boundary, and something has to
+carry what the human says back to the record.**
+
+- **S3** deferred the Mast's approaching and reached notices, and its hard-stop
+  override, because building a note store another slice must consume made six
+  of its eleven objections.
+- **S4** deferred the WIP Warden's `strict` override for the same reason — an
+  override worth recording is worth recording once.
+- **S2** shipped the Coda without knowing any of this existed.
+
+So this slice is the missing half of two sentinels and a contract change to a
+third. That is unusual and worth stating plainly: it is not a feature slice, it
+is the seam.
+
+## 2. What Speaks, and Once
+
+| Notice | Fires | Says |
+| --- | --- | --- |
+| **approaching** | at 80% of the way from session start to `hard_stop_hour` | where you are, and what the line is |
+| **reached** | at `hard_stop_hour` | one recommendation: `/coda` |
+
+**One recommendation, once.** No repeats, no escalation, no second notice ten
+minutes later.
+
+<!-- evidence: boundary-moment reality checks improve adherence where ambient
+     reminders do not. The mechanism is a prompt at the decision point, not
+     accumulated pressure — which is why repeating it would not make it work
+     better, it would make it work worse. That is also why §3 exists: two
+     advisories arriving together IS accumulated pressure, even when each was
+     designed as a single prompt. -->
+
+Both ride the `Stop` hook, so they arrive between turns rather than
+interrupting one. Both are `{"systemMessage": ...}` advisories: they never
+block, never exit non-zero, and never require a disposition.
+
+**Only `hard_stop_hour` produces notices.** `focus_blocks` has two endpoints
+and no defined fraction; `sessions_per_day` is a count the registry cannot
+reconstruct; `daily_cost_ceiling` is not observable at all. S3 §2.1 settled
+what each key can honestly support, and only one supports a line in time.
+
+## 3. The Advisory Rail
+
+Two sentinels now counsel stopping on the same rail, and they can fire on the
+same turn: `reservoir-check.sh` puts a declared `lark` into its suboptimal band
+at hour ≥ 20, so a `hard_stop_hour: 20:00` produces two independent stop
+advisories saying essentially the same thing.
+
+That is not a cosmetic clash. The evidence this slice is built on says a single
+boundary-moment prompt works and accumulated pressure does not — and two
+messages about stopping, arriving together, **is** accumulated pressure. The
+Mast would be degrading the Reservoir Warden's effectiveness without editing
+one of its files.
+
+### 3.1 One claim per turn
+
+`hooks/scripts/lib/advisory-rail.sh` exposes:
+
+```text
+advisory_claim <kind>   # true for the first claim of this kind this turn
+```
+
+The first hook to claim `stop` in a given turn emits; every later one stays
+silent about stopping. Nothing re-derives anyone else's logic — which is the
+point.
+
+**The alternative was worse.** Having the Mast stay quiet by re-deriving the
+Warden's chronotype band would pin a copy of logic another slice owns, which is
+the anti-pattern `AGENTS.md` has already caught twice in this epic (the README
+counts, and `registry_list`'s docstring). A shared rail costs one line in each
+participant and copies nothing.
+
+### 3.2 The one line in `reservoir-check.sh`
+
+`reservoir-check.sh` gains a single `advisory_claim stop` guard before it
+emits.
+
+This is a change to the Reservoir Warden's hook, and constraint 5 says that
+agent is untouched. The judgement, recorded here: **this is a coordination
+change, not a behavioural one.** The Warden's proxies, thresholds, honesty
+flags, recommendation text, and advisory-forever standing are all unchanged. It
+still fires whenever it would have fired — it simply claims the turn first, and
+by ordering it always wins the claim.
+
+The Warden going first is deliberate. It is the older sentinel, it is
+advisory-forever by charter, and its advice is the more general — *decide your
+stop* subsumes *you have reached the stop you decided*.
+
+### 3.3 What the Mast does when it loses the claim
+
+It stays silent **and still logs the note** (§4). The human's boundary was
+still reached; the only thing suppressed is a second message saying so.
+
+A later reader of the session's record sees that the line was passed. They just
+were not told twice at the time.
+
+## 4. The Note Store
+
+`~/.claude/mast/<sanitised-session-id>.notes` — append-only within a session,
+one line per event.
+
+```text
+2026-08-12T20:00:00Z reached hard_stop_hour=20:00
+2026-08-12T20:00:00Z continued past the 20:00 stop by choice
+2026-08-12T21:14:00Z wip-override 3 live against a limit of 2
+2026-08-12T23:10:00Z consumed-by-coda
+```
+
+### 4.1 Marked consumed, never deleted
+
+The Coda **marks** the file consumed rather than removing it.
+
+S3's O3 found the reason: the once-per-session notice state lives in this file,
+and `/coda`'s final step is a statement rather than a process termination — the
+session is still alive and the `Stop` rail keeps firing. A file deleted at close
+would take the notice state with it, and the reached notice would fire again on
+the next turn, on exactly the sessions where the human had already overridden
+once.
+
+Marking also makes a second `/coda` in the same session idempotent, which the
+first design would not have been.
+
+**Boundedness is unchanged**: the file is lease-pruned on the same `Stop` rail,
+exactly as the registry is. That is what satisfies the operational-state
+carve-out's second condition, and it never depended on deletion-at-close.
+
+### 4.2 Two libraries, split on the trust boundary
+
+| File | Exposes | Who may source it |
+| --- | --- | --- |
+| `lib/mast-notes-read.sh` | `notes_read`, `notes_has` | hooks, commands, **and sentinels** |
+| `lib/mast-notes-write.sh` | `notes_append`, `notes_mark_consumed`, `notes_prune` | hooks and commands **only** |
+
+S3's O2 called the single-library design a critical, and correctly: a
+`role: sentinel` agent must reach the read side, and a library exposing
+`notes_prune` to it would breach the boundary through the exact channel
+`sentinel-integrity-check.sh` names as its own known limit. S1 shipped this
+split for the registry; this follows it.
+
+### 4.3 Self-gated, and disclosed
+
+**Nothing is created for a human who declared no `Budgets` block.** S3's O11:
+a directory appearing under `~/.claude/` for someone who opted into nothing is
+operational state with no operational purpose, and documenting a store that
+should not exist is an explanation rather than a disclosure.
+
+The hook checks `block_state` first and exits 0 before touching the filesystem,
+exactly as `reservoir-check.sh` does.
+
+`reference/hooks.md` states what the store holds, how long, and how to switch
+the hook off.
+
+### 4.4 The carve-out's four conditions
+
+| Condition | How it holds |
+| --- | --- |
+| **Local, never committed** | `~/.claude/mast/`, outside every work tree |
+| **Bounded** | lease-pruned on the `Stop` rail; consumption marks rather than removes, and does not affect the bound |
+| **Nothing in it judges** | facts about the session — a notice fired, a line was passed, an override was spoken. No score, no assessment, no count across sessions |
+| **Disclosed and declinable** | `reference/hooks.md`, with the opt-out |
+
+## 5. The Contract Change to S2
+
+The Coda's survey gains a fourth row, and its `Closed` field gains what that
+row produces. **S3b owns this change explicitly**, per the promoted decision
+that a consumer never mutates the contract it consumes — this is the third
+worked instance.
+
+### 5.1 The survey
+
+| Item | Flag |
+| --- | --- |
+| Commits, working-tree state, dispositions | `observed` |
+| Merged PRs, open-PR check state | `observed` / `inferred` |
+| Which files constitute one thread | `asked` |
+| **Boundary events this session** | **`observed`** |
+
+`observed` is honest here: the note file records what actually fired and what
+the human actually said. The Coda is reading a log, not inferring.
+
+### 5.2 The `Closed` field
+
+```text
+- **Closed**: [what landed; the filename of each record parked; any boundary
+  events and what was decided]
+```
+
+### 5.3 Who marks it consumed
+
+The `/coda` **command**, not the agent. The Coda agent holds no `Write` and
+must never source `mast-notes-write.sh`.
+
+### 5.4 What the override looks like once it lands
+
+S3's O9 asked the sharp question: the note file is bounded and local, but
+`REFLECTION_LOG.md` is committed, aggregated, and permanently archived. One
+`grep` would return every night the human worked past their line.
+
+**So the Coda writes the human's own sentence, not the machine's.** At close it
+asks what to record — offering the note's plain content as a starting point —
+and what reaches the reflection fragment is a line the person authored and would
+recognise as theirs.
+
+That is the same resolution S2 reached for the next-action override: the record
+carries the human's words, not a machine verdict, and it is what keeps a
+permanent committed artefact on the *by the person* side of the boundary.
+
+If they would rather record nothing, nothing is recorded. The override was
+never a gate, so there is nothing that must be accounted for.
+
+## 6. Files
+
+| File | Purpose |
+| --- | --- |
+| `hooks/scripts/mast-boundary-check.sh` | `Stop` — the two notices, the notes, the prune |
+| `hooks/scripts/lib/advisory-rail.sh` | one stop-advisory per turn |
+| `hooks/scripts/lib/mast-notes-read.sh` | the read surface |
+| `hooks/scripts/lib/mast-notes-write.sh` | the write surface |
+| `hooks/scripts/reservoir-check.sh` | **one line**: claim the rail first |
+| `agents/coda.agent.md`, `commands/coda.md` | the survey row and the `Closed` field |
+| `agents/wip-warden.agent.md`, `commands/wip.md` | the override is now recorded |
+| `skills/mast/SKILL.md`, `skills/wip-warden/SKILL.md` | the notices, the rail |
+
+## 7. Non-Goals
+
+- **No blocking.** Nothing here can end or hold a session.
+- **No notices for keys that cannot support one.** Only `hard_stop_hour`.
+- **No cross-session aggregation.** A note is per-session and pruned. Counting
+  overrides across sessions would be a record of how often someone works late.
+- **No changes to the Reservoir Warden's behaviour** — one coordination line,
+  §3.2, and nothing else.
+- **No machine-authored sentence in a committed file.** §5.4.
+
+## 8. Acceptance Scenarios (TDAD)
+
+### 8.1 The rail — `test-advisory-rail.sh`
+
+- **AR1** — the first claim of a kind in a turn succeeds; the second fails.
+- **AR2** — a different kind claims independently.
+- **AR3** — a new turn resets the claim.
+- **AR4** — claiming writes nothing outside the store, and exits 0 when it
+  cannot write.
+
+### 8.2 The notices — `test-mast-boundary.sh`
+
+- **MB1** — approaching fires once at 80%; a second run in the same session is
+  silent.
+- **MB2** — reached fires once and recommends `/coda`.
+- **MB3** — silent before the fraction.
+- **MB4** — silent with no `Budgets` block, **and no store is created**.
+- **MB5** — a malformed block degrades to silence, never a gate.
+- **MB6** — losing the rail claim suppresses the message **but still logs the
+  note**.
+- **MB7** — the notice state survives `consumed-by-coda`: after consumption,
+  reached does not fire again.
+- **MB8** — exits 0 on every path, including an unwritable store and `HOME`
+  unset.
+- **MB9** — a hostile session id sanitises to `unknown`.
+
+### 8.3 The libraries — `test-mast-notes.sh`
+
+- **MN1** — append and read round-trip.
+- **MN2** — `notes_mark_consumed` marks and does **not** remove.
+- **MN3** — a stale file is pruned past its lease.
+- **MN4** — the read library defines no mutator, and its transitive source
+  closure contains none.
+- **MN5** — reading one session's notes returns only that session's lines.
+
+### 8.4 Agent-verified
+
+- **A1** — the Coda's survey reports boundary events, flagged `observed`.
+- **A2** — the Coda asks what to record and writes the human's sentence.
+- **A3** — recording nothing is a valid answer.
+- **A4** — neither the Coda nor the WIP Warden agent sources a write surface.
+
+## 9. Rollout
+
+Minor bump, 0.70.1 → 0.71.0 — new hook and libraries, and a changed contract.
+
+No new agent, skill, or command, so the component counts are unchanged.
+
+Docs: the hook and the store in `reference/hooks.md`; the notices in the Mast's
+and WIP Warden's how-tos; the override in `reference/parking-record-format.md`'s
+neighbour, `closing-a-session.md`.

--- a/tdad_tests/layer0_deterministic/test-advisory-rail.sh
+++ b/tdad_tests/layer0_deterministic/test-advisory-rail.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for the advisory rail
+# (spec 2026-08-12-cadence-sentinels-s3b-boundary-notices-design.md, §3; AR1–AR6).
+#
+# AR2 is the reason this exists and the reason the design changed. Two
+# sentinels counsel stopping on the Stop rail, and they operate on different
+# periods: `reservoir-check.sh` has NO once-per-session guard and cannot have
+# one — it persists nothing by charter and re-emits every turn while a
+# threshold stays crossed — while the Mast's `reached` fires once, ever.
+#
+# First-claim-wins with the warden ordered first therefore preserved the
+# message that repeats and permanently spent the one designed to arrive once.
+# So the rail arbitrates by PRECEDENCE: a once-only advisory speaks, and a
+# repeating one defers to the next turn it is going to get anyway.
+#
+# AR5 pins the atomicity. A check-then-act on a shared file is a race, and a
+# rail whose guarantee flickers teaches the human to discount the sentinel —
+# which is the failure the rail exists to prevent, arriving by another door.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN="$SCRIPT_DIR/../../ai-literacy-superpowers"
+RAIL="$PLUGIN/hooks/scripts/lib/advisory-rail.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+[ -f "$RAIL" ] || fail "advisory rail not found at $RAIL"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export CLAUDE_ADVISORY_DIR="$TMP/rail"
+
+# shellcheck source=/dev/null
+. "$RAIL"
+for fn in advisory_claim advisory_defer_if_claimed advisory_reset; do
+  declare -F "$fn" >/dev/null || fail "rail must define $fn"
+done
+
+# --- AR1: a once-only advisory claims and speaks -----------------------------
+advisory_claim once-only stop || fail "AR1: a first once-only claim must succeed"
+
+# --- AR2: a repeating advisory defers when a once-only has claimed -----------
+# The finding that reshaped the slice. The warden defers to a turn it will get
+# again; the Mast's notice has no next turn.
+if advisory_defer_if_claimed stop; then
+  : # deferred, as required
+else
+  fail "AR2: a repeating advisory must defer when a once-only has claimed this turn"
+fi
+
+# --- AR3: with no once-only claim, a repeating advisory speaks ---------------
+advisory_reset
+if advisory_defer_if_claimed stop; then
+  fail "AR3: with no claim outstanding, a repeating advisory must speak"
+fi
+
+# --- AR4: a different kind claims independently ------------------------------
+advisory_reset
+advisory_claim once-only stop || fail "AR4: setup"
+if advisory_defer_if_claimed park; then
+  fail "AR4: a claim on 'stop' must not silence an unrelated kind"
+fi
+
+# --- AR6: the claim expires with the turn ------------------------------------
+# A turn has no identifier a hook can read, so it is scoped by a short
+# wall-clock window. Both failure modes are disclosed in the docs; this pins
+# that the window exists and expires.
+advisory_reset
+advisory_claim once-only stop || fail "AR6: setup"
+# A claim carries its window in its NAME, so an earlier turn's claim is simply
+# a name nobody looks at. Rename it to a past window to simulate one.
+for c in "$CLAUDE_ADVISORY_DIR"/stop.*.claim; do
+  [ -d "$c" ] || continue
+  mv "$c" "$CLAUDE_ADVISORY_DIR/stop.1.claim"
+done
+if advisory_defer_if_claimed stop; then
+  fail "AR6: a claim from an earlier window must not silence this turn"
+fi
+
+# --- AR5: claiming is atomic -------------------------------------------------
+# mkdir is atomic on every POSIX filesystem; a check-then-act would race.
+advisory_reset
+winners=0
+for _ in 1 2 3 4 5 6 7 8; do
+  ( advisory_claim once-only stop && echo won >> "$TMP/winners" ) &
+done
+wait
+[ -f "$TMP/winners" ] && winners=$(grep -c . "$TMP/winners" || true)
+[ "$winners" = "1" ] \
+  || fail "AR5: exactly one concurrent claimant must win, got $winners"
+
+# --- AR4b: never fails, never writes outside its store -----------------------
+export CLAUDE_ADVISORY_DIR="$TMP/blocked/rail"
+: > "$TMP/blocked"
+set +e; advisory_claim once-only stop; rc=$?; set -e
+[ "$rc" -le 1 ] || fail "AR4b: an unwritable store must not error out, got $rc"
+set +e
+( unset HOME; advisory_defer_if_claimed stop ); rc=$?
+set -e
+[ "$rc" -le 1 ] || fail "AR4b: HOME unset must not error out, got $rc"
+
+echo "PASS: advisory rail — once-only speaks, repeating defers, claims are atomic and expire"

--- a/tdad_tests/layer0_deterministic/test-mast-boundary.sh
+++ b/tdad_tests/layer0_deterministic/test-mast-boundary.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for the boundary notices and the note store
+# (spec 2026-08-12-cadence-sentinels-s3b-boundary-notices-design.md; MB/MN).
+#
+# MB4 and MB10 carry the constitutional weight.
+#
+# MB4: nothing is created for a human who declared no Budgets block. A
+# directory appearing under ~/.claude/ for someone who opted into nothing is
+# operational state with no operational purpose.
+#
+# MB10: the store records only what FIRED. An earlier design carried a line
+# reading "continued past the 20:00 stop by choice", timestamped identically to
+# the notice — written before the human had done anything. Nothing observes a
+# choice; continuing is the absence of stopping, and reading intent into
+# silence is exactly what the boundary between counting and watching forbids.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN="$SCRIPT_DIR/../../ai-literacy-superpowers"
+HOOK="$PLUGIN/hooks/scripts/mast-boundary-check.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+[ -f "$HOOK" ] || fail "boundary hook not found at $HOOK"
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+export CLAUDE_MAST_DIR="$TMP/mast" CLAUDE_ADVISORY_DIR="$TMP/rail" CLAUDE_PACTS_FILE="$TMP/pacts.md"
+
+# shellcheck source=/dev/null
+. "$PLUGIN/hooks/scripts/lib/mast-notes-write.sh"
+
+run() { set +e; OUT="$(printf '{"cwd":"%s"}' "$TMP" | bash "$HOOK" 2>/dev/null)"; RC=$?; set -e; }
+
+# pact <hard_stop_hour> [extra...] — a well-formed Budgets block
+pact() {
+  { printf '# Pacts\n\n## Budgets\n\n- hard_stop_hour: %s\n' "$1"; shift
+    [ "$#" -gt 0 ] && printf '%s\n' "$@"
+    printf '\nUnspent budget is not a debt.\n'; } > "$CLAUDE_PACTS_FILE"
+}
+at() { printf '%02d:%02d' "$1" "$2"; }   # a local HH:MM
+minutes_from_now() { date -v+"$1"M +%H:%M 2>/dev/null || date -d "+$1 minutes" +%H:%M; }
+
+# --- MB4: no block, no output, AND no store ---------------------------------
+: > "$CLAUDE_PACTS_FILE"
+run
+[ "$RC" -eq 0 ] || fail "MB4: must exit 0 (got $RC)"
+[ -z "$OUT" ] || fail "MB4: must be silent with no Budgets block. Got: $OUT"
+[ ! -d "$CLAUDE_MAST_DIR" ] \
+  || fail "MB4: no store may be created for a human who declared nothing"
+
+# --- MB3: silent well before the line ---------------------------------------
+pact "$(minutes_from_now 300)"
+run
+[ -z "$OUT" ] || fail "MB3: must be silent five hours out. Got: $OUT"
+
+# --- MB1: approaching fires once --------------------------------------------
+pact "$(minutes_from_now 20)"
+run
+echo "$OUT" | grep -qiE 'minute' || fail "MB1: approaching must fire inside the lead. Got: $OUT"
+run
+[ -z "$OUT" ] || fail "MB1: approaching must fire once. Got: $OUT"
+
+# --- MB2: reached fires once and recommends /coda ---------------------------
+rm -rf "${CLAUDE_MAST_DIR:?}" "${CLAUDE_ADVISORY_DIR:?}"
+pact "$(at 0 1)"   # 00:01 — already passed for any run after 00:01
+run
+echo "$OUT" | grep -qF '/coda' || fail "MB2: reached must recommend /coda. Got: $OUT"
+echo "$OUT" | grep -qiE 'stops you|keep going' \
+  || fail "MB2: reached must say it does not stop you. Got: $OUT"
+run
+[ -z "$OUT" ] || fail "MB2: reached must fire once. Got: $OUT"
+
+# --- MB7: the notice state survives consumption ------------------------------
+# /coda's last step is a statement, not a process ending, so the Stop rail keeps
+# firing. A store deleted at close would re-fire reached on the next turn.
+notes_mark_consumed "$TMP"
+notes_read "$TMP" | grep -q 'consumed-by-coda' || fail "MB7: consumption must be recorded"
+[ -f "$(notes_path "$TMP")" ] || fail "MB7: consumption must MARK, never remove"
+rm -rf "${CLAUDE_ADVISORY_DIR:?}"
+run
+[ -z "$OUT" ] || fail "MB7: reached must not fire again after consumption. Got: $OUT"
+
+# --- MB10: the store records what fired, never what it meant -----------------
+contents="$(notes_read "$TMP")"
+echo "$contents" | grep -q 'reached hard_stop_hour' || fail "MB10: the fired event must be recorded"
+if echo "$contents" | grep -qiE 'by choice|continued|chose|decided|ignored'; then
+  fail "MB10: the store must hold no attribution of intent. Got: $contents"
+fi
+
+# --- MB6: a repeating advisory defers to the once-only notice ----------------
+# shellcheck source=/dev/null
+. "$PLUGIN/hooks/scripts/lib/advisory-rail.sh"
+rm -rf "${CLAUDE_MAST_DIR:?}" "${CLAUDE_ADVISORY_DIR:?}"
+pact "$(at 0 1)"
+run
+[ -n "$OUT" ] || fail "MB6: setup — reached should have fired"
+advisory_defer_if_claimed stop \
+  || fail "MB6: a once-only notice must claim the turn so a repeating advisory defers"
+
+# --- MB11: the warden DEFERS; it does not claim ------------------------------
+# Structural, and deliberately so. Driving reservoir-check.sh to the point of
+# emission needs an opted-in Cognitive reservoir block and crossed git-window
+# thresholds, which is beyond Layer 0 — but the distinction it guards is the
+# one that reshaped this slice, so it is worth pinning at the only level
+# available here.
+#
+# If the warden claimed once-only instead of deferring, first-claim-wins would
+# return by the back door: it re-emits every turn while a threshold stays
+# crossed, so it would take the claim on the turn before the Mast's notice and
+# permanently spend a message designed to arrive once.
+RCHK="$PLUGIN/hooks/scripts/reservoir-check.sh"
+grep -q 'advisory_defer_if_claimed stop' "$RCHK" \
+  || fail "MB11: reservoir-check must DEFER to a once-only claim"
+if grep -q 'advisory_claim once-only' "$RCHK"; then
+  fail "MB11: reservoir-check must not claim once-only — it repeats every turn and would spend the Mast's single notice"
+fi
+
+# --- MB5: malformed degrades to silence, never a gate -----------------------
+rm -rf "${CLAUDE_MAST_DIR:?}" "${CLAUDE_ADVISORY_DIR:?}"
+printf '# Pacts\n\n## Budgets\n\n- hard_stop_hour: 00:01\n\nThe clause is gone.\n' > "$CLAUDE_PACTS_FILE"
+run
+[ "$RC" -eq 0 ] || fail "MB5: malformed must never gate (got $RC)"
+[ -z "$OUT" ] || fail "MB5: malformed must be silent. Got: $OUT"
+
+# --- MN3/MB8: the prune is unconditional, and everything exits 0 -------------
+# The janitor must not sit behind the opt-in: deleting your pact would
+# otherwise leave every note file behind forever.
+mkdir -p "$CLAUDE_MAST_DIR"; : > "$CLAUDE_MAST_DIR/old.notes"
+touch -t 202001010000 "$CLAUDE_MAST_DIR/old.notes"
+: > "$CLAUDE_PACTS_FILE"          # opted out entirely
+run
+[ ! -f "$CLAUDE_MAST_DIR/old.notes" ] \
+  || fail "MN3: a stale note file must be pruned even with no declared block"
+
+blocked="$TMP/blocked"; : > "$blocked"
+set +e; OUT="$(printf '{"cwd":"%s"}' "$TMP" | CLAUDE_MAST_DIR="$blocked/x" bash "$HOOK" 2>/dev/null)"; RC=$?; set -e
+[ "$RC" -eq 0 ] || fail "MB8: an unwritable store must still exit 0 (got $RC)"
+set +e; OUT="$(printf 'not json' | env -u HOME bash "$HOOK" 2>/dev/null)"; RC=$?; set -e
+[ "$RC" -eq 0 ] || fail "MB8: HOME unset and junk stdin must still exit 0 (got $RC)"
+
+# --- MN4: the read library exposes no mutation -------------------------------
+R="$PLUGIN/hooks/scripts/lib/mast-notes-read.sh"
+( unset -f notes_append notes_prune notes_mark_consumed 2>/dev/null || true
+  # shellcheck source=/dev/null
+  . "$R"
+  if declare -F notes_append >/dev/null || declare -F notes_prune >/dev/null; then
+    echo "FAIL: MN4: sourcing the read library must not define a mutator" >&2; exit 1
+  fi ) || exit 1
+if grep -nE '(^|[^[:alnum:]_])(rm|rmdir|mv|cp|tee|truncate)[[:space:]]' "$R" | grep -vqE ':[[:space:]]*#'; then
+  fail "MN4: the read library must contain no mutation command"
+fi
+
+# --- MN5: one repo's notes are its own ---------------------------------------
+rm -rf "${CLAUDE_MAST_DIR:?}"
+notes_append "reached a" "/repo/alpha"
+notes_append "reached b" "/repo/beta"
+notes_read "/repo/alpha" | grep -q 'reached a' || fail "MN5: alpha's note must be readable"
+if notes_read "/repo/alpha" | grep -q 'reached b'; then
+  fail "MN5: one repo's notes must not leak into another's"
+fi
+
+echo "PASS: boundary notices — once each, store holds only what fired, prune unconditional"

--- a/tdad_tests/tests/test_layer0_deterministic.py
+++ b/tdad_tests/tests/test_layer0_deterministic.py
@@ -80,6 +80,10 @@ BASH_TEST_SCRIPTS = [
     # Cadence Sentinels S4 — the WIP breach check. RED until S4 ships
     # hooks/scripts/wip-check.sh.
     "test-wip-check",
+    # Cadence Sentinels S3b — the advisory rail. RED until S3b ships
+    # hooks/scripts/lib/advisory-rail.sh.
+    "test-advisory-rail",
+    "test-mast-boundary",
 ]
 
 


### PR DESCRIPTION
Closes #501. The seam three slices deferred into.

- **S3** deferred the Mast's notices and its override — building a note store another slice must consume caused six of its eleven objections.
- **S4** deferred the WIP Warden's override for the same reason: an override worth recording is worth recording once.
- **S2** shipped the Coda without knowing either existed.

So this isn't a feature slice. It's the join.

## The gate found three criticals, and each changed the design

**O1 — the rail was protecting the thing it was built to prevent.**

`reservoir-check.sh` has **no once-per-session guard and cannot have one** — it persists nothing by charter and re-emits every turn while a threshold stays crossed. The Mast's `reached` fires once, ever.

First-claim-wins with the Warden ordered first therefore preserved the message that **repeats** and permanently spent the one designed to arrive **once**. And since the note was still logged on the suppressed turn, the human would never have received the boundary message at all.

The rail now arbitrates by **precedence**: once-only speaks, repeating defers to the turn it's going to get anyway.

**O6 — my own example line was an inference about a person.**

The spec's illustration of what the store may hold read `continued past the 20:00 stop by choice`, timestamped **identically** to the notice — written before the human had done anything.

Nothing observes a choice. Continuing is the absence of stopping, and reading intent into silence is exactly what the counting/watching boundary forbids. The store now records **only what fired**; what you decided is asked for at close, in your words, or not recorded at all.

**O9 — the store was keyed by something its writers can't know.**

Keyed by session id, written by `/coda` and `/wip` — commands, which have no channel to learn one. Re-keyed by repo, which every participant can name.

## Also fixed

- **A lead time replaces the 80% fraction**, which wasn't computable: `started_at` is UTC, `hard_stop_hour` is local, and `started_at` is deliberately never reset across resume — so the notice would have fired every morning with nothing approached.
- **The prune runs unconditionally**, before the opt-in check. Gating the janitor behind the feature meant deleting your pact stranded every note file forever — on the one path where consent had been withdrawn.
- **The notes file gains a heartbeat**, so one lease can both bound the store and preserve the once-per-session notice state.
- **Consumption marks rather than deletes**, because `/coda`'s last step is a statement, not a process ending.

## The rail's race, caught first run

The first implementation cleared a stale claim before claiming. AR5 immediately returned **three winners**: concurrent callers each found no claim, then each deleted the claim a previous one had just won.

Bucketing the claim *name* by time window removes the cleanup step entirely — everyone in a window computes the same name, `mkdir` arbitrates atomically, and an earlier window's claim is simply a name nobody looks at.

## One line in `reservoir-check.sh`

Recorded as a judgement in the spec: **a coordination change, not a behavioural one.** Its proxies, thresholds, honesty flags, recommendation text and advisory-forever standing are all unchanged. It still fires whenever it would have — except on the at most one turn per session when a once-only advisory has spoken.

## Verification

33/33 Layer-0 green. Five mutants killed. The fifth survived at first, because nothing exercised `reservoir-check.sh` itself — MB11 now pins it structurally, and says *why* it's structural rather than pretending otherwise.

Version: 0.70.1 → 0.71.0. No new agent, skill, or command, so component counts are unchanged.