### PR TITLE
Cadence Sentinels S5 — the Convener (/convene)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.71.0",
+  "plugin_version": "0.72.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.71.0"
+      "version": "0.72.0"
     },
     {
       "name": "model-cards",

--- a/.cursor/rules/constraints.mdc
+++ b/.cursor/rules/constraints.mdc
@@ -127,6 +127,13 @@ alwaysApply: true
 - **Tool**: harness-enforcer
 - **Scope**: pr
 
+## PRs have disposed consultation voices
+
+- **Rule**: Every consultation record under `docs/superpowers/consultations/` must have every voice disposed: `consulted` or `deliberately-not-consulted`, each with a one-line `outcome`, and **no two voices in one record may carry the same outcome**. Complete-if-present — a PR whose spec has no consultation record passes, and running `/convene` remains a choice. The check reads the current state of each record chain (`records_latest`), so a `.resolved.md` supersedes its pending predecessor. It never judges a reason: "no time; the docs owner is on leave" passes. It refuses one string standing for several decisions.
+- **Enforcement**: deterministic
+- **Tool**: `ai-literacy-superpowers/scripts/check-consultation-dispositions.py`
+- **Scope**: pr
+
 ## Tests must pass
 
 - **Rule**: The project's test suite must pass with zero failures before any code is merged

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -111,6 +111,10 @@ Every feature or behaviour-change PR must have (a) a spec-mode objection record 
 
 Every non-exempt PR must have either (a) at least one spec in `docs/superpowers/specs/` with a corresponding choice-story record at `docs/superpowers/stories/<spec-slug>.md` whose every story has `disposition` set to one of `accepted`, `revisit`, or `promoted` — no `pending` values; or (b) one of the exempt labels: `bug`, `fix`, `chore`, `maintenance`, `cross-repo`, or a branch prefixed `fix/` or `chore/`. Per-spec exemptions: specs with filename date before 2026-04-27 are exempt; specs with `cartographer: exempt-pre-existing` in their frontmatter are exempt individually. Enforcement: agent (harness-enforcer). Scope: pr.
 
+### PRs have disposed consultation voices
+
+Every consultation record under `docs/superpowers/consultations/` must have every voice disposed: `consulted` or `deliberately-not-consulted`, each with a one-line `outcome`, and **no two voices in one record may carry the same outcome**. Complete-if-present — a PR whose spec has no consultation record passes, and running `/convene` remains a choice. The check reads the current state of each record chain (`records_latest`), so a `.resolved.md` supersedes its pending predecessor. It never judges a reason: "no time; the docs owner is on leave" passes. It refuses one string standing for several decisions. Enforcement: deterministic (`ai-literacy-superpowers/scripts/check-consultation-dispositions.py`). Scope: pr.
+
 ### Tests must pass
 
 The project's test suite must pass with zero failures before any code is merged. Enforcement: unverified. Scope: pr.

--- a/.github/workflows/consultation-disposition-check.yml
+++ b/.github/workflows/consultation-disposition-check.yml
@@ -1,0 +1,49 @@
+# Consultation-record disposition check for pull requests.
+#
+# Enforces the HARNESS constraint "PRs have disposed consultation voices":
+# every voice in a consultation record is `consulted` or
+# `deliberately-not-consulted`, each with its own distinct one-line `outcome`.
+#
+# COMPLETE-IF-PRESENT. A PR whose spec has no consultation record passes, and
+# a repo with no `consultations/` directory passes. Running `/convene` remains
+# a choice. What this catches is the ABANDONED conversation — someone ran it,
+# saw a voice they knew mattered, and shipped without saying either way.
+#
+# The `paths` filter deliberately does NOT include `docs/superpowers/specs/**`.
+# A spec without a record is not a breach, so a spec-only change has nothing
+# here to fail — and a path filter that fired on every spec would imply the
+# constraint requires a record, which it does not.
+#
+# This workflow is what makes `Enforcement: deterministic` true rather than
+# claimed. A constraint declaring an enforcement nothing runs is the drift the
+# harness-auditor exists to find.
+
+name: Consultation Disposition Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "docs/superpowers/consultations/**"
+      - "ai-literacy-superpowers/scripts/check-consultation-dispositions.py"
+      - "ai-literacy-superpowers/hooks/scripts/lib/record-paths.sh"
+      - ".github/workflows/consultation-disposition-check.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check consultation-record dispositions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Verify every consultation voice is disposed
+        run: python3 ai-literacy-superpowers/scripts/check-consultation-dispositions.py

--- a/.windsurf/rules/constraints.md
+++ b/.windsurf/rules/constraints.md
@@ -121,6 +121,13 @@
 - **Tool**: harness-enforcer
 - **Scope**: pr
 
+## PRs have disposed consultation voices
+
+- **Rule**: Every consultation record under `docs/superpowers/consultations/` must have every voice disposed: `consulted` or `deliberately-not-consulted`, each with a one-line `outcome`, and **no two voices in one record may carry the same outcome**. Complete-if-present — a PR whose spec has no consultation record passes, and running `/convene` remains a choice. The check reads the current state of each record chain (`records_latest`), so a `.resolved.md` supersedes its pending predecessor. It never judges a reason: "no time; the docs owner is on leave" passes. It refuses one string standing for several decisions.
+- **Enforcement**: deterministic
+- **Tool**: `ai-literacy-superpowers/scripts/check-consultation-dispositions.py`
+- **Scope**: pr
+
 ## Tests must pass
 
 - **Rule**: The project's test suite must pass with zero failures before any code is merged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,74 @@
 # Changelog
 
+## 0.72.0 — 2026-08-12
+
+### The Convener (Cadence Sentinels S5)
+
+- **New sentinel `convener`** — runs at plan approval beside the
+  `choice-cartographer`. Maps the roles and groups a spec affects, drafts the
+  one concrete question worth asking each, and returns a consultation record.
+  Attacks **isolation drift**: a spec can be internally excellent and still be
+  wrong because the person who wrote it never asked the one question that would
+  have changed it, and that failure is invisible from inside.
+- **It never contacts anyone**, in any medium. The read-only trust boundary
+  forecloses every mechanical path; the charter draws a line against drift —
+  *a question is one sentence a person could answer; a message has a
+  salutation, a context paragraph, or a sign-off*.
+- **New `/convene` command** — dispatches the agent, runs a prune-**and-add**
+  dialogue, and persists the record append-only (`.superseded.md` on re-run,
+  never an in-place edit). Carries an F1–F8 validation checkpoint.
+- **New `convener` skill** — the charter, the question/message line as a worked
+  pair, the derivation table for `inferred` voices, the cap, and the
+  anti-pattern gallery.
+- **New constraint `PRs have disposed consultation voices`** —
+  `Enforcement: deterministic`, matched by
+  `scripts/check-consultation-dispositions.py`. Every voice disposed with its
+  own distinct `outcome`. **Complete-if-present**: a PR whose spec has no
+  consultation record passes, because running `/convene` is a choice.
+- **Optional `## Stakeholders` section** in `HARNESS.md` (and the template,
+  commented out) declares who a project affects. Absent is not an error — the
+  agent derives candidates and flags every one `inferred`.
+- **Orchestrator wired**, not implied: a numbered step beside `1b`, a named
+  soft gate, and a structured `convene_pending_count`.
+- **The Routing Rule is now three-way** across the diaboli, cartographer and
+  convener skills, with the tie-break stated: a finding about a person who
+  should be asked is the Convener's even when it also names a failure class,
+  because the remedy is a conversation rather than a spec change.
+
+### Why outcomes must be distinct
+
+- `pending` is a **detectable** failure. N voices bulk-filled
+  `deliberately-not-consulted / "no time"` is an **undetectable** one, and
+  strictly worse: an all-pending record is truthful about disengagement, while
+  an all-declined one launders it into decisions nobody made — permanently,
+  because records are append-only and the next reader will trust the file.
+- The check never judges a reason. *"No time; shipping Thursday and the docs
+  owner is on leave"* passes. It refuses one string standing for several
+  decisions.
+
+### Substrate and honesty corrections
+
+- **`records_latest` added to `hooks/scripts/lib/record-paths.sh`** (carved
+  commit) — the current state of every record chain. `records_open` excludes
+  `*.resolved.md` by name, and a disposition only ever exists inside one, so
+  the only query S1 shipped could not see the only file that matters.
+- **Consultation records are named `<spec-slug>.md`**, matching the objection
+  and story records, so one spec resolves to one record across all three.
+- **The gate is no longer described as "agent-verified"** — never a value of
+  the enum (`deterministic | agent | unverified`). The **rung** is
+  deterministic and the **reach** is complete-if-present; those are different
+  axes.
+- **All three sentinel rosters reconciled 5 → 9**, narrative sentences
+  included — `README.md`, `sentinel-design/SKILL.md`, and the explanation page.
+  The drift is S2's, S3's and S4's: each updated the explanation page and
+  missed the other two. #507 tracks deriving the roster rather than pinning it.
+
+### Docs
+
+- New how-to: **Convening the voices**.
+- Reference entries on `agents.md`, `skills.md`, `commands.md`, and the
+  corrected `consultation-record-format.md`.
+
 ## 0.71.0 — 2026-08-12
 
 ### Cadence Sentinels S3b — boundary notices and the hard stop

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -270,6 +270,13 @@
 - **Tool**: harness-enforcer
 - **Scope**: pr
 
+### PRs have disposed consultation voices
+
+- **Rule**: Every consultation record under `docs/superpowers/consultations/` must have every voice disposed: `consulted` or `deliberately-not-consulted`, each with a one-line `outcome`, and **no two voices in one record may carry the same outcome**. Complete-if-present — a PR whose spec has no consultation record passes, and running `/convene` remains a choice. The check reads the current state of each record chain (`records_latest`), so a `.resolved.md` supersedes its pending predecessor. It never judges a reason: "no time; the docs owner is on leave" passes. It refuses one string standing for several decisions.
+- **Enforcement**: deterministic
+- **Tool**: `ai-literacy-superpowers/scripts/check-consultation-dispositions.py`
+- **Scope**: pr
+
 ### Tests must pass
 
 - **Rule**: The project's test suite must pass with zero failures before

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.71.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.72.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
-[![Skills](https://img.shields.io/badge/Skills-40-2E8B57?style=flat-square)](#skills-40)
-[![Agents](https://img.shields.io/badge/Agents-19-2E8B57?style=flat-square)](#agents-19)
-[![Commands](https://img.shields.io/badge/Commands-31-2E8B57?style=flat-square)](#commands-31)
+[![Skills](https://img.shields.io/badge/Skills-41-2E8B57?style=flat-square)](#skills-41)
+[![Agents](https://img.shields.io/badge/Agents-20-2E8B57?style=flat-square)](#agents-20)
+[![Commands](https://img.shields.io/badge/Commands-32-2E8B57?style=flat-square)](#commands-32)
 [![Harness](https://img.shields.io/badge/Harness-31%2F32_enforced-4682B4?style=flat-square)](HARNESS.md)
 [![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/2026-07-21-snapshot.md)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.71.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **40 skills, 19 agents, 31 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.72.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **41 skills, 20 agents, 32 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 
@@ -158,7 +158,7 @@ This plugin works with both Claude Code and GitHub Copilot CLI from the same rep
 
 The remaining sections of this README document the **`ai-literacy-superpowers`** plugin in detail. For `model-cards`, see [its README](model-cards/README.md) and [its docs](docs/plugins/model-cards/index.md).
 
-### Skills (40)
+### Skills (41)
 
 Code quality, harness engineering, and governance knowledge that agents read when working in your codebase.
 
@@ -199,7 +199,7 @@ Code quality, harness engineering, and governance knowledge that agents read whe
 | cognitive-reservoir | Watches the human verifier the harness cannot verify — four observable proxies, observed/inferred/asked confidence discipline, disjunctive thresholds, the decide-your-stop-first principle, and the honesty rule separating contested science (ego depletion, hungry judges) from the robust basis (vigilance decrement, switching cost); advisory-only, never a fatigue score |
 | sentinel-design | Defines the sentinel agent category — the three-part signature (S1 read-only, S2 advisory-to-human, S3 explicit honesty rule), the near-miss gallery (why code-reviewer and harness-auditor don't qualify), the honesty-rule-before-detection-logic discipline, and the three anti-patterns (scoring the human, persisting human-state records, gating automatically) |
 
-### Agents (19)
+### Agents (20)
 
 A coordinated team that handles the full development lifecycle. It
 splits into two families: **sentinels**, whose object of care is the
@@ -265,7 +265,7 @@ sentinels** guard the shape of the work around those decisions: the
 | assessor | AI literacy assessment — scans repo, asks questions, applies fixes, recommends workflow changes | Read + Write |
 | governance-auditor | Governance specialist — semantic drift analysis, debt inventory, three-frame alignment | Read + limited Write |
 
-### Commands (31)
+### Commands (32)
 
 | Command | What it does |
 | ------- | ------------ |

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ splits into two families: **sentinels**, whose object of care is the
 human's understanding and judgement, and **pipeline & harness agents**,
 whose object of care is an artefact, the pipeline, or the harness.
 
-#### Sentinels (5)
+#### Sentinels (9)
 
 > **Sentinel** — any agent whose primary purpose is to protect and
 > support the understanding and judgement of the human in the workflow.
@@ -232,7 +232,10 @@ skill for the near-miss gallery and authoring guidance.
 The [decision-discipline triad](docs/plugins/ai-literacy-superpowers/explanation/decision-discipline-triad.md)
 (`carpaccio`, `advocatus-diaboli`, `choice-cartographer`) guards
 *decisions*; the `reservoir-warden` guards *the decider*; the
-`cost-estimator` guards *the decision's inputs*.
+`cost-estimator` guards *the decision's inputs*. The four **cadence
+sentinels** guard the shape of the work around those decisions: the
+`coda` guards *the ending*, the `mast` *the pact*, the `wip-warden`
+*the count*, and the `convener` *the room*.
 
 | Agent | Guards | Role | Trust boundary |
 | ----- | ------ | ---- | -------------- |
@@ -241,6 +244,10 @@ The [decision-discipline triad](docs/plugins/ai-literacy-superpowers/explanation
 | choice-cartographer | Understanding of implicit decisions | Decision-archaeology mapper — runs after spec-mode diaboli dispositions are resolved; emits choice stories (Henney pattern stories) for each material implicit decision; soft gate at plan approval, merge-time HARNESS constraint enforces resolution | Read only |
 | reservoir-warden | The decider | Verifier-watch — counts observable proxies (session span, decision volume, context switches, wall-clock hour) over the recent git window, reports each with an observed/inferred/asked flag, and offers the single decide-your-stop-first recommendation when a threshold is crossed; persists no record of the human's state | Read only (no Write/Edit) |
 | cost-estimator | The decision's inputs | Prospective-cost emitter — reads MODEL_ROUTING.md and the latest observability/costs/ snapshot, applies the cost-estimation methodology, and returns an estimate-record string (token + time ranges, dollar cost only when grounded) for a dispatcher to persist after a human disposes; refuses rather than fabricating an ungroundable estimate | Read only |
+| coda | The ending | Session-close ritual — surfaces what was decided, what is left open, and the next action; parks open threads as append-only records for a later session to resume; returns record content for `/coda` to persist; never records why someone stopped | Read only |
+| mast | The pact | Pact-keeper — recites a limit the person set in clear weather before measuring anything against it, so the recitation cannot be shaped by the moment; refuses to estimate spend it cannot observe; discloses its own check's blind spot; never gates | Read only |
+| wip-warden | The count | Concurrency counter — counts live sessions against a limit the person declared, never inventing one; reports the count's honesty flag; watches sessions, never the human; says plainly that `strict` cannot compel | Read only |
+| convener | The room | Counsel-bringer — runs at plan approval beside the cartographer; maps the roles and groups a spec affects and drafts the one concrete question worth asking each; soft gate at plan approval, complete-if-present merge constraint; **never contacts anyone**, in any medium, ever | Read only |
 
 #### Pipeline & harness agents (11)
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/convener.agent.md
+++ b/ai-literacy-superpowers/agents/convener.agent.md
@@ -1,0 +1,151 @@
+---
+name: convener
+description: Use at plan approval, after spec-mode advocatus-diaboli dispositions are resolved and alongside the choice-cartographer — reads the spec, maps the roles and groups it affects, drafts the one concrete question worth asking each of them, and produces a structured consultation record; never contacts anyone, and the read-only trust boundary enforces the human-cognition gate on dispositions
+tools: [Read, Glob, Grep]
+role: sentinel
+---
+
+# Convener Agent
+
+You are the counsel-bringer in the spec-first pipeline. You read a spec at
+plan approval, map the **voices** it affects — the roles and groups outside
+the room — draft the one concrete question worth asking each of them, and
+return a structured *consultation* record.
+
+You attack **isolation drift**: a spec can be internally excellent and still
+be wrong, because the person who wrote it never asked the one question that
+would have changed it. That failure is invisible from inside, which is why
+the pipeline surfaces you rather than waiting to be asked.
+
+The Diaboli attacks the spec's premises. The Cartographer surfaces the
+decisions it made without noticing. Neither can see the decision that was
+never made *because nobody outside the room was asked*.
+
+## Your first action
+
+Read the `convener` skill:
+
+```text
+ai-literacy-superpowers/skills/convener/SKILL.md
+```
+
+The skill defines your charter, the line you never cross, where voices come
+from, what makes a question worth asking, the Routing Rule, and the output
+format. Follow it exactly.
+
+## You never contact anyone
+
+Not by email, not by issue, not by mention, not by opening a PR against
+another repository, and **not by drafting a message for the human to send
+unedited**.
+
+An agent that contacts a colleague on someone's behalf has spent that
+person's social capital without their knowledge, in their name, and there is
+no undo. The human carries the conversation, or the conversation does not
+happen.
+
+**Where the line is:** a question is one sentence a person could answer. A
+message has a salutation, a context paragraph, or a sign-off — and the moment
+any of those appears, you have crossed. The skill carries the worked
+examples.
+
+## An agent is never a voice
+
+A voice is a **role or a group of people**. Never an agent, never a sentinel,
+never "the reviewer" meaning a model. Listing an agent as a consultable voice
+would let the record show a conversation that never involved a person —
+precisely the isolation you exist to attack, dressed up as its remedy.
+
+Nor is a voice a named individual. Roles outlive the people holding them, and
+a record naming a person ages into a record naming the wrong person.
+
+## Input
+
+You receive a spec file path.
+
+Read the spec in full before naming any voice. Who a change affects is a
+whole-document property: section 3 may change a public error code while only
+section 1 says the surface is public.
+
+Also read these, when they exist:
+
+- **`HARNESS.md`'s `## Stakeholders` section**, if the project declares one.
+  A voice it names is flagged `observed`.
+- The matching diaboli objection record at
+  `docs/superpowers/objections/<spec-slug>.md`, and the choice-story record
+  at `docs/superpowers/stories/<spec-slug>.md`. Use them to apply the
+  three-way Routing Rule.
+- `AGENTS.md` and `REFLECTION_LOG.md`, for prior decisions and surprises that
+  name who was affected last time.
+
+## Trust Boundary
+
+You have **Read, Glob, and Grep only**. You cannot write files. You cannot
+execute shell commands. You cannot modify the spec or any disposition.
+
+This is not a limitation — it is the mechanism. The consultation record must
+be written by `/convene` using content you return in your output message. The
+`disposition` field on every voice cannot be filled by any agent; it can only
+be filled by a human. That constraint **is** the cognitive-engagement gate.
+
+## Reasoning Protocol
+
+Work through these steps in order. Full detail is in the skill.
+
+1. Read the spec end-to-end.
+2. Read `HARNESS.md`'s `## Stakeholders` section, if present.
+3. Derive further candidate voices from the change itself.
+4. Apply the Routing Rule — drop candidates that belong in the objection or
+   story record.
+5. Rank. **Cap at 8. Bias toward 3–5.**
+6. Draft one concrete question per surviving voice.
+7. Flag each voice `observed`, `inferred`, or `asked`.
+8. Return the complete file content, every voice `disposition: pending` and
+   `outcome: null`.
+
+## Honesty flags
+
+Every voice carries a `source_flag` saying how you came by it:
+
+| Flag | Meaning |
+| --- | --- |
+| `observed` | A declared `## Stakeholders` section named it. |
+| `inferred` | You derived it from the change itself. |
+| `asked` | The human named it during the dialogue. |
+
+If a project declares no stakeholder map, say so plainly and flag every voice
+`inferred`. An absent section is **not an error** and produces no warning — it
+produces a shorter, less certain list, honestly labelled. Never present a
+derived voice as a declared one.
+
+## Selectivity is the value
+
+**At most 8 voices. Three to five is the good number.**
+
+The cap is an honesty device aimed at *you*, not an ergonomic concession to
+the human. An uncapped generative agent pads, and from the inside padding is
+indistinguishable from thoroughness.
+
+The asymmetry is what makes it bite: under the merge-time check, a voice you
+propose that the human does not actively delete becomes a mandatory
+disposition. Deleting is cheap and immediate; failing to delete is expensive
+and deferred. Every marginal voice you emit spends someone else's attention
+later.
+
+If after the Routing Rule you have two material voices, emit two. Do not pad.
+
+## Output
+
+Return the complete content of the consultation file as your message — YAML
+frontmatter, a prose body (one `## <Voice>` section per frontmatter entry
+carrying the question and why it is worth asking), and nothing outside of it.
+
+`/convene` writes the content, after the human prunes and adds, to:
+
+```text
+docs/superpowers/consultations/<spec-slug>.md
+```
+
+Do not invent fields, omit required fields, or pre-fill dispositions. The
+format is defined in the skill and in
+`reference/consultation-record-format.md`.

--- a/ai-literacy-superpowers/agents/orchestrator.agent.md
+++ b/ai-literacy-superpowers/agents/orchestrator.agent.md
@@ -140,10 +140,22 @@ message with multiple Agent tool calls.
            "PRs have adjudicated choice stories" is the forcing function;
            the soft gate is an invitation to engage now while context is
            fresh, not a block. Do NOT let any agent write dispositions.
+  1b'. SEQUENTIAL — convener  Alongside 1b, on the same spec at the same
+           moment; produces the consultation record at
+           `docs/superpowers/consultations/<spec-slug>.md`.
+     SOFT GATE: Consultation Surface — surface the record to the user and run
+           the prune-AND-add dialogue. ALLOW progression even if every voice
+           is still `pending`. Emit a structured `convene_pending_count: N`
+           field in the plan-approval summary. The merge-time HARNESS
+           constraint "PRs have disposed consultation voices" is the forcing
+           function, and it is complete-if-present — a PR with no record
+           passes. Do NOT let any agent write dispositions, and the convener
+           NEVER contacts anyone.
      GATE: Plan Approval — once 1a dispositions are resolved (hard) and the
-           choice-story record is surfaced (soft), present the plan summary
-           alongside both adjudicated records and `cartograph_pending_count`;
-           wait for approval.
+           choice-story and consultation records are surfaced (soft), present
+           the plan summary alongside the adjudicated records,
+           `cartograph_pending_count` and `convene_pending_count`; wait for
+           approval.
   1c. SEQUENTIAL — agent-artefact scope detection (no agent dispatch)
            Before dispatching tdd-agent, inspect the plan for any file path
            under `ai-literacy-superpowers/skills/<name>/SKILL.md`,
@@ -443,6 +455,35 @@ Do not inline check definitions here — edits to the validation contract
 live in the reference file so this orchestrator and the
 `/choice-cartograph` command stay in sync.
 
+### Step 5a: Dispatch convener (alongside the cartographer)
+
+Dispatch the convener agent with the spec file path. It reads the spec,
+`HARNESS.md`'s `## Stakeholders` section if the project declares one, and the
+adjudicated objection and story records, then returns the full consultation
+record with every voice `disposition: pending`.
+
+Run the prune-**and-add** dialogue from `/convene` step 4 before writing: show
+the proposed voices with their questions and `source_flag`s, ask which do not
+apply, and ask **who it missed**. A voice the human names is written with
+`source_flag: asked`.
+
+Both directions matter. The agent cannot see an org chart, a long-running
+argument, or the team that got burned by this last quarter — so the
+highest-leverage voice in a session is usually the one it failed to derive,
+and a prune-only dialogue has nowhere to put it.
+
+Write the pruned-and-extended content to
+`docs/superpowers/consultations/<spec-slug>.md`. Records are append-only: if
+one already exists, write `<spec-slug>.superseded.md` naming the prior file in
+`supersedes:` rather than editing in place.
+
+Apply the F1–F8 validation checkpoint defined in `commands/convene.md` step 6,
+fixing deviations in place rather than re-dispatching.
+
+The convener is read-only by tool boundary (Read, Glob, Grep) and **never
+contacts anyone** — not by email, issue, mention, or a message drafted for the
+human to send. The orchestrator writes the file from the returned content.
+
 ### Step 6: Surface the choice-story record (soft gate)
 
 PAUSE and present the choice-story record to the user. Show:
@@ -504,6 +545,9 @@ adjudicated records. Show:
 - **`carpaccio_progressed_slice: S<N>`** — the slice id this plan
   covers; surfaces "this plan covers only slice S2 of 4" so the
   plan review isn't confused about scope.
+- **`convene_pending_count: N`** — the count of consultation voices still
+  `pending`, surfaced as a structured field on the same terms as
+  `cartograph_pending_count`
 - Lens distribution of the choice-story record
 - **Cost estimate (spec-grounded, this slice) — from Step 6a**, a labelled
   block surfaced **alongside** `cartograph_pending_count` as informational
@@ -535,6 +579,13 @@ blocks the PR until choice-story dispositions are resolved. If the user
 chooses Approve with `cartograph_pending_count > 0`, the orchestrator
 proceeds to tdd-agent without further prompting on the cartographer
 state.
+
+`convene_pending_count` follows the **same rule**, with one difference worth
+naming: the Cartographer's merge constraint requires a story record on every
+non-exempt spec, while the Convener's is **complete-if-present** — a PR with no
+consultation record passes. Running `/convene` remains a choice. What the
+constraint catches is the *abandoned* conversation: someone saw a voice they
+knew mattered and shipped without saying either way.
 
 The **cost-estimate block** (Step 6a) is surfaced under the **same rule**:
 informational observability, **not** a separate decision point. It adds no

--- a/ai-literacy-superpowers/commands/convene.md
+++ b/ai-literacy-superpowers/commands/convene.md
@@ -1,0 +1,167 @@
+---
+name: convene
+description: Run the Convener on a spec — maps the roles and groups it affects, drafts the concrete question worth asking each one, and writes the consultation record at docs/superpowers/consultations/<slug>.md; never contacts anyone; use at plan approval alongside /choice-cartograph
+---
+
+# /convene \<spec-path\>
+
+Run the convener agent against a spec file, prune and add voices with the
+human, and write the structured consultation record. Use at plan approval,
+after spec-mode `/diaboli` dispositions are resolved and alongside
+`/choice-cartograph`.
+
+**This command never contacts anyone.** It maps voices and drafts questions.
+The human carries every conversation, or the conversation does not happen.
+
+## When to use
+
+- At plan approval, beside `/choice-cartograph`, on any spec that changes
+  something outside the room — a user-facing surface, a published document, a
+  default, an error message, a behaviour rather than an internal
+- When a spec is substantively edited after a consultation record exists —
+  this writes a `.superseded.md` transition rather than editing in place
+- Never as a substitute for talking to someone
+
+## Process
+
+### 1. Validate input
+
+Confirm the spec file exists at the given path. If not, abort with:
+
+```text
+Error: spec file not found at <path>. Pass a valid path under docs/superpowers/specs/.
+```
+
+### 2. Derive the slug
+
+Strip the date prefix and `.md` extension from the filename — the same
+convention the objection and story records use, so one spec resolves to one
+record across all three.
+
+Example: `docs/superpowers/specs/2026-08-12-retry-semantics-design.md` →
+slug `retry-semantics-design`.
+
+Output path: `docs/superpowers/consultations/<slug>.md`
+
+### 3. Dispatch the convener agent
+
+Pass the spec file path. The agent reads the spec, `HARNESS.md`'s
+`## Stakeholders` section if one exists, and the matching objection and story
+records, then returns the full consultation-record content with every voice
+`disposition: pending`.
+
+Do not pass any prior consultation record — the agent maps fresh.
+
+### 4. Prune **and add**, with the human
+
+Show the proposed voices as a numbered list, each with its question and its
+`source_flag`. Then ask, in one exchange:
+
+```text
+Voices proposed for <slug>:
+
+  1. Support   [inferred]  when this returns the new error code instead of
+                           timing out, does that change what you tell people
+                           who call about it?
+  2. Docs      [observed]  the published reference describes the 30-second
+                           timeout as guaranteed — is that page generated, or
+                           maintained by hand?
+  3. PO        [inferred]  this changes behaviour for existing integrations on
+                           upgrade rather than behind a flag. Fine this
+                           quarter, or does it wait?
+
+Which of these do not apply? (numbers, or "none")
+Who did it miss? (a role or group, or "nobody")
+```
+
+**Both directions, every time.** The prune half is cheap for the human and
+the add half is where the value usually is: the highest-leverage voice in a
+session is typically the one the agent could not derive.
+
+A voice the human names is written with `source_flag: asked`. Ask them for
+the question to put against it; if they would rather not draft one, ask the
+agent to draft one for that voice and keep the flag `asked` — the flag
+records **who named the voice**, not who wrote the question.
+
+Never argue a voice back onto the list. The human knows their organisation
+and the agent does not.
+
+### 5. Write the consultation record
+
+Write the pruned-and-extended content to
+`docs/superpowers/consultations/<slug>.md`.
+
+**Records are append-only.** If a file already exists at that path:
+
+1. Write the new record to `<slug>.md` only if no record exists.
+2. Otherwise write `<slug>.superseded.md` naming the prior file in
+   `supersedes:`, and tell the user which record it replaces.
+
+Never edit an existing record in place, and never delete one. State lives in
+the filename.
+
+### 6. Validation checkpoint
+
+Read back the written file and check:
+
+- **F1** — frontmatter carries `spec`, `date`, `state`, `supersedes`, and a
+  `voices` list. Fix in place from the agent's output if any is missing.
+- **F2** — every voice has `voice`, `source_flag`, `question`,
+  `disposition`, `outcome`.
+- **F3** — every `disposition` is `pending`. A pre-filled disposition is the
+  cognitive-engagement gate defeated; reset it to `pending` and say so.
+- **F4** — every `source_flag` is `observed`, `inferred`, or `asked`, and a
+  voice is flagged `observed` **only** if `HARNESS.md`'s `## Stakeholders`
+  section names it. Downgrade to `inferred` otherwise.
+- **F5** — no voice names an agent, a sentinel, or an individual person.
+  Drop any that does, and say which and why.
+- **F6** — no `question` field carries a salutation, a context paragraph, or
+  a sign-off. A question is one sentence a person could answer. Rewrite in
+  place to the question alone.
+- **F7** — at most 8 voices. If more, keep the highest-ranked 8 per the
+  skill's ranking criteria and tell the user which were dropped.
+- **F8** — the record resolves: `docs/superpowers/specs/<date>-<slug>.md`
+  exists.
+
+Fix deviations **in place**. Do not re-dispatch the agent.
+
+### 7. Present the record to the user
+
+Show:
+
+- Output path, and whether it superseded a prior record
+- Voice count, and the `source_flag` distribution
+- Whether the project declares a `## Stakeholders` section — and if not, say
+  plainly that every voice is `inferred` and the list is therefore shorter
+  and less certain than a declared map would produce
+- A reminder:
+
+```text
+Edit docs/superpowers/consultations/<slug>.md to set each voice's
+disposition to `consulted` or `deliberately-not-consulted`, each with a
+one-line `outcome`.
+
+Both are complete answers. Deciding not to ask someone, for a stated
+reason, is a real decision made deliberately — that is the point.
+
+Each outcome must name something specific to that voice: the merge-time
+check refuses one string standing for several decisions. It never judges
+your reasons.
+
+The plan-approval gate is SOFT — a `convene_pending_count` is surfaced and
+the plan may be approved with every voice still pending. The merge-time
+HARNESS constraint **PRs have disposed consultation voices** is the forcing
+function, and it is complete-if-present: a PR with no consultation record
+passes.
+```
+
+### 8. Suggest next steps
+
+If invoked manually (not via orchestrator):
+
+- Carry the conversations yourself. Then record what came back.
+- Resolving dispositions at plan-approval time is cheaper than at merge time
+  — the context is fresh, and a question asked before implementation can
+  still change the spec.
+- Once disposed, write the `.resolved.md` transition naming the open record
+  in `supersedes:`. Never edit dispositions into the existing file.

--- a/ai-literacy-superpowers/hooks/scripts/lib/record-paths.sh
+++ b/ai-literacy-superpowers/hooks/scripts/lib/record-paths.sh
@@ -58,3 +58,36 @@ records_open() {
     printf '%s\n' "$f"
   done
 }
+
+# records_latest <dir> — the CURRENT state of every record chain, one path per
+# line: the newest file in each supersession chain, transitions included.
+#
+# The complement of records_open, and a genuine gap in the substrate rather
+# than one consumer's special case. `records_open` answers "what is still
+# unresolved" and therefore excludes every transition file by name — which
+# means the one place a disposition ever lives is the one place it cannot see.
+# S5's merge check needed to read dispositions out of `.resolved.md` files and
+# found nothing to read them with.
+#
+# So: for each chain, return the file nothing supersedes. An open record with
+# no successor returns itself; a resolved one returns the `.resolved.md`, not
+# its predecessor.
+records_latest() {
+  local dir="$1" f base superseded
+
+  [ -d "$dir" ] || return 0
+
+  superseded="$(grep -hE '^supersedes:[[:space:]]*[^[:space:]]' "$dir"/*.md 2>/dev/null \
+    | sed -E 's/^supersedes:[[:space:]]*//; s/[[:space:]]+$//' \
+    | grep -v '^null$' || true)"
+
+  for f in "$dir"/*.md; do
+    [ -e "$f" ] || continue
+    base="$(basename "$f")"
+    [ "$base" = "README.md" ] && continue
+    if [ -n "$superseded" ] && printf '%s\n' "$superseded" | grep -qxF "$base"; then
+      continue
+    fi
+    printf '%s\n' "$f"
+  done
+}

--- a/ai-literacy-superpowers/scripts/check-consultation-dispositions.py
+++ b/ai-literacy-superpowers/scripts/check-consultation-dispositions.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Verify every consultation record has disposed each voice it names.
+
+A consultation record (`reference/consultation-record-format.md`) lists the
+voices a spec affects and the question worth asking each one. This check
+enforces the S5 merge-time constraint: **a PR whose spec has a consultation
+record must have no voice left `pending`.** Every voice is either `consulted`
+or `deliberately-not-consulted`, each with its one-line outcome.
+
+COMPLETE-IF-PRESENT, NOT REQUIRED. A spec with no record passes, and a repo
+with no `consultations/` directory passes. Running `/convene` stays a choice.
+The failure worth catching first is the *abandoned* conversation — someone ran
+`/convene`, saw a voice they knew mattered, and shipped without saying either
+way. A project that never convened has made a different mistake, and a merge
+gate is not how you fix it.
+
+WHY OUTCOMES MUST BE DISTINCT. `pending` is a detectable failure. Eight voices
+bulk-filled `deliberately-not-consulted / "no time"` is an undetectable one, and
+it is strictly worse: an all-`pending` record is at least truthful about
+disengagement, while an all-declined one *launders* it into eight deliberate
+decisions nobody made — permanently, because records are append-only and the
+next reader will trust the file.
+
+This never judges a reason. "No time; shipping Thursday and the docs owner is
+on leave" passes, and is honest. What it refuses is one string standing for
+several decisions, so that a bulk-fill costs more than thinking does.
+
+Spec: docs/superpowers/specs/2026-08-12-cadence-sentinels-s5-convener-design.md
+Tests: tdad_tests/layer0_deterministic/test-convene-check.sh (V1-V9)
+No third-party dependencies (CI-friendly).
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import re
+import subprocess
+import sys
+
+CONSULTATIONS = "docs/superpowers/consultations"
+SPECS = "docs/superpowers/specs"
+
+VALID_DISPOSITIONS = {"pending", "consulted", "deliberately-not-consulted"}
+VALID_SOURCE_FLAGS = {"observed", "inferred", "asked"}
+
+# The one library that knows what a `.resolved.md` is.
+RECORD_PATHS_LIB = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "hooks",
+    "scripts",
+    "lib",
+    "record-paths.sh",
+)
+
+
+def latest_records(directory: str) -> list[str]:
+    """The current state of every record chain, via S1's `records_latest`.
+
+    Shelling out rather than re-deriving the walk is deliberate. A disposition
+    only ever exists inside a `.resolved.md` — the append-only rule forbids
+    editing a `disposition:` key in place — and `records_open` excludes those
+    by name, so this check needs the *other* query. Reimplementing it here
+    would make this the second place in the repo that knows what `.resolved.md`
+    means, which is the duplication S1's library exists to prevent.
+    """
+    if not os.path.isdir(directory):
+        return []
+    if not os.path.isfile(RECORD_PATHS_LIB):
+        print(f"::error::record-paths.sh not found at {RECORD_PATHS_LIB}")
+        sys.exit(1)
+    result = subprocess.run(
+        ["bash", "-c", f'. "$1"; records_latest "$2"', "_", RECORD_PATHS_LIB, directory],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        print(f"::error::records_latest failed: {result.stderr.strip()}")
+        sys.exit(1)
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def frontmatter(text: str) -> str | None:
+    """The YAML frontmatter block, or None when there is none to read."""
+    if not text.startswith("---"):
+        return None
+    body = text[3:]
+    end = body.find("\n---")
+    if end == -1:
+        return None
+    return body[:end]
+
+
+def parse_voices(fm: str) -> list[dict[str, str]] | None:
+    """The `voices:` list as dicts, or None when the block is unreadable.
+
+    A deliberately small subset of YAML: a `voices:` key, then list items of
+    `- key: value` followed by `  key: value` lines. Anything outside that
+    shape is reported malformed rather than guessed at — a matcher that cannot
+    parse a record must not report it clean.
+    """
+    lines = fm.splitlines()
+    try:
+        start = next(i for i, ln in enumerate(lines) if re.match(r"^voices:\s*", ln))
+    except StopIteration:
+        return None
+
+    inline = lines[start].split(":", 1)[1].strip()
+    if inline in ("[]", "[ ]"):
+        return []
+    if inline:
+        return None  # a flow-style list is outside the documented shape
+
+    voices: list[dict[str, str]] = []
+    for raw in lines[start + 1 :]:
+        if raw.strip() == "":
+            continue
+        if not raw.startswith(" "):
+            break  # a new top-level key ends the list
+        item = re.match(r"^\s+-\s+(\S+):\s*(.*)$", raw)
+        if item:
+            voices.append({item.group(1): item.group(2).strip()})
+            continue
+        cont = re.match(r"^\s+(\S+):\s*(.*)$", raw)
+        if cont and voices:
+            voices[-1][cont.group(1)] = cont.group(2).strip()
+            continue
+        return None
+    return voices
+
+
+def normalise(outcome: str) -> str:
+    """An outcome reduced to what it actually says.
+
+    Case, surrounding whitespace and trailing punctuation do not make one
+    decision two, so a bulk-fill cannot be disguised by capitalising one of
+    them.
+    """
+    return re.sub(r"\s+", " ", outcome).strip().strip(".;,").lower()
+
+
+def is_empty(value: str) -> bool:
+    return value.strip().strip("\"'") in ("", "null", "~")
+
+
+def spec_for(record_path: str) -> str | None:
+    """The spec a record belongs to, resolved from the record's filename.
+
+    The record is named `<spec-slug>.md` — the spec's filename with its date
+    prefix and extension stripped — matching the objection and story records,
+    so one spec resolves to one record across all three.
+    """
+    base = os.path.basename(record_path)
+    slug = re.sub(r"\.md$", "", base)
+    slug = re.sub(r"\.(resolved|superseded|resumed)$", "", slug)
+    matches = sorted(glob.glob(os.path.join(SPECS, f"[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-{slug}.md")))
+    return matches[0] if matches else None
+
+
+def check_record(path: str) -> list[str]:
+    errors: list[str] = []
+    slug = re.sub(r"\.md$", "", os.path.basename(path))
+
+    with open(path, encoding="utf-8") as handle:
+        text = handle.read()
+
+    fm = frontmatter(text)
+    if fm is None:
+        return ["malformed: no YAML frontmatter — a record that cannot be read "
+                "must not be reported clean"]
+
+    if spec_for(path) is None:
+        errors.append(
+            f"no spec found at {SPECS}/<date>-{slug}.md — an orphan record is "
+            "silently unenforced, which is the drift this check exists to find"
+        )
+
+    voices = parse_voices(fm)
+    if voices is None:
+        return errors + ["malformed: the `voices:` block could not be parsed"]
+
+    seen_outcomes: dict[str, str] = {}
+    for index, voice in enumerate(voices, start=1):
+        name = voice.get("voice", f"<voice {index} has no `voice:` key>")
+
+        flag = voice.get("source_flag", "")
+        if flag.strip().strip("\"'") not in VALID_SOURCE_FLAGS:
+            errors.append(
+                f"voice '{name}': source_flag '{flag}' is not one of "
+                f"{sorted(VALID_SOURCE_FLAGS)}"
+            )
+
+        disposition = voice.get("disposition", "").strip().strip("\"'")
+        if disposition not in VALID_DISPOSITIONS:
+            errors.append(
+                f"voice '{name}': disposition '{disposition}' is not one of "
+                f"{sorted(VALID_DISPOSITIONS)}"
+            )
+            continue
+
+        if disposition == "pending":
+            errors.append(
+                f"voice '{name}' is still pending — consult them, or record "
+                "deliberately-not-consulted with the because"
+            )
+            continue
+
+        outcome = voice.get("outcome", "")
+        if is_empty(outcome):
+            errors.append(
+                f"voice '{name}': {disposition} needs a one-line outcome. The "
+                "because is what makes it a disposition rather than a shrug"
+            )
+            continue
+
+        key = normalise(outcome)
+        if key in seen_outcomes:
+            errors.append(
+                f"voice '{name}' repeats the outcome already given for "
+                f"'{seen_outcomes[key]}' — each outcome must name something "
+                "specific to that voice. One string cannot stand for several "
+                "decisions"
+            )
+        else:
+            seen_outcomes[key] = name
+
+    return errors
+
+
+def main() -> int:
+    records = sorted(latest_records(CONSULTATIONS))
+    failed = False
+    for path in records:
+        for error in check_record(path):
+            print(f"::error file={path}::{error}")
+            failed = True
+
+    if failed:
+        print(
+            "\nConsultation disposition check FAILED. Every voice in a "
+            "consultation record needs a disposition with its own outcome. A "
+            "spec with no record passes — this check is complete-if-present, "
+            "not a requirement to convene."
+        )
+        return 1
+
+    print(f"Consultation disposition check passed ({len(records)} records).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md
+++ b/ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md
@@ -98,24 +98,36 @@ the wrong thing.
 *Example: "The spec says 'update the pipeline diagram' without specifying
 whether the ASCII diagram, the prose description, or both require updating."*
 
-## The Routing Rule (diaboli vs. Choice Cartographer)
+## The Routing Rule (diaboli vs. Cartographer vs. Convener)
 
-When the spec-first pipeline includes both this agent and the Choice
-Cartographer (decision-archaeology agent), apply the Routing Rule before
-emitting any candidate objection:
+When the spec-first pipeline includes this agent alongside the Choice
+Cartographer (decision-archaeology) and the Convener (voice-mapping), apply
+the Routing Rule before emitting any candidate objection:
 
 > A finding belongs in your objection record iff: removing it would leave
 > a class of failures undetected.
 >
 > A finding belongs in the Cartographer's choice-story record iff: removing
-> it would leave a decision unrecorded but no failure undetected.
+> it would leave a decision unrecorded but no failure undetected.>
+> A finding belongs in the **Convener's consultation record** iff: it names a
+> person or group who should be asked something, and the remedy is a
+> conversation rather than a change to the artefact.
 
-When a finding satisfies both tests, it is yours (failures dominate
-decisions for routing purposes); when it satisfies neither, drop it. The
-test is deterministic — apply it explicitly to each candidate before
-considering category fit. The Cartographer's skill references the same
-test from its side; the two agents together form a complete partition
-of findings worth surfacing about a spec.
+When a finding satisfies both the failure and decision tests, it is yours
+(failures dominate decisions for routing purposes); when it satisfies none of
+the three, drop it. The test is deterministic — apply it explicitly to each
+candidate before considering category fit. The Cartographer's and Convener's
+skills reference the same test from their sides; the three agents together
+form a complete partition of findings worth surfacing about a spec.
+
+**The Convener's tie-break runs the other way.** A finding about a person who
+should be asked is the Convener's *even when it also names a failure class*,
+because the remedy is a conversation rather than a spec change. "The docs
+owner should have been asked, and the published page will describe behaviour
+that no longer exists" is both — and it is the Convener's. The objection worth
+raising on it separately is that the spec does not say what happens to the
+docs; only the Convener can name who to ask.
+
 
 Findings that look like "this chose X over Y" without a failure
 implication belong in the Cartographer's record, not yours. Reframe or

--- a/ai-literacy-superpowers/skills/choice-cartographer/SKILL.md
+++ b/ai-literacy-superpowers/skills/choice-cartographer/SKILL.md
@@ -57,7 +57,7 @@ choices is tomorrow's refactor.
 - **Not a code reviewer.** This release is spec-mode only. Code-mode is
   tracked under follow-up issue #209.
 
-## The Routing Rule (Cartographer vs. diaboli)
+## The Routing Rule (Cartographer vs. diaboli vs. Convener)
 
 Apply this test before emitting any candidate:
 
@@ -65,15 +65,34 @@ Apply this test before emitting any candidate:
 > it would leave a decision unrecorded but no failure undetected.
 >
 > A finding belongs in the diaboli's objection record iff: removing it would
-> leave a class of failures undetected.
+> leave a class of failures undetected.>
+> A finding belongs in the **Convener's consultation record** iff: it names a
+> person or group who should be asked something, and the remedy is a
+> conversation rather than a change to the artefact.
 
-When a finding satisfies both tests, it is a diaboli risk (failures dominate
-decisions for routing purposes); when it satisfies neither, drop it. The test
-is deterministic — apply it explicitly to each candidate, and if the routing
-is unclear, default to "drop" rather than emit.
+When a finding satisfies both the failure and decision tests, it is a diaboli
+risk (failures dominate decisions for routing purposes); when it satisfies
+none of the three, drop it. The test is deterministic — apply it explicitly to
+each candidate, and if the routing is unclear, default to "drop" rather than
+emit.
 
-The diaboli skill references the same test from its side. The two agents
-together form a complete partition of findings worth surfacing about a spec.
+The diaboli and convener skills reference the same test from their sides. The
+three agents together form a complete partition of findings worth surfacing
+about a spec.
+
+**The Convener's tie-break runs the other way.** A finding about a person who
+should be asked is the Convener's *even when it also names a failure class*,
+because the remedy is a conversation rather than a spec change. "The docs
+owner should have been asked, and the published page will describe behaviour
+that no longer exists" is both — and it is the Convener's. The objection worth
+raising on it separately is that the spec does not say what happens to the
+docs; only the Convener can name who to ask.
+
+**Why a seventh lens was not the answer.** Folding voice-mapping into the
+Cartographer was weighed and rejected on **object of care**: a choice story
+records a *decision the spec made*, while a voice is a *person the spec
+affects*. Every lens here interrogates the artefact; a seventh would have been
+the first whose subject was not the spec.
 
 ## The Six Lenses
 

--- a/ai-literacy-superpowers/skills/convener/SKILL.md
+++ b/ai-literacy-superpowers/skills/convener/SKILL.md
@@ -133,14 +133,12 @@ Every voice gets **one concrete question worth asking**.
 Not "sync with support". Not "check with the PO". A question a person could
 answer without a meeting:
 
-> **Support:** when this returns the new error code instead of timing out,
-> does that change what you tell people who call about it?
-
-> **Docs:** the published reference describes the 30-second timeout as
-> guaranteed — is that page generated, or maintained by hand?
-
-> **PO:** this changes behaviour for existing integrations on upgrade rather
-> than behind a flag. Is that fine this quarter, or does it need to wait?
+- **Support:** when this returns the new error code instead of timing out,
+  does that change what you tell people who call about it?
+- **Docs:** the published reference describes the 30-second timeout as
+  guaranteed — is that page generated, or maintained by hand?
+- **PO:** this changes behaviour for existing integrations on upgrade rather
+  than behind a flag. Is that fine this quarter, or does it need to wait?
 
 **A vague question is worse than none.** It converts a real gap into a
 scheduled meeting, and the meeting is what makes people stop doing this. Test

--- a/ai-literacy-superpowers/skills/convener/SKILL.md
+++ b/ai-literacy-superpowers/skills/convener/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: convener
+description: Use when mapping the voices a spec affects and drafting the concrete question worth asking each one — the charter, the line the agent never crosses, where voices come from, what makes a question worth asking rather than a meeting worth scheduling, the three-way Routing Rule, and the consultation-record format
+---
+
+# Convener
+
+The counsel-bringer. Maps the voices a spec affects, drafts the actual
+question worth asking each one, and stops.
+
+<!-- evidence: Distributed cognition (Hutchins 1995) locates expertise in the
+system rather than the individual: the support engineer knows the error
+message's call volume, and no amount of reasoning inside the room recovers
+that. Cross-functional consultation is the coordination mechanism, and the
+failure mode the Convener attacks is that it is invisible from inside — the
+absence of a voice leaves no trace in the artefact. -->
+
+## Charter
+
+You do exactly two things:
+
+1. **Map the voices** a spec affects.
+2. **Draft the actual question worth asking each one.**
+
+Then you stop.
+
+You are **not**:
+
+- **Not a contactor.** You never reach anyone, in any medium, ever.
+- **Not a message-drafter.** See "The line", below.
+- **Not exhaustive.** At most 8 voices; three to five is the good number.
+- **Not a disposition-writer.** Every voice ships `disposition: pending`.
+  The human decides.
+- **Not a judge of reasons.** "No time" is a complete disposition and an
+  honest one. You never grade a because.
+- **Not an objection-raiser.** That is the Diaboli's. See the Routing Rule.
+
+## The line you never cross
+
+You never contact anyone: not by email, not by issue, not by mention, not by
+opening a PR against another repository, and **not by drafting a message for
+the human to send unedited**.
+
+The read-only trust boundary already forecloses every *mechanical* path — you
+hold no Write and no Bash. So what remains is **drift**: producing
+progressively more sendable questions until one of them is a message. Drift
+needs a line, not a lock.
+
+**Where the line is:** a question is one sentence a person could answer. A
+message has a **salutation**, a **context paragraph**, or a **sign-off** — and
+the moment any of those appears, you have crossed.
+
+| This is a question | This is a message |
+| --- | --- |
+| when this returns the new error code instead of timing out, does that change what you tell people who call about it? | Hi Support — we're changing the timeout behaviour next sprint. When this returns the new error code instead of timing out, does that change what you tell people who call about it? Thanks! |
+
+Same sentence. The wrapper is the whole difference, and the wrapper is what
+makes it sendable by someone who is not the human whose name is on it.
+
+**Why the line is severe and one-directional.** An agent that contacts a
+colleague on someone's behalf has spent that person's social capital without
+their knowledge, in their name, and there is no undo. The human carries the
+conversation, or the conversation does not happen.
+
+## What a voice is
+
+A voice is a **role or a group of people**.
+
+**Never an agent**, never a sentinel, never "the reviewer" meaning a model.
+Listing an agent as a consultable voice would let the record show a
+conversation that never involved a person — precisely the isolation you exist
+to attack, dressed up as its remedy.
+
+**Never a named individual.** Roles outlive the people holding them, and a
+record naming a person ages into a record naming the wrong person. "Support",
+not "Priya on support".
+
+## Where voices come from
+
+### A declared stakeholder map — `observed`
+
+A project may declare one in `HARNESS.md`:
+
+```markdown
+## Stakeholders
+
+- Support — fields questions about the CLI
+- Docs — owns the published reference
+- PO — disposes behaviour changes
+```
+
+`HARNESS.md` because **who a project affects is a property of the project**.
+That is the same reasoning that sent pacts *out* of `HARNESS.md` and into a
+personal file: a stop hour belongs to a person, a stakeholder map belongs to a
+repo.
+
+A voice named here is flagged **`observed`**.
+
+### Derived from the change — `inferred`
+
+When no section is declared — or when the change reaches past it — derive
+candidates from the change itself and flag every one **`inferred`**:
+
+| Signal in the spec | Candidate voice |
+| --- | --- |
+| A user-facing surface changes | whoever uses that surface |
+| `CODEOWNERS` names an adjacent module | its owners |
+| Behaviour changes rather than internals | the PO or product owner |
+| A published doc page describes the old behaviour | its owner |
+| An error message, exit code, or log line changes | whoever reads them in anger |
+| A default changes for existing users | whoever will be surprised on upgrade |
+
+An absent `## Stakeholders` section is **not an error** and produces no
+warning. It produces a shorter, less certain list, honestly labelled. Say
+plainly that the project declares no stakeholder map.
+
+### Named by the human — `asked`
+
+The dialogue runs in **both directions**: the human prunes voices that do not
+apply, **and adds ones you missed**. A voice the human names is flagged
+**`asked`**.
+
+The add step is not a courtesy. The highest-value voice in any session is
+usually the one you failed to derive — you cannot see an org chart, a
+long-running argument, or the team that got burned by this last quarter. A
+prune-only dialogue reproduces the Convener's own founding failure one level
+up: it asks the human to filter your view instead of contributing theirs.
+
+## A question, not a ping
+
+Every voice gets **one concrete question worth asking**.
+
+Not "sync with support". Not "check with the PO". A question a person could
+answer without a meeting:
+
+> **Support:** when this returns the new error code instead of timing out,
+> does that change what you tell people who call about it?
+
+> **Docs:** the published reference describes the 30-second timeout as
+> guaranteed — is that page generated, or maintained by hand?
+
+> **PO:** this changes behaviour for existing integrations on upgrade rather
+> than behind a flag. Is that fine this quarter, or does it need to wait?
+
+**A vague question is worse than none.** It converts a real gap into a
+scheduled meeting, and the meeting is what makes people stop doing this. Test
+each question by asking: *could someone answer this in one line, in a chat
+thread, without preparing?* If not, it is not yet a question.
+
+Nothing validates the question, because the question is **your** output rather
+than the human's. Writing a good one is your job, and there is nobody to gate
+it. The rubric a reviewer applies is in the spec's §9.2.
+
+## Selectivity — cap at 8, bias 3–5
+
+**At most 8 voices. Three to five is the good number.**
+
+The cap is an honesty device aimed at *you*, not an ergonomic concession to
+the human — the same discipline the Diaboli (12) and the Cartographer (15,
+biasing 5–8) already carry. An uncapped generative agent pads, and from the
+inside padding is indistinguishable from thoroughness.
+
+The asymmetry is what makes it bite. Under the merge-time check, a voice you
+propose that the human does not actively delete becomes a **mandatory
+disposition**. Deleting is cheap and immediate; failing to delete is expensive
+and deferred. Every marginal voice you emit spends someone else's attention
+later.
+
+Rank surviving candidates by:
+
+1. **Voices who hold information the spec cannot recover by reasoning** — the
+   support engineer who knows this error is the one people call about.
+   Highest leverage, least replaceable.
+2. **Voices who own a surface the change silently invalidates** — the docs
+   page, the runbook, the dashboard.
+3. **Voices who dispose rather than inform** — the PO who would have said the
+   change is fine but not this quarter.
+4. **Voices adjacent by ownership** — `CODEOWNERS` on a neighbouring module.
+   Lowest; often already covered by review.
+
+If after the Routing Rule you have two material voices, emit two. Do not pad.
+
+## The Routing Rule (three-way)
+
+Three records now describe one spec, so apply this before emitting any
+candidate:
+
+> A finding belongs in the **diaboli's objection record** iff: removing it
+> would leave a class of failures undetected.
+>
+> A finding belongs in the **Cartographer's choice-story record** iff:
+> removing it would leave a decision unrecorded but no failure undetected.
+>
+> A finding belongs in **your consultation record** iff: it names a person or
+> group who should be asked something, and the remedy is a conversation.
+
+**Tie-break: a finding about a person who should be asked is yours, even when
+it also names a failure class**, because the remedy is a conversation rather
+than a spec change. "The docs owner should have been asked, and the published
+page will describe behaviour that no longer exists" is both — and it is
+yours. The Diaboli can object that the spec does not say what happens to the
+docs; only you can name who to ask.
+
+When a candidate satisfies none of the three, drop it. If routing is unclear,
+default to drop rather than emit.
+
+## Dispositions
+
+Every voice ships `disposition: pending`. The human writes the disposition,
+and there are exactly two complete answers:
+
+- **`consulted`** — with a one-line outcome saying what came back.
+- **`deliberately-not-consulted`** — with a one-line because.
+
+**`deliberately-not-consulted` is not a lesser disposition and must not read
+as one.** Deciding *not* to ask someone, for a stated reason, is a real
+decision made deliberately — which is the entire point. Your value is that the
+choice becomes visible, not that everyone gets consulted.
+
+"The docs page is generated from this file, so the docs owner has nothing to
+decide" is a complete disposition. "No time" is also a complete disposition,
+and an honest one.
+
+**But each outcome must be distinct**, naming something specific to that
+voice. That is a deterministic check at merge time, and it is not the plugin
+judging anyone's reasons — *"no time; shipping Thursday and the docs owner is
+on leave"* passes. What it refuses is one string standing for eight decisions.
+An all-`pending` record is at least truthful about disengagement; an
+all-declined one launders it into decisions nobody made, permanently, in an
+append-only file the next reader will trust.
+
+## Output format
+
+Return the complete file content and nothing else. Frontmatter first:
+
+```yaml
+---
+spec: docs/superpowers/specs/2026-08-12-retry-semantics-design.md
+date: 2026-08-12
+state: open
+supersedes: null
+voices:
+  - voice: Support
+    source_flag: inferred
+    question: when this returns the new error code instead of timing out, does that change what you tell people who call about it?
+    disposition: pending
+    outcome: null
+---
+```
+
+Then a prose body — one `## <Voice>` section per frontmatter entry, carrying
+the question and, in a sentence or two, **why it is worth asking**: what this
+voice knows that the spec cannot recover by reasoning.
+
+State the record's honesty position in the body's opening: whether the project
+declares a `## Stakeholders` section, and therefore whether the list is
+`observed` or `inferred`.
+
+Full field definitions: `reference/consultation-record-format.md`. The record
+is written by `/convene` to `docs/superpowers/consultations/<spec-slug>.md` —
+the spec's filename with its date prefix and extension stripped, matching the
+objection and story records, so one spec resolves to one record across all
+three.
+
+## Anti-patterns
+
+| Anti-pattern | Why it fails |
+| --- | --- |
+| "Sync with support before shipping" | A meeting, not a question. Converts a real gap into calendar time. |
+| Listing `code-reviewer` as a voice | An agent is never a voice. The record would show a conversation with nobody. |
+| "Ask Priya about the docs" | Names a person, not a role. Ages into naming the wrong person. |
+| Drafting "Hi Support — we're changing…" | Over the line. The wrapper is what makes it sendable in the human's name. |
+| Eleven voices "to be thorough" | Padding. Costs someone else a mandatory disposition each. |
+| Flagging a derived voice `observed` | The honesty flag is the whole contract. Never present inference as declaration. |
+| Warning that no `## Stakeholders` section exists | An absent section is not an error. Say so, flag `inferred`, move on. |
+| Pre-filling `disposition: consulted` | The pending field **is** the cognitive-engagement gate. |

--- a/ai-literacy-superpowers/skills/sentinel-design/SKILL.md
+++ b/ai-literacy-superpowers/skills/sentinel-design/SKILL.md
@@ -131,10 +131,16 @@ solid and which are precaution under uncertainty.
 | `choice-cartographer` | Understanding of the implicit decisions a spec has made |
 | `carpaccio` | Judgement scale — keeps each decision small enough to hold |
 | `cost-estimator` | The decision's inputs — what a choice will cost before it is made |
+| `coda` | The ending — that a session stops by decision rather than by attrition |
+| `mast` | The pact — that a limit set in clear weather survives the moment it governs |
+| `wip-warden` | The count — how much is open at once, against a line the person drew |
+| `convener` | The room — that a spec is not decided by everyone it affects being absent |
 
 Narrative: the decision-discipline triad guards *decisions*; the
 reservoir-warden guards *the decider*; the cost-estimator guards *the
-decision's inputs*.
+decision's inputs*. The four cadence sentinels guard the shape of the
+work around those decisions — the `coda` *the ending*, the `mast` *the
+pact*, the `wip-warden` *the count*, and the `convener` *the room*.
 
 ## The near-miss gallery
 

--- a/ai-literacy-superpowers/templates/HARNESS.md
+++ b/ai-literacy-superpowers/templates/HARNESS.md
@@ -36,6 +36,23 @@
 - **Error handling**: {{ERROR_HANDLING}}
 - **Documentation**: {{DOCUMENTATION_STYLE}}
 
+<!-- ## Stakeholders
+
+     OPTIONAL. Who this project affects, as roles or groups — never named
+     individuals, and never agents. The Convener reads this section to map the
+     voices a spec touches, flagging a voice it names `observed` rather than
+     `inferred`.
+
+     Who a project affects is a property of the PROJECT, which is why it lives
+     here rather than in a personal file. Leaving this out is not an error: the
+     Convener derives candidates from the change itself and flags every one
+     `inferred`, producing a shorter, less certain list, honestly labelled.
+
+- Support — fields questions about the CLI
+- Docs — owns the published reference
+- PO — disposes behaviour changes
+-->
+
 ---
 
 ## Constraints
@@ -96,6 +113,27 @@
   still act on it.
 - **Enforcement**: agent
 - **Tool**: harness-enforcer
+- **Scope**: pr
+
+### PRs have disposed consultation voices
+
+- **Rule**: Every consultation record under
+  `docs/superpowers/consultations/` must have every voice disposed:
+  `consulted` or `deliberately-not-consulted`, each with a one-line
+  `outcome`, and **no two voices in one record may carry the same
+  outcome**. Complete-if-present — a PR whose spec has no consultation
+  record passes, and running `/convene` remains a choice. The check reads
+  the current state of each record chain (`records_latest`), so a
+  `.resolved.md` supersedes its pending predecessor.
+
+  It never judges a reason: "no time; the docs owner is on leave" passes.
+  What it refuses is one string standing for several decisions. `pending`
+  is a *detectable* failure; N voices bulk-filled with one outcome is an
+  undetectable one, and worse — an all-pending record is truthful about
+  disengagement, while an all-declined one launders it into decisions
+  nobody made, permanently, in an append-only file.
+- **Enforcement**: deterministic
+- **Tool**: `ai-literacy-superpowers/scripts/check-consultation-dispositions.py`
 - **Scope**: pr
 
 ### Tests must pass

--- a/docs/plugins/ai-literacy-superpowers/explanation/sentinels.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/sentinels.md
@@ -113,13 +113,17 @@ build goes red. S2 and S3 are agent-verifiable via the harness-enforcer.
 | `wip-warden` | The count — how much is open at once, against a line the person drew | Read-only; counts sessions and never watches the human; reports the count's flag; never invents a limit; says plainly that `strict` cannot compel |
 | `coda` | The ending — that a session stops by decision rather than by attrition | Read-only; returns record content for `/coda` to persist; per-item observed/inferred/asked flags; never refuses a next action and never records why someone stopped |
 
+| `convener` | The room — that a spec is not decided by everyone it affects being absent | Read-only; voices disposed at a soft gate; observed/inferred/asked per voice; never contacts anyone and never drafts a message to send |
 The narrative: the decision-discipline triad guards *decisions*; the
 `reservoir-warden` guards *the decider*; the `cost-estimator` guards
 *the decision's inputs*; the `coda` guards *the ending* — that a
 session stops by decision rather than by attrition, and that what was
 left open is written down rather than carried — and the `mast` guards
 *the pact*, so that a limit set in clear weather is still there when the
-weather changes.
+weather changes. The `wip-warden` guards *the count*, and the `convener`
+guards *the room* — a spec can be internally excellent and still be wrong
+because the person who wrote it never asked the one question that would
+have changed it, and that failure is invisible from inside.
 
 ### A second declaration surface: the pact file
 

--- a/docs/plugins/ai-literacy-superpowers/how-to/convening-the-voices.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/convening-the-voices.md
@@ -1,0 +1,184 @@
+# Convening the voices
+
+Map the roles and groups a spec affects, and draft the one question worth
+asking each of them.
+
+`/convene` never contacts anyone. It produces a list and a set of questions;
+you carry the conversations.
+
+## When to run it
+
+At plan approval, beside `/choice-cartograph`, on any spec that changes
+something outside the room:
+
+- a user-facing surface — a CLI flag, an API response, an error message
+- a published document, runbook, or dashboard that describes the old behaviour
+- a default that changes for existing users on upgrade
+- behaviour rather than internals
+
+Run it *before* implementation. A question asked at plan approval can still
+change the spec; the same question asked at merge time can only change a plan
+you have already paid for.
+
+## Declaring who your project affects
+
+Optional, in `HARNESS.md`:
+
+```markdown
+## Stakeholders
+
+- Support — fields questions about the CLI
+- Docs — owns the published reference
+- PO — disposes behaviour changes
+```
+
+It lives in `HARNESS.md` because **who a project affects is a property of the
+project**. That is the same reasoning that keeps personal pacts out of it: a
+stop hour belongs to a person, a stakeholder map belongs to a repo.
+
+Roles or groups only. Never named individuals — roles outlive the people
+holding them, and a record naming a person ages into a record naming the wrong
+person.
+
+**Leaving it out is not an error.** The Convener derives candidates from the
+change itself and flags every one `inferred`, producing a shorter and less
+certain list, honestly labelled. You get no warning and no nag.
+
+## Running it
+
+```bash
+/convene docs/superpowers/specs/2026-08-12-retry-semantics-design.md
+```
+
+You get a proposed list, then a two-part question:
+
+```text
+Voices proposed for retry-semantics-design:
+
+  1. Support   [inferred]  when this returns the new error code instead of
+                           timing out, does that change what you tell people
+                           who call about it?
+  2. Docs      [observed]  the published reference describes the 30-second
+                           timeout as guaranteed — is that page generated, or
+                           maintained by hand?
+  3. PO        [inferred]  this changes behaviour for existing integrations on
+                           upgrade rather than behind a flag. Fine this
+                           quarter, or does it wait?
+
+Which of these do not apply? (numbers, or "none")
+Who did it miss? (a role or group, or "nobody")
+```
+
+**Answer the second question properly.** It is where the value usually is. The
+agent cannot see your org chart, the argument that has been running since
+March, or the team that got burned by this last time — so the highest-leverage
+voice in a session is typically the one it could not derive. A voice you name
+is flagged `asked`.
+
+The flags mean:
+
+| Flag | Meaning |
+| --- | --- |
+| `observed` | Your `## Stakeholders` section named it. |
+| `inferred` | The agent derived it from the change. |
+| `asked` | You named it. |
+
+## What makes a question worth asking
+
+Not "sync with support". A question someone could answer in one line, in a
+chat thread, without preparing:
+
+> **Support:** when this returns the new error code instead of timing out, does
+> that change what you tell people who call about it?
+
+A vague question is **worse than none**: it converts a real gap into a
+scheduled meeting, and the meeting is what makes people stop doing this.
+
+## The line the agent does not cross
+
+A question is one sentence a person could answer. A message has a salutation, a
+context paragraph, or a sign-off.
+
+| A question | A message |
+| --- | --- |
+| when this returns the new error code instead of timing out, does that change what you tell people who call about it? | Hi Support — we're changing the timeout behaviour next sprint. When this returns the new error code instead of timing out, does that change what you tell people who call about it? Thanks! |
+
+Same sentence. The wrapper is the entire difference, and the wrapper is what
+would make it sendable in your name by something that is not you. An agent that
+contacts a colleague on your behalf has spent your social capital without your
+knowledge — and there is no undo.
+
+## Recording what happened
+
+Two dispositions, both complete answers:
+
+```yaml
+  - voice: Support
+    source_flag: inferred
+    question: does the new error code change what you tell callers?
+    disposition: consulted
+    outcome: they want the code in the message body, not just the header
+
+  - voice: Docs
+    source_flag: observed
+    question: is the published reference generated or hand-maintained?
+    disposition: deliberately-not-consulted
+    outcome: the page is generated from this file, so there is nothing to decide
+```
+
+**`deliberately-not-consulted` is not a lesser answer.** Deciding *not* to ask
+someone, for a stated reason, is a real decision made deliberately — which is
+the whole point. The value is that the choice becomes visible, not that
+everyone gets consulted.
+
+"No time" is a complete disposition, and an honest one.
+
+### One rule: each outcome must be distinct
+
+No two voices in one record may carry the same `outcome`. Each must name
+something specific to that voice.
+
+This is not the plugin judging your reasons. *"No time; shipping Thursday and
+the docs owner is on leave"* passes. What it refuses is **one string standing
+for eight decisions**.
+
+The reason is worth knowing. `pending` is a *detectable* failure — the check
+catches it. Eight voices bulk-filled with one line is an *undetectable* one,
+and it is strictly worse: an all-`pending` record is at least truthful about
+disengagement, while an all-declined one launders it into eight deliberate
+decisions nobody made. Records are append-only, so that stays true forever, and
+the next reader will believe it.
+
+### Records are append-only
+
+Never edit dispositions into an existing record. Write the transition:
+
+```text
+docs/superpowers/consultations/retry-semantics-design.md            # open
+docs/superpowers/consultations/retry-semantics-design.resolved.md   # disposed
+```
+
+The `.resolved.md` names its predecessor in `supersedes:` and carries the full
+voice list with dispositions filled in. State lives in the filename.
+
+## The gates
+
+**At plan approval — soft.** A `convene_pending_count` is surfaced and you may
+approve a plan with every voice still `pending`. The record simply says so.
+
+**At merge — deterministic, and complete-if-present.** The constraint **PRs
+have disposed consultation voices** runs
+`scripts/check-consultation-dispositions.py` over the current state of each
+record chain. Every voice must be disposed with its own distinct outcome.
+
+**A PR with no consultation record passes.** Running `/convene` is a choice.
+What the check catches is the *abandoned* conversation — you ran it, saw a
+voice you knew mattered, and shipped without saying either way. A project that
+never convened at all has made a different mistake, and a merge gate is not how
+you fix that one.
+
+## See also
+
+- [Sentinels](../explanation/sentinels.md) — the category and its signature
+- [Consultation record format](../reference/consultation-record-format.md)
+- [`/convene` reference](../reference/commands.md)

--- a/docs/plugins/ai-literacy-superpowers/reference/agents.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/agents.md
@@ -12,7 +12,8 @@ Cutting across those groups is a fourth, cross-cutting family — the
 **[sentinels](../explanation/sentinels.md)**. A sentinel is any agent
 whose object of care is the human's understanding and judgement rather
 than an artefact: `carpaccio`, `advocatus-diaboli`,
-`choice-cartographer`, `reservoir-warden`, `cost-estimator`, `coda`, `mast`, and `wip-warden`. Each
+`choice-cartographer`, `reservoir-warden`, `cost-estimator`, `coda`, `mast`, `wip-warden`, and
+`convener`. Each
 declares `role: sentinel` in its frontmatter, is read-only (criterion
 S1, enforced deterministically by the Sentinel integrity constraint),
 emits advisory output a human disposes (S2), and carries an explicit
@@ -239,6 +240,36 @@ Never invents a limit. A `Session WIP` block with its clause and no
 the human never drew is the worst thing it could do.
 
 See the `wip-warden` skill and [Watching your WIP](../how-to/watching-your-wip.md).
+
+### convener
+
+**Role:** sentinel · **Tools:** Read, Glob, Grep · **Trust boundary:** read-only
+
+Runs at plan approval beside the `choice-cartographer`. Maps the **voices** a
+spec affects — the roles and groups outside the room — drafts the one concrete
+question worth asking each, and returns a consultation record with every voice
+`disposition: pending`.
+
+It attacks **isolation drift**: a spec can be internally excellent and still be
+wrong because the person who wrote it never asked the one question that would
+have changed it. That failure is invisible from inside, which is why the
+pipeline surfaces the agent rather than waiting to be asked.
+
+**It never contacts anyone** — not by email, issue, mention, a PR against
+another repo, or a message drafted for the human to send. The tool boundary
+forecloses every mechanical path already; the charter draws the line against
+drift. *A question is one sentence a person could answer; a message has a
+salutation, a context paragraph, or a sign-off.*
+
+An agent is never a voice, and neither is a named individual. Voices are roles
+or groups: a record naming a person ages into a record naming the wrong person,
+and a record naming an agent shows a conversation that never involved anyone.
+
+Caps at 8 voices, biasing 3–5 — an honesty device aimed at the agent, since
+under the merge check a voice the human does not delete becomes a mandatory
+disposition.
+
+See the `convener` skill and [Convening the voices](../how-to/convening-the-voices.md).
 
 ### cost-estimator
 

--- a/docs/plugins/ai-literacy-superpowers/reference/commands.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/commands.md
@@ -633,6 +633,39 @@ See the `wip-warden` skill and [Watching your WIP](../how-to/watching-your-wip.m
 
 ---
 
+### /convene \<spec-path\>
+
+- **Skills read**: `convener`
+- **Agents dispatched**: `convener`
+
+Maps the roles and groups a spec affects, drafts the one concrete question worth
+asking each, and writes the consultation record at
+`docs/superpowers/consultations/<spec-slug>.md`.
+
+**It never contacts anyone.** You carry every conversation, or the conversation
+does not happen.
+
+The dialogue runs both ways: it asks which proposed voices do not apply, **and
+who it missed**. A voice you name is flagged `asked` — the flag records who
+named the voice, not who wrote the question. The one the agent could not derive
+is usually the one worth the most.
+
+Records are append-only. Re-running against a spec that already has a record
+writes a `.superseded.md` transition rather than editing the existing file.
+
+Two dispositions are complete answers: `consulted` with what came back, and
+`deliberately-not-consulted` with the because. Each needs a one-line `outcome`,
+and **no two voices may share one** — the merge-time check refuses one string
+standing for several decisions, and never judges a reason.
+
+The plan-approval gate is soft. The merge constraint **PRs have disposed
+consultation voices** is deterministic but **complete-if-present**: a PR with no
+consultation record passes, because running `/convene` is a choice.
+
+See the `convener` skill and [Convening the voices](../how-to/convening-the-voices.md).
+
+---
+
 ### /reservoir
 
 - **Skills read**: `cognitive-reservoir`

--- a/docs/plugins/ai-literacy-superpowers/reference/commands.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/commands.md
@@ -633,7 +633,9 @@ See the `wip-warden` skill and [Watching your WIP](../how-to/watching-your-wip.m
 
 ---
 
-### /convene \<spec-path\>
+### /convene
+
+Usage: `/convene <spec-path>`
 
 - **Skills read**: `convener`
 - **Agents dispatched**: `convener`

--- a/docs/plugins/ai-literacy-superpowers/reference/consultation-record-format.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/consultation-record-format.md
@@ -51,6 +51,11 @@ the rule says is immutable.
 `records_open` in `hooks/scripts/lib/record-paths.sh` answers "which
 consultations are still open" from the filenames.
 
+`records_latest` in the same library answers the complementary question —
+**the current state of each chain**, transitions included. Consumers reading
+dispositions need that one: `records_open` excludes `*.resolved.md` by name,
+and a disposition only ever exists inside a `.resolved.md`.
+
 ## Frontmatter
 
 ```yaml
@@ -88,11 +93,28 @@ voices:
 
 ## The gate is soft
 
-At plan approval, unresolved voices are **listed, not blocking**. An
-agent-verified merge-time check flags a spec whose consultation record still
-carries a voice with no disposition. It is never escalated to deterministic
-enforcement.
+At plan approval, unresolved voices are **listed, not blocking**.
+
+At merge time, the constraint **PRs have disposed consultation voices** is
+`Enforcement: deterministic` — a matcher,
+`scripts/check-consultation-dispositions.py`, over the current state of each
+record chain. S1 described this as "agent-verified", which was never a value of
+the enum (`harness-md-format.md` gives `deterministic | agent | unverified`)
+and overclaimed in the other direction too.
+
+**The rung and the reach are different axes.** The rung is deterministic. The
+reach is **complete-if-present**: a PR whose spec has no consultation record
+passes, and running `/convene` remains a choice. What is held back is the scope
+of what the constraint demands, not the rigour of the check.
 
 A voice recorded as `deliberately-not-consulted` with a stated because is a
 complete, healthy disposition — not a debt. The record exists to make the
 decision visible, not to require that everyone be asked.
+
+**But no two voices in one record may carry the same `outcome`.** Each must
+name something specific to that voice. `pending` is a detectable failure;
+several voices bulk-filled with one string is an undetectable one, and worse —
+an all-`pending` record is at least truthful about disengagement, while an
+all-declined one launders it into decisions nobody made, permanently, in a
+file the next reader will trust. The check never judges a reason: *"no time;
+shipping Thursday and the docs owner is on leave"* passes.

--- a/docs/plugins/ai-literacy-superpowers/reference/consultation-record-format.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/consultation-record-format.md
@@ -17,8 +17,15 @@ it consumes.
 ## Filename
 
 ```text
-docs/superpowers/consultations/<YYYY-MM-DD>-<slug>.md
+docs/superpowers/consultations/<spec-slug>.md
 ```
+
+**`<spec-slug>` is the spec's filename with its date prefix and `.md`
+extension stripped** — the same convention the objection and story records use,
+so one spec resolves to one record across all three. Added 2026-08-12: the
+first revision gave `<YYYY-MM-DD>-<slug>.md` without saying what `slug` was or
+how it related to the `spec:` field, which left a consumer unable to answer
+"does this spec have a record" without guessing.
 
 State lives **in the filename**, and a transition writes a new file:
 

--- a/docs/plugins/ai-literacy-superpowers/reference/skills.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/skills.md
@@ -77,6 +77,19 @@ a session, the flag discipline for a count that is never exact, and the reason
 the boundary is **not** machine-enforced — including the worked sentences a
 word-ban would have passed.
 
+### convener
+
+The line between a question and a message — *a question is one sentence a
+person could answer; a message has a salutation, a context paragraph, or a
+sign-off* — shown as a worked pair where the wrapper is the only difference.
+
+Also carries why a voice is a role and never an agent or a person, the
+derivation table for `inferred` voices, the prune-**and-add** dialogue that
+makes S1's third honesty flag `asked` reachable, the cap at 8 biasing 3–5 with
+the merge-time asymmetry that motivates it, the three-way Routing Rule with the
+Convener tie-break, and why `deliberately-not-consulted` is a complete answer
+whose `outcome` must still be distinct.
+
 ### cognitive-reservoir
 
 The shared grounding for the reservoir-warden agent and the reservoir-check Stop hook — the framework's watch on the one actor it cannot verify, the human verifier. Defines the four observable proxies (session span, decision volume, context switches, wall-clock hour), the `observed` / `inferred` / `asked` confidence discipline, the disjunctive default thresholds, the one firm principle (decide your stop before the next session begins), the six-level scaling guidance, and the honesty rule that keeps the contested science (ego depletion, the hungry-judges study) separate from the robust basis (vigilance decrement, task-switching cost). Advisory-only; never a fatigue score, never a gate.

--- a/docs/superpowers/objections/cadence-sentinels-s5-convener-design.md
+++ b/docs/superpowers/objections/cadence-sentinels-s5-convener-design.md
@@ -1,0 +1,119 @@
+---
+spec: docs/superpowers/specs/2026-08-12-cadence-sentinels-s5-convener-design.md
+date: 2026-08-12
+mode: spec
+diaboli_model: claude-opus-5[1m]
+objections:
+  - id: O1
+    category: implementation
+    severity: critical
+    claim: "The merge-time check cannot be built on S1's shipped query surface — dispositions exist only inside .resolved.md files, which records_open excludes by name, so V4 is unreachable and V5's 'its successor is checked' contradicts the only S1 code artefact over consultation records."
+    evidence: "record-paths.sh excludes README.md, *.resumed.md, *.superseded.md and *.resolved.md from records_open. Verified. Since disposing voices writes a .resolved.md, that is the only place a non-pending disposition ever exists — so a spec with a resolved record yields an empty set and passes vacuously."
+    disposition: accepted
+    disposition_rationale: "records_latest is added to S1's record-paths.sh, carved as its own commit with its own scenarios, exactly as the registry_list repair was in S4. S1 built the query for 'what is still open' and never needed 'what is the current state of this record'; that is a genuine gap in the substrate rather than a consumer's special case, and every future consumer gets both queries. Re-deriving the walk inside the check would have been the second place in the repo that knows what .resolved.md means, which is the duplication S1's library exists to prevent."
+  - id: O2
+    category: specification quality
+    severity: high
+    claim: "Section 9.1's 'deterministic even though its enforcement is agent-mediated' does not resolve to a shippable artefact: section 7's file table lists no matcher for test-convene-check.sh to exercise, and if a matcher does ship then 'No deterministic enforcement' and the progressive-hardening argument are both false."
+    evidence: "Every Layer 0 test in this epic asserts its subject is an executable file. check-objection-taxonomy.py is a matcher over records and its HARNESS entry reads Enforcement: deterministic. And 'agent-verified' is not a value of the enum — harness-md-format.md gives deterministic, agent, unverified."
+    disposition: accepted
+    disposition_rationale: "A matcher ships, and the constraint declares Enforcement: deterministic — which is what it is. Calling an LLM applying a rule 'deterministic' because the rule could be matched deterministically is exactly the overclaim this epic keeps catching, and 'agent-verified' was not even a value of the enum. Section 4.1's progressive-hardening argument is corrected rather than defended: the rung is deterministic, the reach is complete-if-present, and those are different axes. A harness that declares an enforcement it does not have is the drift the harness-auditor exists to find."
+  - id: O3
+    category: scope
+    severity: high
+    claim: "Section 3 inserts the Convener into the orchestrator pipeline but section 7 does not list orchestrator.agent.md, and 'No requirement to convene' contradicts a pipeline step — leaving it undecided whether the pipeline changes at all."
+    evidence: "orchestrator.agent.md gives the cartographer a numbered step 1b, a named SOFT GATE, and a structured cartograph_pending_count field that observability tooling reads. None of that transfers by implication, and no sentinel since S1 has claimed a pipeline position."
+    disposition: accepted
+    disposition_rationale: "Wired properly: an orchestrator step, a named soft gate, and a structured convene_pending_count, mirroring step 1b. Section 1's argument is that this failure is invisible from inside — so the people who need the Convener are precisely the people who will not think to run it, and a manual-only command does not address the thing the slice exists for. The non-goal is narrowed to what it meant: the pipeline surfaces it, and a plan may still be approved with every voice pending."
+  - id: O4
+    category: risk
+    severity: high
+    claim: "The gate as designed converts a detectable failure into an undetectable one: pending fails the check, but N voices bulk-filled deliberately-not-consulted / 'no time' pass it, and the spec explicitly blesses that string as complete."
+    evidence: "Section 4.2 blesses 'no time' as a complete disposition and section 8 forbids validating dispositions, while section 4.1 claims the target is the abandoned conversation. An all-declined record asserts N deliberate decisions that were not made, in a committed append-only file the next reader will trust."
+    disposition: accepted
+    disposition_rationale: "Each outcome must be distinct and name something specific to that voice, so a bulk-fill costs more than thinking. This is not the plugin judging anyone's reasons — 'no time; shipping Thursday and the docs owner is on leave' passes and is honest. It is refusing to let one string stand for eight decisions. An all-pending record is at least truthful about disengagement; an all-declined one launders it, and the record is append-only, so the lie is permanent."
+  - id: O5
+    category: implementation
+    severity: high
+    claim: "'No cap' plus 'propose and prune' plus a merge-time gate means the agent's verbosity sets the human's mandatory merge-time workload, and the spec does not engage with why both sibling sentinels cap."
+    evidence: "advocatus-diaboli caps at 12 with a stated justification; choice-cartographer caps at 15 and biases toward 5-8, with 'do not pad'. Under the merge gate, a proposed voice the human does not actively delete becomes a mandatory disposition — so deleting is cheap and failing to delete is expensive and deferred."
+    disposition: accepted
+    disposition_rationale: "Cap at 8, bias toward 3-5, matching the siblings' discipline. Their caps are an honesty device aimed at the AGENT, not an ergonomic concession to the human: an uncapped generative agent pads, and padding is indistinguishable from thoroughness from the inside. The spec was overturning a settled position on two neighbouring components without noticing it was doing so."
+  - id: O6
+    category: specification quality
+    severity: medium
+    claim: "Nothing defines how the check resolves 'the consultation record for this spec' — S1's filename grammar carries a record date and an undefined slug, not the <spec-slug>.md convention the objection and story records use."
+    evidence: "consultation-record-format.md gives <YYYY-MM-DD>-<slug>.md with no statement of what slug is or how it relates to the spec field. The date prefix is the record's date, not the spec's, so the strip-the-date-prefix derivation used by /diaboli and /choice-cartograph does not carry over."
+    disposition: accepted
+    disposition_rationale: "The record is named <spec-slug>.md, matching the objection and story records exactly, and the naming rule is added to S1's format page as part of the carved contract change alongside records_latest. This is the one place the no-contract-change claim did not hold: the schema needed no new field, but the check needed a naming rule the contract never stated."
+  - id: O7
+    category: implementation
+    severity: medium
+    claim: "S1's third honesty flag, asked, is unreachable under S5's prune-only flow — the human who knows a voice the agent missed has no path into the record, which is the isolation the Convener exists to attack."
+    evidence: "Section 5.3 is prune-only and A4 pins two flags. The token asked appears nowhere in S5, while the shipped contract defines it as 'the human named it'. Section 5.3's own rationale is that the human knows their organisation and the agent does not."
+    disposition: accepted
+    disposition_rationale: "The dialogue gains an add step, and a human-named voice is flagged asked. The rationale argued for a two-way exchange and the mechanism delivered a one-way filter — which reproduces the Convener's own founding failure one level up: the highest-value voice in any session is the one the agent failed to derive, and there was nowhere to put it."
+  - id: O8
+    category: scope
+    severity: medium
+    claim: "Adding an active constraint heading to HARNESS.md deterministically fails check-convention-parity.py unless three convention files are updated in the same PR, and the constraint is not added to templates/HARNESS.md as its sibling was."
+    evidence: "check-convention-parity.py requires every active constraint heading to appear in all three convention files. templates/HARNESS.md carries the sibling constraint in full; section 7 lists only the Stakeholders section for the template."
+    disposition: accepted
+    disposition_rationale: "All three convention files and templates/HARNESS.md are updated. The template asymmetry mattered most: an adopting project would have received the declaration surface without the constraint that gives it consequence, which is the opposite of how the sibling shipped."
+  - id: O9
+    category: scope
+    severity: medium
+    claim: "Section 10's 'roster 8 to 9' is true of only one of the three files section 7 names — README.md and sentinel-design/SKILL.md are both still at 5."
+    evidence: "README.md reads '#### Sentinels (5)' with five rows; sentinel-design carries a five-row roster and a narrative sentence naming the old five. Coda, Mast and WIP Warden are absent from both, though all three ship as role: sentinel agents."
+    disposition: accepted
+    disposition_rationale: "All three rosters reconciled to 9 here, including the narrative sentence. The drift is S2's, S3's and S4's — each updated the explanation page and missed the other two surfaces, three slices running. Follow-up filed (#507): a roster is a pinned copy of a derived fact, which agents carry role: sentinel, and the same ARCH_DECISION already caught the README count badges twice in this epic."
+  - id: O10
+    category: specification quality
+    severity: medium
+    claim: "Section 2.3 states that nothing validates the question and A2 states that the question is validated; both cannot hold, and the two readings produce different agent files."
+    evidence: "Section 2.3 says 'nothing validates it... there is nobody to gate'; A2 asserts 'every voice carries a concrete question, not sync with X', which is the phrase 2.3 uses for a bad question."
+    disposition: accepted
+    disposition_rationale: "Section 2.3 wins, and A2 is rewritten as what it always should have been: a rubric a human reviewer applies to the AGENT's output, not a check applied to anyone's words. The distinction matters because S2 built a lexical anchor check and then demoted it from judge to trigger after finding that lexical form does not measure specificity — an implementer reading the old A2 would have rebuilt exactly that defect."
+  - id: O11
+    category: risk
+    severity: medium
+    claim: "The never-draft-a-message guard has no stated test, and the spec's own worked example is simultaneously the question field's required content and a sendable message."
+    evidence: "Section 2.1 forbids drafting a message to send and stakes the guard on there being no undo; section 2 requires drafting the question; the worked example is both. A6 has nothing to assert against."
+    disposition: accepted
+    disposition_rationale: "The skill draws the boundary explicitly: a question is one sentence a person could answer; a message has a salutation, a context paragraph, or a sign-off, and the moment any of those appears the agent has crossed. The read-only boundary forecloses every mechanical path already, so what remained was drift — an agent producing progressively more sendable questions — and drift needs a line, not a lock."
+  - id: O12
+    category: alternatives
+    severity: medium
+    claim: "A seventh Cartographer lens was not weighed against a fourth component, and the new record arrives without extending the documented diaboli/cartographer Routing Rule that currently partitions findings about a spec."
+    evidence: "advocatus-diaboli's skill states that the two agents 'together form a complete partition of findings worth surfacing about a spec'. A finding like 'the docs owner should have been asked, and the published page will describe behaviour that no longer exists' is both a class of undetected failures and a voice — so with three records and a two-way partition it lands in two or neither."
+    disposition: accepted
+    disposition_rationale: "The fold-in is rejected on object of care: a choice story records a decision the spec made, and a voice is a person the spec affects — the Cartographer's lenses all interrogate the artefact, and none of them looks outward. But the Routing Rule half is accepted and acted on: it becomes three-way, with the tie-break stated. A finding about a person who should be asked is the Convener's even when it also names a failure class, because the remedy is a conversation rather than a spec change."
+---
+# Objection record — Cadence Sentinels S5: The Convener (spec mode)
+
+Twelve objections: one critical, four high, seven medium. All accepted.
+
+**Dispatcher verification note (2026-08-12).** Three claims were checked against
+shipped code and all three held. `record-paths.sh` excludes `*.resolved.md`
+from `records_open` by name — and that is the only place a non-`pending`
+disposition ever lives. `harness-md-format.md` gives the enforcement enum as
+`deterministic | agent | unverified`, so **"agent-verified" is not a value**.
+And `README.md` reads `#### Sentinels (5)` with five rows while
+`sentinel-design`'s roster carries the same five — Coda, Mast and WIP Warden
+absent from both, three slices running.
+
+**The claim that mattered most was half true.** §6 said "S5 changes no
+contract", and the schema half is exactly right — every field this writes
+exists, and `outcome` is already documented as required when the disposition is
+`deliberately-not-consulted`, which is V4 verbatim. What the claim missed is
+that a contract has a *query surface* and a *naming rule* as well as a schema,
+and this slice needed both. `records_latest` and the `<spec-slug>.md`
+convention are added to S1 in a carved commit, and §6's claim is narrowed to
+what it can support.
+
+**The pattern this gate names.** For the fourth slice running, the sharpest
+finding traced to something written rather than something built — a docstring
+in S4, an example line in S3b, an enum value here, and a roster that three
+slices updated in one place out of three. A confident sentence is the most
+dangerous artefact in a repository, because every consumer reads it instead of
+the thing it describes.

--- a/docs/superpowers/specs/2026-08-12-cadence-sentinels-s5-convener-design.md
+++ b/docs/superpowers/specs/2026-08-12-cadence-sentinels-s5-convener-design.md
@@ -1,11 +1,13 @@
 # Spec: Cadence Sentinels S5 — The Convener
 
-**Status:** Approved (revision 1)
+**Status:** Approved (revision 2, post-diaboli)
 **Date:** 2026-08-12
 **Issue:** #495
 **Epic:** The Cadence Sentinels (S1–S7)
-**Depends on:** S1 (0.67.0) — the consultation-record contract, already shipped
-and unchanged by this slice
+**Objections:** `docs/superpowers/objections/cadence-sentinels-s5-convener-design.md`
+— 12 objections, all accepted
+**Depends on:** S1 (0.67.0) — the consultation-record contract, extended here
+in a carved commit (§6)
 **Scope:** `ai-literacy-superpowers` plugin; one agent, skill, command, and one
 `HARNESS.md` constraint
 **Explicitly out of scope:** contacting anyone, ever.
@@ -42,6 +44,15 @@ Then it stops.
 Not by email, not by issue, not by mention, not by opening a PR against another
 repository, not by drafting a message for the human to send unedited.
 
+**Where the line is.** A question is one sentence a person could answer. A
+message has a salutation, a context paragraph, or a sign-off — and the moment
+any of those appears, the agent has crossed.
+
+That boundary needs stating because the read-only trust boundary already
+forecloses every *mechanical* path, so what remains is drift: an agent
+producing progressively more sendable questions until one of them is a message.
+Drift needs a line, not a lock (O11).
+
 This is a scope guard rather than a technical limit, and it exists because the
 failure mode is severe and one-directional. An agent that contacts a colleague
 on someone's behalf has spent that person's social capital without their
@@ -75,6 +86,12 @@ question is the *Convener's* output, not the human's. The Coda checks a human's
 words because the human wrote them; here, writing a good question is the
 agent's job, and there is nobody to gate.
 
+A9.2's A2 is therefore a **rubric a human reviewer applies to the agent's
+output**, not a check applied to anyone's words. Revision 1 wrote it as though
+it were a check, which would have had an implementer rebuild exactly the defect
+S2 diagnosed: a lexical matcher for "sync with X", on a property — question
+quality — that lexical form does not measure (O10).
+
 ## 3. Where It Runs
 
 At **plan approval**, after the Diaboli's spec-gate dispositions are resolved
@@ -90,9 +107,25 @@ spec → diaboli spec-gate → convener + cartographer → plan approval → imp
 human may approve a plan with every voice still `pending`; the record simply
 says so.
 
+### 3.1 The pipeline is wired, not implied
+
+`orchestrator.agent.md` gains a numbered step beside the Cartographer's `1b`, a
+named **SOFT GATE**, and a structured `convene_pending_count` field alongside
+`cartograph_pending_count`. None of that transfers by implication (O3).
+
+It has to be wired, because §1's argument is that this failure is *invisible
+from inside*: the people who most need the Convener are precisely the people who
+will not think to run it, and a manual-only command does not address the thing
+the slice exists for.
+
+What the "no requirement to convene" non-goal actually meant is narrower than it
+read — **the pipeline surfaces it; the human may approve a plan with every voice
+still pending**, and the merge check stays complete-if-present.
+
 ## 4. The Merge-Time Check
 
-A `HARNESS.md` constraint, **agent-verified**, scoped to `pr`:
+A `HARNESS.md` constraint, **`Enforcement: deterministic`**, scoped to `pr`,
+matched by `scripts/check-consultation-dispositions.py`:
 
 > A PR whose spec has a consultation record must have **no voice left
 > `pending`**. Every voice is either `consulted` with a one-line outcome, or
@@ -106,11 +139,18 @@ choice.
 This is deliberately weaker than the Cartographer's sibling constraint, which
 *requires* a story record on every non-exempt PR with a spec. Two reasons.
 
-**Progressive hardening.** A new sentinel earns a required step by proving
-useful, not by declaring itself mandatory on the day it ships. The ladder in
-this repo runs Unverified → Agent-verified → deterministic, and skipping rungs
-because the idea feels important is how a harness accumulates constraints
-nobody believes in.
+**Two axes, not one.** Revision 1 called this "agent-verified" and argued it
+was a low rung of progressive hardening. That was wrong twice: `agent-verified`
+is not a value of the enum — `harness-md-format.md` gives `deterministic`,
+`agent`, `unverified` — and a matcher over record frontmatter is plainly the
+first of those. Calling an LLM applying a rule "deterministic" because the rule
+*could* be matched deterministically is the overclaim this epic keeps catching
+(O2).
+
+So the **rung** is deterministic and the **reach** is complete-if-present, and
+those are different things. What is held back is not the rigour of the check
+but the scope of what it demands. A new sentinel earns a required step by
+proving useful, not by declaring itself mandatory on the day it ships.
 
 **The failure worth catching first is the abandoned conversation.** Someone ran
 `/convene`, saw a voice they knew mattered, and shipped without saying either
@@ -134,6 +174,27 @@ choice becomes visible, not that everyone gets consulted.
 The `because` is what carries it: "the docs page is generated from this file,
 so the docs owner has nothing to decide" is a complete disposition. "No time"
 is also a complete disposition, and an honest one.
+
+### 4.3 Each outcome must be distinct
+
+**No two voices in one record may carry the same `outcome`.** Each must name
+something specific to that voice.
+
+Without this, the gate converts a detectable failure into an undetectable one.
+`pending` fails the check — but eight voices bulk-filled
+`deliberately-not-consulted / "no time"` pass it, and revision 1 explicitly
+blessed that string as complete while forbidding any validation of dispositions
+(O4).
+
+An all-`pending` record is at least truthful about disengagement. An
+all-declined one **launders** it: the file now asserts eight deliberate
+decisions that were never made, it is append-only, and the next reader will
+trust it. The lie is permanent.
+
+This is not the plugin judging anyone's reasons. *"No time; shipping Thursday
+and the docs owner is on leave"* passes, and is honest — it is specific to that
+voice. What the rule refuses is **one string standing for eight decisions**, so
+that a bulk-fill costs more than thinking does.
 
 ## 5. Where Voices Come From
 
@@ -177,21 +238,62 @@ same reason: at the moment this runs the human knows their organisation and the
 agent does not, and the cheaper direction is deleting a wrong row rather than
 composing a list from nothing.
 
-There is **no cap** on voices proposed, and one is stated as a non-goal rather
-than left implicit — a cap would silently drop the voice a change most needed,
-and the human can delete faster than they can recall.
+### 5.4 Prune **and add**
+
+The dialogue offers both directions. A voice the human names is written into the
+record and flagged **`asked`**.
+
+Revision 1 was prune-only, and that made S1's third honesty flag unreachable —
+`asked` means "the human named it" and there was nowhere to name one. Worse, it
+reproduced the Convener's own founding failure one level up: §5.3's rationale
+argues for a two-way exchange because the human knows the organisation, and then
+the mechanism delivered a one-way filter. **The highest-value voice in any
+session is the one the agent failed to derive** (O7).
+
+### 5.5 At most eight, and three to five is the good number
+
+The Convener proposes **at most 8 voices, biasing toward 3–5**.
+
+Revision 1 declared "no cap" a non-goal. That overturned a settled position on
+both sibling components without noticing: the Diaboli caps at 12 with a stated
+justification, and the Cartographer caps at 15 while biasing toward 5–8 with an
+explicit *do not pad*.
+
+Their caps are **an honesty device aimed at the agent, not an ergonomic
+concession to the human**. An uncapped generative agent pads, and from the
+inside padding is indistinguishable from thoroughness. Under the merge check the
+asymmetry bites: a proposed voice the human does not actively delete becomes a
+mandatory disposition, so deleting is cheap and immediate while failing to
+delete is expensive and deferred (O5).
 
 ## 6. The Record
 
-**S5 changes no contract.** S1's `reference/consultation-record-format.md`
-already defines everything this writes: `spec`, `date`, `state`,
-`supersedes`, and per voice `voice`, `source_flag`, `question`, `disposition`,
-`outcome`.
+**S5 changes no *schema*.** S1's `reference/consultation-record-format.md`
+already defines every field this writes: `spec`, `date`, `state`, `supersedes`,
+and per voice `voice`, `source_flag`, `question`, `disposition`, `outcome` —
+including that `outcome` is required when the disposition is
+`deliberately-not-consulted`, which is V4 verbatim.
 
-That is worth noting rather than passing over. Every slice since S2 has had to
-carve a contract change out of a neighbour; this one does not, because S1 wrote
-the schema before the consumer existed and got it right. A substrate slice
-paying off looks like a later slice with nothing to say.
+Revision 1 claimed more than that: "S5 changes no contract". A contract has a
+**query surface** and a **naming rule** as well as a schema, and this slice
+needed both (O1, O6). Two things are therefore added to S1, **carved as their
+own commit** with their own scenarios, exactly as the `registry_list` repair was
+in S4:
+
+**`records_latest <dir>`** in `hooks/scripts/lib/record-paths.sh` — the current
+state of every record chain, one path per line, transitions included. S1 built
+`records_open` to answer *what is still outstanding*, and it excludes
+`*.resolved.md` by name. But a disposed voice only ever exists inside a
+`.resolved.md`, so the check as specified in revision 1 would have read an empty
+set for every disposed record and passed it vacuously. Re-deriving the walk
+inside the check would have made it the second place in the repo that knows what
+`.resolved.md` means — the duplication S1's library exists to prevent.
+
+**The naming rule**: a consultation record lives at
+`docs/superpowers/consultations/<spec-slug>.md`, matching the objection and
+story records exactly. S1's grammar gave `<YYYY-MM-DD>-<slug>.md` with the
+record's own date and an undefined slug, so nothing connected a spec to its
+record.
 
 The agent holds no `Write`: it returns record content and `/convene` persists
 it after the human disposes — the `cost-estimator` precedent, and the same
@@ -207,31 +309,34 @@ naming its predecessor in `supersedes`, and no record is ever edited in place.
 | `agents/convener.agent.md` | `role: sentinel`, read-only — maps voices, drafts questions |
 | `skills/convener/SKILL.md` | the scope guard, what a good question is, the anti-patterns |
 | `commands/convene.md` | dispatches, prunes with the human, persists |
-| `HARNESS.md` | the merge-time constraint (§4) |
-| `templates/HARNESS.md` | the optional `Stakeholders` section, commented out |
-| `docs/.../explanation/sentinels.md`, `skills/sentinel-design/SKILL.md`, `README.md` | roster 8 → 9 |
+| `scripts/check-consultation-dispositions.py` | the matcher (§4), over `records_latest` |
+| `agents/orchestrator.agent.md` | the step, the soft gate, `convene_pending_count` (§3.1) |
+| `hooks/scripts/lib/record-paths.sh` | `records_latest` — carved commit (§6) |
+| `reference/consultation-record-format.md` | the `<spec-slug>.md` naming rule — carved commit (§6) |
+| `HARNESS.md` + 3 convention files | the merge-time constraint (§4); parity is enforced |
+| `templates/HARNESS.md` | the `Stakeholders` section **and** the constraint |
+| `skills/advocatus-diaboli/SKILL.md`, `skills/choice-cartographer/SKILL.md` | Routing Rule 2-way → 3-way (§11) |
+| `README.md`, `skills/sentinel-design/SKILL.md`, `docs/.../explanation/sentinels.md` | roster 5 → 9 |
 | `reference/agents.md`, `commands.md`, `skills.md`, `harness-md-format.md` | entries |
 
 ## 8. Non-Goals
 
 - **No contacting anyone**, in any form, including drafting a message to send.
 - **No agent as a voice.**
-- **No cap on voices.** A cap drops the one that mattered.
-- **No validation of the human's dispositions.** `deliberately-not-consulted`
-  with a thin because is still a disposition; the record makes it visible, and
-  visibility is the mechanism.
-- **No contract change.** S1's schema is used as shipped.
-- **No requirement to convene.** §4.1.
-- **No deterministic enforcement.** Agent-verified is the rung this ships at.
+- **No judging anyone's reasons.** "No time; shipping Thursday and the docs
+  owner is on leave" passes, and is honest. What the check refuses is one string
+  standing for eight decisions (§4.3).
+- **No schema change.** S1's fields are used as shipped; the query surface and
+  the naming rule are extended (§6).
+- **No requirement to *have* convened.** A PR with no record passes (§4.1).
+- **No changes to the Reservoir Warden**, and none to the Cartographer's lenses
+  — the fold-in was weighed and rejected (§11).
 
 ## 9. Acceptance Scenarios (TDAD)
 
-Prefixed **V** for the merge-time check and **A** for agent-verified behaviour.
+Prefixed **V** for the matcher and **A** for the review rubric.
 
-### 9.1 The constraint — `tdad_tests/layer0_deterministic/test-convene-check.sh`
-
-The check is a matcher over records, so it is deterministic even though its
-enforcement is agent-mediated.
+### 9.1 The matcher — `tdad_tests/layer0_deterministic/test-convene-check.sh`
 
 - **V1 — no record passes.** A spec with no consultation record is not a
   breach.
@@ -240,18 +345,37 @@ enforcement is agent-mediated.
 - **V3 — a `pending` voice fails**, naming the spec and the voice.
 - **V4 — `deliberately-not-consulted` with no `outcome` fails.** The because is
   what makes it a disposition rather than a shrug.
-- **V5 — a superseded record is not checked**; its successor is.
+- **V5 — a superseded record is not checked**; its successor is, read through
+  `records_latest` rather than `records_open` (§6).
 - **V6 — a malformed record fails loudly** rather than passing by default. A
   matcher that cannot parse a record must not report it clean.
+- **V7 — identical outcomes across voices fail** (§4.3). One string cannot stand
+  for several decisions.
+- **V8 — a record is found by `<spec-slug>.md`** (§6), and a spec with no
+  matching filename is V1, not an error.
 
-### 9.2 Agent-verified
+### 9.2 The review rubric
+
+Applied by a human reviewer to the **agent's** output. These are not checks over
+anyone's words — §2.3 (O10).
 
 - **A1** — every voice is a role or group; no agent appears as a voice.
-- **A2** — every voice carries a concrete question, not "sync with X".
-- **A3** — voices are proposed for the human to prune, not decided alone.
-- **A4** — a derived voice is flagged `inferred`; a declared one `observed`.
+- **A2** — every voice carries a question a person could answer without a
+  meeting, not "sync with X".
+- **A3** — voices are proposed for the human to prune **and add to**, not
+  decided alone (§5.4).
+- **A4** — a declared voice is flagged `observed`, a derived one `inferred`, a
+  human-named one `asked`.
 - **A5** — the agent writes no file.
-- **A6** — nothing is contacted, and no message is drafted for sending.
+- **A6** — nothing is contacted, and nothing crosses §2.1's line: no salutation,
+  no context paragraph, no sign-off.
+- **A7** — at most 8 voices (§5.5).
+
+### 9.3 The carved contract extension
+
+- **C1–C4** in `test-record-paths.sh`: `records_latest` returns the newest file
+  in each supersession chain, skips `README.md`, is empty on a missing
+  directory, and returns a bare record with no successor.
 
 ## 10. Rollout
 
@@ -260,8 +384,35 @@ plugin-table cell, and the README count badges, anchors and headings — 40
 skills → 41, 19 agents → 20, 31 commands → 32.
 
 A TDAD scenario per new component. Docs: a how-to, reference entries on all
-three component pages, the `Stakeholders` section in `harness-md-format.md`,
-and the sentinels roster 8 → 9.
+three component pages, the `Stakeholders` section in `harness-md-format.md`.
+
+**Three rosters, all reconciled to 9 here** — `README.md`'s
+`#### Sentinels (5)` and its five rows, `sentinel-design`'s five-row roster
+*and its narrative sentence*, and the explanation page. The drift is S2's,
+S3's and S4's: each updated the explanation page and missed the other two,
+three slices running (O9). Follow-up filed as **#507** — a roster is a pinned
+copy of a derived fact (which agents carry `role: sentinel`), and the promoted
+`ARCH_DECISION` at `AGENTS.md:481` has already caught the README count badges
+twice in this epic.
 
 No breaking changes. The constraint is new and complete-if-present, so no
 existing PR shape starts failing.
+
+## 11. The Routing Rule Becomes Three-Way
+
+`advocatus-diaboli/SKILL.md` states that the Diaboli and the Cartographer
+"together form a complete partition of findings worth surfacing about a spec".
+A third record arriving without touching that sentence leaves findings landing
+in two places or neither (O12).
+
+A finding like *"the docs owner should have been asked, and the published page
+will describe behaviour that no longer exists"* is simultaneously a class of
+undetected failures and a voice. **Tie-break: it is the Convener's, because the
+remedy is a conversation rather than a spec change.**
+
+### 11.1 Why not a seventh Cartographer lens
+
+Weighed and rejected on **object of care**. A choice story records a *decision
+the spec made*; a voice is a *person the spec affects*. Every Cartographer lens
+interrogates the artefact, and none of them looks outward — a seventh would have
+been the first lens whose subject was not the spec.

--- a/docs/superpowers/specs/2026-08-12-cadence-sentinels-s5-convener-design.md
+++ b/docs/superpowers/specs/2026-08-12-cadence-sentinels-s5-convener-design.md
@@ -1,0 +1,267 @@
+# Spec: Cadence Sentinels S5 — The Convener
+
+**Status:** Approved (revision 1)
+**Date:** 2026-08-12
+**Issue:** #495
+**Epic:** The Cadence Sentinels (S1–S7)
+**Depends on:** S1 (0.67.0) — the consultation-record contract, already shipped
+and unchanged by this slice
+**Scope:** `ai-literacy-superpowers` plugin; one agent, skill, command, and one
+`HARNESS.md` constraint
+**Explicitly out of scope:** contacting anyone, ever.
+
+**Provenance:** *The Second Front — Arc Insertion Remit* (slide S5).
+
+---
+
+## 1. Problem Statement
+
+A spec can be internally excellent and still be wrong, because the person who
+wrote it never asked the one question that would have changed it.
+
+That failure is invisible from inside. The Diaboli attacks the spec's premises;
+the Cartographer surfaces the decisions it made without noticing. Neither can
+see the decision that was never made *because nobody outside the room was
+asked* — the support engineer who knows this error message is the one people
+call about, the person who owns the docs page this silently invalidates, the PO
+who would have said the behaviour change is fine but not this quarter.
+
+**Epithet:** *the counsel-bringer.* **Attacks:** isolation drift.
+
+## 2. What It Does, and the Line It Does Not Cross
+
+The Convener does exactly two things:
+
+1. **Maps the voices** a spec affects.
+2. **Drafts the actual question worth asking each one.**
+
+Then it stops.
+
+### 2.1 It never contacts anyone
+
+Not by email, not by issue, not by mention, not by opening a PR against another
+repository, not by drafting a message for the human to send unedited.
+
+This is a scope guard rather than a technical limit, and it exists because the
+failure mode is severe and one-directional. An agent that contacts a colleague
+on someone's behalf has spent that person's social capital without their
+knowledge, in their name, and there is no undo. The human carries the
+conversation, or the conversation does not happen.
+
+### 2.2 An agent is never a voice
+
+A voice is a **role or a group of people**. Never an agent, never a sentinel,
+never "the reviewer" meaning a model.
+
+Listing an agent as a consultable voice would let the record show a
+conversation that never involved a person, which is precisely the isolation the
+Convener exists to attack — dressed up as its remedy.
+
+### 2.3 A question, not a ping
+
+Every voice gets **one concrete question worth asking**.
+
+Not "sync with support". Not "check with the PO". A question a person could
+answer without a meeting:
+
+> *Support:* when this returns the new error code instead of timing out, does
+> that change what you tell people who call about it?
+
+A vague question is worse than none: it converts a real gap into a scheduled
+meeting, and the meeting is what makes people stop doing this.
+
+**And unlike the Coda's next action, nothing validates it** — because the
+question is the *Convener's* output, not the human's. The Coda checks a human's
+words because the human wrote them; here, writing a good question is the
+agent's job, and there is nobody to gate.
+
+## 3. Where It Runs
+
+At **plan approval**, after the Diaboli's spec-gate dispositions are resolved
+and alongside the Choice Cartographer — mirroring that agent's shape exactly,
+because the two answer adjacent questions about the same spec at the same
+moment.
+
+```text
+spec → diaboli spec-gate → convener + cartographer → plan approval → implement
+```
+
+**Soft at plan approval.** Unresolved voices are *listed*, not blocking. The
+human may approve a plan with every voice still `pending`; the record simply
+says so.
+
+## 4. The Merge-Time Check
+
+A `HARNESS.md` constraint, **agent-verified**, scoped to `pr`:
+
+> A PR whose spec has a consultation record must have **no voice left
+> `pending`**. Every voice is either `consulted` with a one-line outcome, or
+> `deliberately-not-consulted` with the because.
+
+### 4.1 Complete-if-present, not required
+
+A PR with **no** consultation record passes. Running `/convene` remains a
+choice.
+
+This is deliberately weaker than the Cartographer's sibling constraint, which
+*requires* a story record on every non-exempt PR with a spec. Two reasons.
+
+**Progressive hardening.** A new sentinel earns a required step by proving
+useful, not by declaring itself mandatory on the day it ships. The ladder in
+this repo runs Unverified → Agent-verified → deterministic, and skipping rungs
+because the idea feels important is how a harness accumulates constraints
+nobody believes in.
+
+**The failure worth catching first is the abandoned conversation.** Someone ran
+`/convene`, saw a voice they knew mattered, and shipped without saying either
+way. That is a decision made by omission, and it is exactly the shape the
+record exists to make visible. A project that never convened at all has not
+made that mistake — it has made a different one, and a merge gate is not how
+you fix it.
+
+**Promotion is future work, on the record.** If teams run this and the
+undispositioned-voice failure stops occurring, requiring a record is the next
+rung.
+
+### 4.2 `deliberately-not-consulted` is a complete answer
+
+It is not a lesser disposition, and it must not read as one.
+
+Deciding *not* to ask someone, for a stated reason, is a real decision made
+deliberately — which is the entire point. The Convener's value is that the
+choice becomes visible, not that everyone gets consulted.
+
+The `because` is what carries it: "the docs page is generated from this file,
+so the docs owner has nothing to decide" is a complete disposition. "No time"
+is also a complete disposition, and an honest one.
+
+## 5. Where Voices Come From
+
+### 5.1 A declared `Stakeholders` section
+
+Optional, in `HARNESS.md`:
+
+```markdown
+## Stakeholders
+
+- Support — fields questions about the CLI
+- Docs — owns the published reference
+- PO — disposes behaviour changes
+```
+
+`HARNESS.md` because **who a project affects is a property of the project**.
+That is the same reasoning that sent pacts *out* of it in S3, applied in
+reverse: a stop hour belongs to a person, a stakeholder map belongs to a repo.
+
+### 5.2 When it is absent
+
+The Convener derives candidates from the change itself and **flags every one
+`inferred`**:
+
+| Signal | Candidate voice |
+| --- | --- |
+| A user-facing surface changes | whoever uses that surface |
+| `CODEOWNERS` names an adjacent module | its owners |
+| Behaviour changes rather than internals | the PO or product owner |
+| A published doc page describes the old behaviour | its owner |
+
+An absent section is not an error and produces no warning. It produces a
+shorter, less certain list, honestly labelled.
+
+### 5.3 Propose and prune
+
+The Convener proposes voices; the human removes the ones that do not apply.
+
+Same shape as the Mast's tune dialogue and the Coda's thread grouping, for the
+same reason: at the moment this runs the human knows their organisation and the
+agent does not, and the cheaper direction is deleting a wrong row rather than
+composing a list from nothing.
+
+There is **no cap** on voices proposed, and one is stated as a non-goal rather
+than left implicit — a cap would silently drop the voice a change most needed,
+and the human can delete faster than they can recall.
+
+## 6. The Record
+
+**S5 changes no contract.** S1's `reference/consultation-record-format.md`
+already defines everything this writes: `spec`, `date`, `state`,
+`supersedes`, and per voice `voice`, `source_flag`, `question`, `disposition`,
+`outcome`.
+
+That is worth noting rather than passing over. Every slice since S2 has had to
+carve a contract change out of a neighbour; this one does not, because S1 wrote
+the schema before the consumer existed and got it right. A substrate slice
+paying off looks like a later slice with nothing to say.
+
+The agent holds no `Write`: it returns record content and `/convene` persists
+it after the human disposes — the `cost-estimator` precedent, and the same
+split every sentinel in this epic uses.
+
+State lives in the filename, per S1: disposing voices writes a `.resolved.md`
+naming its predecessor in `supersedes`, and no record is ever edited in place.
+
+## 7. Files
+
+| File | Purpose |
+| --- | --- |
+| `agents/convener.agent.md` | `role: sentinel`, read-only — maps voices, drafts questions |
+| `skills/convener/SKILL.md` | the scope guard, what a good question is, the anti-patterns |
+| `commands/convene.md` | dispatches, prunes with the human, persists |
+| `HARNESS.md` | the merge-time constraint (§4) |
+| `templates/HARNESS.md` | the optional `Stakeholders` section, commented out |
+| `docs/.../explanation/sentinels.md`, `skills/sentinel-design/SKILL.md`, `README.md` | roster 8 → 9 |
+| `reference/agents.md`, `commands.md`, `skills.md`, `harness-md-format.md` | entries |
+
+## 8. Non-Goals
+
+- **No contacting anyone**, in any form, including drafting a message to send.
+- **No agent as a voice.**
+- **No cap on voices.** A cap drops the one that mattered.
+- **No validation of the human's dispositions.** `deliberately-not-consulted`
+  with a thin because is still a disposition; the record makes it visible, and
+  visibility is the mechanism.
+- **No contract change.** S1's schema is used as shipped.
+- **No requirement to convene.** §4.1.
+- **No deterministic enforcement.** Agent-verified is the rung this ships at.
+
+## 9. Acceptance Scenarios (TDAD)
+
+Prefixed **V** for the merge-time check and **A** for agent-verified behaviour.
+
+### 9.1 The constraint — `tdad_tests/layer0_deterministic/test-convene-check.sh`
+
+The check is a matcher over records, so it is deterministic even though its
+enforcement is agent-mediated.
+
+- **V1 — no record passes.** A spec with no consultation record is not a
+  breach.
+- **V2 — a fully-dispositioned record passes**, whether voices were
+  `consulted` or `deliberately-not-consulted`.
+- **V3 — a `pending` voice fails**, naming the spec and the voice.
+- **V4 — `deliberately-not-consulted` with no `outcome` fails.** The because is
+  what makes it a disposition rather than a shrug.
+- **V5 — a superseded record is not checked**; its successor is.
+- **V6 — a malformed record fails loudly** rather than passing by default. A
+  matcher that cannot parse a record must not report it clean.
+
+### 9.2 Agent-verified
+
+- **A1** — every voice is a role or group; no agent appears as a voice.
+- **A2** — every voice carries a concrete question, not "sync with X".
+- **A3** — voices are proposed for the human to prune, not decided alone.
+- **A4** — a derived voice is flagged `inferred`; a declared one `observed`.
+- **A5** — the agent writes no file.
+- **A6** — nothing is contacted, and no message is drafted for sending.
+
+## 10. Rollout
+
+Minor bump, 0.71.0 → 0.72.0. Five CI-checked version locations, the README
+plugin-table cell, and the README count badges, anchors and headings — 40
+skills → 41, 19 agents → 20, 31 commands → 32.
+
+A TDAD scenario per new component. Docs: a how-to, reference entries on all
+three component pages, the `Stakeholders` section in `harness-md-format.md`,
+and the sentinels roster 8 → 9.
+
+No breaking changes. The constraint is new and complete-if-present, so no
+existing PR shape starts failing.

--- a/tdad_tests/layer0_deterministic/test-convene-check.sh
+++ b/tdad_tests/layer0_deterministic/test-convene-check.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for the consultation-disposition check
+# (spec 2026-08-12-cadence-sentinels-s5-convener-design.md, §9.1; V1–V8).
+#
+# V5 is the one the spec gate found, and it is why S1 grew a second query.
+# `records_open` excludes `*.resolved.md` BY NAME — and a disposed voice only
+# ever exists inside a `.resolved.md`, because the append-only rule forbids
+# editing a `disposition` key in place. A check built on `records_open` would
+# therefore read an empty set for every fully-disposed record and pass it
+# vacuously: the one query available could not see the one file that matters.
+# So this reads through `records_latest`.
+#
+# V7 is the other half of the design. `pending` is a detectable failure; eight
+# voices bulk-filled `deliberately-not-consulted / "no time"` is an undetectable
+# one, and revision 1 blessed exactly that string while forbidding any check on
+# dispositions. An all-pending record is truthful about disengagement; an
+# all-declined one launders it into eight decisions nobody made — permanently,
+# because the record is append-only and the next reader will trust it.
+#
+# The check never judges a REASON. "No time; shipping Thursday and the docs
+# owner is on leave" passes. It refuses one string standing for eight decisions.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$SCRIPT_DIR/../.."
+CHECK="$ROOT/ai-literacy-superpowers/scripts/check-consultation-dispositions.py"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+[ -f "$CHECK" ] || fail "consultation check not found at $CHECK"
+
+PY=/usr/bin/python3
+command -v "$PY" >/dev/null 2>&1 || PY=python3
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+SPECS="$TMP/docs/superpowers/specs"
+RECS="$TMP/docs/superpowers/consultations"
+mkdir -p "$SPECS" "$RECS"
+
+spec() {  # spec <slug> — a spec file the check will look for a record against
+  printf '# Spec\n' > "$SPECS/2026-08-12-$1-design.md"
+}
+
+run() {
+  set +e
+  OUT="$( cd "$TMP" && "$PY" "$CHECK" 2>&1 )"
+  RC=$?
+  set -e
+}
+
+# --- V1: a spec with no consultation record passes ---------------------------
+# Complete-if-present, not required. Running /convene remains a choice, and a
+# project that never convened has not made the mistake this catches.
+spec retry-semantics
+run
+[ "$RC" -eq 0 ] || fail "V1: a spec with no record must pass (got $RC). Out: $OUT"
+
+# --- V8: the record is found by <spec-slug>.md -------------------------------
+# S1's first grammar gave <YYYY-MM-DD>-<slug>.md carrying the RECORD's date, so
+# nothing connected a spec to its record. The naming rule is now the same one
+# the objection and story records use.
+cat > "$RECS/retry-semantics-design.md" <<'EOF'
+---
+spec: docs/superpowers/specs/2026-08-12-retry-semantics-design.md
+date: 2026-08-12
+state: open
+supersedes: null
+voices:
+  - voice: Support
+    source_flag: inferred
+    question: does the new error code change what you tell callers?
+    disposition: pending
+    outcome: null
+---
+EOF
+run
+[ "$RC" -ne 0 ] || fail "V8: a record at <spec-slug>.md must be found. Out: $OUT"
+echo "$OUT" | grep -qF "retry-semantics" \
+  || fail "V8: the failure must name the spec. Got: $OUT"
+
+# --- V3: a pending voice fails, naming the voice ------------------------------
+echo "$OUT" | grep -qF "Support" || fail "V3: must name the pending voice. Got: $OUT"
+
+# V3b: pending fails even when someone filled in an outcome. `pending` means
+# nobody decided, and an outcome attached to it describes a conversation whose
+# disposition was never recorded — the abandoned conversation exactly.
+cat > "$RECS/retry-semantics-design.md" <<'EOF'
+---
+spec: docs/superpowers/specs/2026-08-12-retry-semantics-design.md
+date: 2026-08-12
+state: open
+supersedes: null
+voices:
+  - voice: Support
+    source_flag: inferred
+    question: does the new error code change what you tell callers?
+    disposition: pending
+    outcome: raised it in standup, waiting to hear back
+---
+EOF
+run
+[ "$RC" -ne 0 ] || fail "V3b: a pending voice must fail even with an outcome. Out: $OUT"
+echo "$OUT" | grep -qi 'pending' \
+  || fail "V3b: the failure must say the voice is pending. Got: $OUT"
+
+# --- V2: a fully-dispositioned record passes ----------------------------------
+# Both dispositions are complete answers. Deciding NOT to ask someone, for a
+# stated reason, is a real decision made deliberately — which is the point.
+cat > "$RECS/retry-semantics-design.md" <<'EOF'
+---
+spec: docs/superpowers/specs/2026-08-12-retry-semantics-design.md
+date: 2026-08-12
+state: open
+supersedes: null
+voices:
+  - voice: Support
+    source_flag: inferred
+    question: does the new error code change what you tell callers?
+    disposition: consulted
+    outcome: they want the code in the message body, not just the header
+  - voice: Docs
+    source_flag: observed
+    question: does the published reference describe the old timeout?
+    disposition: deliberately-not-consulted
+    outcome: the page is generated from this file, so there is nothing to decide
+---
+EOF
+run
+[ "$RC" -eq 0 ] || fail "V2: a fully-dispositioned record must pass. Out: $OUT"
+
+# --- V4: deliberately-not-consulted with no outcome fails ---------------------
+# The because is what makes it a disposition rather than a shrug.
+cat > "$RECS/retry-semantics-design.md" <<'EOF'
+---
+spec: docs/superpowers/specs/2026-08-12-retry-semantics-design.md
+date: 2026-08-12
+state: open
+supersedes: null
+voices:
+  - voice: Docs
+    source_flag: observed
+    question: does the published reference describe the old timeout?
+    disposition: deliberately-not-consulted
+    outcome: null
+---
+EOF
+run
+[ "$RC" -ne 0 ] || fail "V4: declined with no outcome must fail. Out: $OUT"
+echo "$OUT" | grep -qiE 'outcome|because|reason' \
+  || fail "V4: the failure must say the outcome is missing. Got: $OUT"
+
+# --- V7: identical outcomes across voices fail --------------------------------
+# One string cannot stand for several decisions.
+cat > "$RECS/retry-semantics-design.md" <<'EOF'
+---
+spec: docs/superpowers/specs/2026-08-12-retry-semantics-design.md
+date: 2026-08-12
+state: open
+supersedes: null
+voices:
+  - voice: Support
+    source_flag: inferred
+    question: does the new error code change what you tell callers?
+    disposition: deliberately-not-consulted
+    outcome: no time
+  - voice: Docs
+    source_flag: observed
+    question: does the published reference describe the old timeout?
+    disposition: deliberately-not-consulted
+    outcome: no time
+---
+EOF
+run
+[ "$RC" -ne 0 ] || fail "V7: two voices sharing one outcome must fail. Out: $OUT"
+echo "$OUT" | grep -qiE 'same|identical|distinct|repeat' \
+  || fail "V7: the failure must say the outcomes are not distinct. Got: $OUT"
+
+# V7b: a REASON is never judged. Specific-to-the-voice is the whole test.
+cat > "$RECS/retry-semantics-design.md" <<'EOF'
+---
+spec: docs/superpowers/specs/2026-08-12-retry-semantics-design.md
+date: 2026-08-12
+state: open
+supersedes: null
+voices:
+  - voice: Support
+    source_flag: inferred
+    question: does the new error code change what you tell callers?
+    disposition: deliberately-not-consulted
+    outcome: no time; shipping Thursday and support triage is already queued
+  - voice: Docs
+    source_flag: observed
+    question: does the published reference describe the old timeout?
+    disposition: deliberately-not-consulted
+    outcome: no time; the docs owner is on leave until the week after release
+---
+EOF
+run
+[ "$RC" -eq 0 ] || fail "V7b: honest per-voice reasons must pass, however thin. Out: $OUT"
+
+# V7c: capitalising one of them does not make one decision two. Case, spacing
+# and trailing punctuation are not content, and a rule that could be evaded by
+# pressing shift would teach evasion rather than thought.
+cat > "$RECS/retry-semantics-design.md" <<'EOF'
+---
+spec: docs/superpowers/specs/2026-08-12-retry-semantics-design.md
+date: 2026-08-12
+state: open
+supersedes: null
+voices:
+  - voice: Support
+    source_flag: inferred
+    question: does the new error code change what you tell callers?
+    disposition: deliberately-not-consulted
+    outcome: No time.
+  - voice: Docs
+    source_flag: observed
+    question: does the published reference describe the old timeout?
+    disposition: deliberately-not-consulted
+    outcome: no   time
+---
+EOF
+run
+[ "$RC" -ne 0 ] \
+  || fail "V7c: case and spacing must not disguise one string as two. Out: $OUT"
+
+# --- V5: a superseded record is not checked; its successor is -----------------
+# The finding that grew records_latest. The predecessor still carries `pending`
+# on every voice — a check that read it would fail a fully-disposed PR.
+cat > "$RECS/retry-semantics-design.md" <<'EOF'
+---
+spec: docs/superpowers/specs/2026-08-12-retry-semantics-design.md
+date: 2026-08-12
+state: superseded
+supersedes: null
+voices:
+  - voice: Support
+    source_flag: inferred
+    question: does the new error code change what you tell callers?
+    disposition: pending
+    outcome: null
+---
+EOF
+cat > "$RECS/retry-semantics-design.resolved.md" <<'EOF'
+---
+spec: docs/superpowers/specs/2026-08-12-retry-semantics-design.md
+date: 2026-08-12
+state: resolved
+supersedes: retry-semantics-design.md
+voices:
+  - voice: Support
+    source_flag: inferred
+    question: does the new error code change what you tell callers?
+    disposition: consulted
+    outcome: they want the code in the message body, not just the header
+---
+EOF
+run
+[ "$RC" -eq 0 ] \
+  || fail "V5: the resolved successor must be what is checked, not its pending predecessor. Out: $OUT"
+
+# V5b: and the successor's own failures are still caught.
+cat > "$RECS/retry-semantics-design.resolved.md" <<'EOF'
+---
+spec: docs/superpowers/specs/2026-08-12-retry-semantics-design.md
+date: 2026-08-12
+state: resolved
+supersedes: retry-semantics-design.md
+voices:
+  - voice: Support
+    source_flag: inferred
+    question: does the new error code change what you tell callers?
+    disposition: pending
+    outcome: null
+---
+EOF
+run
+[ "$RC" -ne 0 ] || fail "V5b: a pending voice in the successor must still fail. Out: $OUT"
+rm -f "$RECS"/retry-semantics-design*.md
+
+# --- V6: a malformed record fails loudly --------------------------------------
+# A matcher that cannot parse a record must not report it clean. Silence on an
+# unparseable file is the failure mode that makes a green check meaningless.
+printf 'no frontmatter here at all\n' > "$RECS/retry-semantics-design.md"
+run
+[ "$RC" -ne 0 ] || fail "V6: a record with no frontmatter must fail loudly. Out: $OUT"
+echo "$OUT" | grep -qiE 'malformed|could not|cannot|unparse|no frontmatter' \
+  || fail "V6: the failure must say the record could not be read. Got: $OUT"
+
+cat > "$RECS/retry-semantics-design.md" <<'EOF'
+---
+spec: docs/superpowers/specs/2026-08-12-retry-semantics-design.md
+date: 2026-08-12
+state: open
+supersedes: null
+voices:
+  - voice: Support
+    source_flag: inferred
+    question: does the new error code change what you tell callers?
+    disposition: maybe-later
+    outcome: null
+---
+EOF
+run
+[ "$RC" -ne 0 ] || fail "V6b: an off-enum disposition must fail. Out: $OUT"
+rm -f "$RECS"/*.md
+
+# --- V1b: a record with no voices at all is not a breach ----------------------
+# The Convener found nobody, and said so. That is a complete answer.
+cat > "$RECS/retry-semantics-design.md" <<'EOF'
+---
+spec: docs/superpowers/specs/2026-08-12-retry-semantics-design.md
+date: 2026-08-12
+state: open
+supersedes: null
+voices: []
+---
+EOF
+run
+[ "$RC" -eq 0 ] || fail "V1b: an empty voice list must pass. Out: $OUT"
+rm -f "$RECS"/*.md
+
+# --- V1c: no consultations directory at all passes ----------------------------
+# The overwhelming majority of repos. A check that errored here would fail
+# every project that never adopted the Convener.
+rm -rf "$RECS"
+run
+[ "$RC" -eq 0 ] || fail "V1c: an absent consultations directory must pass (got $RC). Out: $OUT"
+mkdir -p "$RECS"
+
+# --- V9: an orphan record — no matching spec — is reported, not ignored -------
+# A record whose spec was renamed or deleted is silently unenforced otherwise,
+# which is the drift the harness-auditor exists to find.
+cat > "$RECS/vanished-design.md" <<'EOF'
+---
+spec: docs/superpowers/specs/2026-08-12-vanished-design.md
+date: 2026-08-12
+state: open
+supersedes: null
+voices:
+  - voice: Support
+    source_flag: inferred
+    question: does anything still call this?
+    disposition: consulted
+    outcome: nothing has called it since the March migration
+---
+EOF
+run
+[ "$RC" -ne 0 ] || fail "V9: a record with no matching spec must be reported. Out: $OUT"
+echo "$OUT" | grep -qiE 'no spec|orphan|missing spec|no matching' \
+  || fail "V9: the failure must say the spec is missing. Got: $OUT"
+
+echo "PASS: consultation dispositions — complete-if-present, reads the successor, refuses one string for many decisions"

--- a/tdad_tests/layer0_deterministic/test-record-contracts.sh
+++ b/tdad_tests/layer0_deterministic/test-record-contracts.sh
@@ -156,4 +156,30 @@ echo "$open_now" | grep -qF "override-example" \
   || fail "P3: an overridden record must still be reported open"
 rm -f "$p2"
 
+# --- C4: records_latest returns the current state of each chain --------------
+# The complement of records_open, and the gap S5's merge check fell into:
+# a disposition only ever exists inside a .resolved.md, and records_open
+# excludes every transition file by name — so the one place a disposition lives
+# was the one place nothing could read.
+declare -F records_latest >/dev/null || fail "C4: lib must define records_latest"
+
+latest=$(records_latest "$FIX" | sort)
+# The resolved successor is current; its predecessor is not.
+echo "$latest" | grep -q "2026-08-02-retry-branch.resumed.md" \
+  || fail "C4: the transition file is the current state of its chain"
+if echo "$latest" | grep -q "2026-08-01-retry-branch.md"; then
+  fail "C4: a superseded predecessor is not current"
+fi
+# A record nothing supersedes returns itself.
+echo "$latest" | grep -q "2026-08-03-parser-rewrite.md" \
+  || fail "C4: an unsuperseded record is its own current state"
+
+# --- C5: records_open and records_latest answer different questions ----------
+# Stating the complement explicitly, because conflating them is what the S5
+# gate did: open excludes transitions, latest includes them.
+open_now=$(records_open "$FIX" | sort)
+if [ "$open_now" = "$latest" ]; then
+  fail "C5: records_open and records_latest must not be the same set here"
+fi
+
 echo "PASS: record contracts — schemas published in reference pages, READMEs point not duplicate, open-record glob honours state-in-the-path"

--- a/tdad_tests/scenarios/agents/convener/never-contacts-anyone.md
+++ b/tdad_tests/scenarios/agents/convener/never-contacts-anyone.md
@@ -1,0 +1,55 @@
+---
+component: convener
+component_type: agent
+tier: structural
+---
+
+# Scenario: the Convener never contacts anyone, and never drafts a message
+
+## Given
+
+The read-only trust boundary already forecloses every **mechanical** path to
+contacting someone: the agent holds `Read, Glob, Grep` and no `Bash`, so it
+cannot send mail, open an issue, or push a branch.
+
+What remains is **drift** — an agent producing progressively more sendable
+questions until one of them is a message. Drift needs a line, not a lock, and
+no script can draw it: a matcher for "Hi" would fail on the word appearing
+anywhere, and one for a sign-off cannot tell a drafted message from a charter
+that names sign-offs in the sentence forbidding them. That is the same
+distinction that moved S4's write-surface check from mentions to sources.
+
+The failure is severe and one-directional. An agent that contacts a colleague
+on someone's behalf has spent that person's social capital without their
+knowledge, in their name, and there is no undo.
+
+## When
+
+`ai-literacy-superpowers/agents/convener.agent.md` is read from the filesystem.
+
+## Then
+
+**Frontmatter:** `name: convener`, non-empty description, `role: sentinel`,
+`tools` exactly `Read, Glob, Grep` — no `Write`, no `Edit`, no `Bash`.
+
+**Charter:**
+
+- States that it never contacts anyone: not by email, issue, mention, or a PR
+  against another repository, **and not by drafting a message for the human to
+  send unedited**.
+- States **where the line is** — a question is one sentence a person could
+  answer; a message has a salutation, a context paragraph, or a sign-off.
+- States the reason the line is severe: social capital spent in someone's name,
+  with no undo.
+- States that an agent is never a voice, **with the reason** — the record would
+  show a conversation that never involved a person, which is the isolation the
+  Convener attacks, dressed as its remedy.
+- States that a voice is a role or group, never a named individual.
+- Caps voices at 8, biasing 3–5, and states the cap is an honesty device aimed
+  at the agent rather than an ergonomic concession to the human.
+- Carries all three honesty flags — `observed`, `inferred`, `asked` — with
+  `asked` meaning the human named the voice.
+- States that an absent `## Stakeholders` section is **not an error** and
+  produces no warning.
+- States that every voice is returned `disposition: pending`, and that the
+  agent writes no file — `/convene` persists after the human disposes.

--- a/tdad_tests/scenarios/commands/convene/prunes-adds-and-supersedes.md
+++ b/tdad_tests/scenarios/commands/convene/prunes-adds-and-supersedes.md
@@ -1,0 +1,49 @@
+---
+component: convene
+component_type: command
+tier: structural
+---
+
+# Scenario: /convene prunes and adds, then supersedes rather than edits
+
+## Given
+
+Records are append-only (constitutional constraint 7), and the consultation
+record's state lives in its filename. A command that "updates" an existing
+record by editing frontmatter would violate the rule while appearing to honour
+it — the same contradiction that put state in the path in S1.
+
+The validation checkpoint is required by CLAUDE.md for every command writing
+structured markdown a downstream consumer parses. Here the downstream consumer
+is a deterministic merge-time check, so a malformed record is not a cosmetic
+problem: it fails CI on a file the human cannot easily see is wrong.
+
+## When
+
+`ai-literacy-superpowers/commands/convene.md` is read from the filesystem.
+
+## Then
+
+**Frontmatter:** `name: convene`, non-empty description that states it never
+contacts anyone.
+
+**Process:**
+
+- Derives the slug by stripping the date prefix and `.md`, and names the output
+  `docs/superpowers/consultations/<slug>.md`.
+- Runs the prune-**and-add** dialogue in one exchange, asking both "which do not
+  apply" and "who did it miss".
+- States that a human-named voice is written `source_flag: asked`, and that the
+  flag records **who named the voice**, not who wrote the question.
+- Writes `<slug>.superseded.md` naming the prior record in `supersedes:` when a
+  record already exists — never edits in place, never deletes.
+- Carries a **validation checkpoint** with checks F1–F8, each with a
+  fix-in-place recipe, including: every disposition reset to `pending`,
+  `observed` downgraded to `inferred` unless `HARNESS.md` declares the voice,
+  agents and named individuals dropped, salutations and sign-offs rewritten out
+  of the `question` field, and the 8-voice cap applied.
+- States the checkpoint fixes in place and does **not** re-dispatch the agent.
+- Tells the user whether the project declares a `## Stakeholders` section, and
+  says plainly when it does not that every voice is therefore `inferred`.
+- States the plan-approval gate is soft and the merge constraint is
+  complete-if-present.

--- a/tdad_tests/scenarios/skills/convener/question-not-a-ping.md
+++ b/tdad_tests/scenarios/skills/convener/question-not-a-ping.md
@@ -1,0 +1,56 @@
+---
+component: convener
+component_type: skill
+tier: structural
+---
+
+# Scenario: the skill draws the question/message line and the prune-and-add loop
+
+## Given
+
+Two failures this skill exists to prevent are invisible to any matcher.
+
+**The vague question.** "Sync with support" converts a real gap into a
+scheduled meeting, and the meeting is what makes people stop doing this. S2
+built a lexical anchor check for exactly this shape and then demoted it from
+judge to trigger, because lexical form does not measure specificity. So the
+skill teaches the property and shows worked examples rather than shipping a
+matcher that would grade the wrong thing.
+
+**The one-way dialogue.** A prune-only flow asks the human to narrow the
+agent's view instead of contributing their own — which reproduces the
+Convener's founding failure one level up, and leaves S1's third honesty flag
+`asked` with nothing to attach to. The highest-value voice in a session is
+usually the one the agent could not derive.
+
+## When
+
+`ai-literacy-superpowers/skills/convener/SKILL.md` is read from the filesystem.
+
+## Then
+
+**Frontmatter:** `name: convener`, non-empty description.
+
+**Content:**
+
+- Carries an `<!-- evidence: ... -->` comment grounding the design.
+- Shows the question/message line as a **side-by-side worked pair** — the same
+  sentence, once bare and once wrapped — and names the wrapper as the whole
+  difference.
+- Gives at least three worked questions, each answerable in one line without
+  preparation, and names that test explicitly.
+- States that nothing validates the question, **with the reason**: the question
+  is the agent's output rather than the human's, so there is nobody to gate.
+- Describes the dialogue as running in **both directions**, and states that a
+  human-named voice is flagged `asked`.
+- Gives the derivation table for `inferred` voices and states that an absent
+  stakeholder map is not an error.
+- Caps at 8, biases 3–5, and states the merge-time asymmetry: deleting is cheap
+  and immediate, failing to delete is expensive and deferred.
+- Carries the **three-way** Routing Rule with the Convener tie-break stated.
+- States that `deliberately-not-consulted` is a complete answer and must not
+  read as a lesser one.
+- States that outcomes must be **distinct**, and that the check never judges a
+  reason.
+- Carries an anti-pattern table including the vague ping, the agent-as-voice,
+  the named individual, and the drafted message.

--- a/tdad_tests/tests/test_layer0_deterministic.py
+++ b/tdad_tests/tests/test_layer0_deterministic.py
@@ -84,6 +84,9 @@ BASH_TEST_SCRIPTS = [
     # hooks/scripts/lib/advisory-rail.sh.
     "test-advisory-rail",
     "test-mast-boundary",
+    # Cadence Sentinels S5 — the consultation-disposition matcher. RED until
+    # S5 ships scripts/check-consultation-dispositions.py.
+    "test-convene-check",
 ]
 
 


### PR DESCRIPTION
Closes #495. Slice S5 of the Cadence Sentinels epic.

The **Convener** maps the roles and groups a spec affects, drafts the one
concrete question worth asking each, and stops. It attacks **isolation
drift**: a spec can be internally excellent and still be wrong because the
person who wrote it never asked the one question that would have changed it —
and that failure is invisible from inside, which is why the pipeline surfaces
it rather than waiting to be asked.

## The line

It never contacts anyone, in any medium. The read-only trust boundary
(`Read, Glob, Grep`, no `Bash`) forecloses every mechanical path already, so
what the charter adds is a line against **drift**:

> A question is one sentence a person could answer. A message has a
> salutation, a context paragraph, or a sign-off — and the moment any of those
> appears, the agent has crossed.

No script can draw that line: a matcher for a sign-off cannot tell a drafted
message from a charter naming sign-offs in the sentence forbidding them. Same
distinction that moved S4's write-surface check from mentions to sources. A
TDAD scenario holds it instead.

## Spec gate — 12 objections, all accepted

`docs/superpowers/objections/cadence-sentinels-s5-convener-design.md`. Three
claims were verified against shipped code before disposition; all three held.
The four that changed the slice most:

**O2 — the enforcement rung.** Revision 1 declared the constraint
"agent-verified", which **is not a value of the enum** (`harness-md-format.md`
gives `deterministic | agent | unverified`), and argued for it on progressive
hardening. Both halves were wrong. A matcher ships, the constraint declares
`Enforcement: deterministic`, and the spec now separates two axes revision 1
conflated: the **rung** (deterministic) and the **reach**
(complete-if-present). Calling an LLM applying a rule "deterministic" because
the rule *could* be matched deterministically is the overclaim this epic keeps
catching.

**O1 — the check could not have been built.** A disposition only ever exists
inside a `.resolved.md` (the append-only rule forbids editing a `disposition:`
key), and `records_open` excludes those **by name**. The check as specified
would have read an empty set for every disposed record and passed it
vacuously. `records_latest` is added to S1's `record-paths.sh` in a **carved
commit** (`33d824d`) with its own scenarios — the same treatment the
`registry_list` repair got in S4.

**O4 — the gate converted a detectable failure into an undetectable one.**
`pending` fails the check; eight voices bulk-filled
`deliberately-not-consulted / "no time"` passed it, and revision 1 explicitly
blessed that string while forbidding any check on dispositions. Outcomes must
now be **distinct**. An all-`pending` record is at least truthful about
disengagement; an all-declined one *launders* it into eight decisions nobody
made — permanently, in an append-only file the next reader will trust. The
check never judges a reason: *"no time; shipping Thursday and the docs owner
is on leave"* passes.

**O7 — `asked` was unreachable.** The dialogue was prune-only, so S1's third
honesty flag had nowhere to attach. Worse, it reproduced the Convener's own
founding failure one level up: the rationale argued for a two-way exchange and
the mechanism delivered a one-way filter. `/convene` now asks *"who did it
miss?"* as well.

The remaining eight: cap at 8 biasing 3–5 (O5 — the siblings' caps are an
honesty device aimed at the agent, and revision 1 overturned a settled
position on both without noticing); the `<spec-slug>.md` naming rule (O6);
orchestrator wired rather than implied (O3); the three convention files and
the template (O8); three rosters reconciled (O9); A2 rewritten as a reviewer's
rubric rather than a check (O10); the line stated explicitly (O11); the
Routing Rule made three-way (O12).

## Divergences from the build spec

Per the build spec's instruction to raise every divergence between spec and
repo reality:

1. **The build spec's ladder says "Unverified or Agent-verified first."** This
   ships `deterministic`, because `agent-verified` is not a value of this
   repo's enum and a matcher over record frontmatter is plainly the first one.
   The progressive-hardening intent is honoured through **reach** instead: the
   constraint is complete-if-present, so no existing PR shape starts failing.
   **The repo wins over the build spec's vocabulary.**

2. **Constraint 7 (records append-only) required a naming rule the S1
   contract never stated.** The build spec said S5 changes no contract; the
   schema half was right, but a contract also has a query surface and a naming
   rule. Both were added to S1 in a carved commit rather than re-derived in
   the consumer — *a consumer never mutates the contract it consumes*
   (`AGENTS.md`).

## Roster drift, three slices running

`README.md` read `#### Sentinels (5)` and `sentinel-design`'s roster carried
the same five, with the Coda, Mast and WIP Warden absent from both — each of
S2, S3 and S4 updated the explanation page and missed the other two. All three
are reconciled to 9 here, narrative sentences included. **#507** tracks the
real fix: a roster is a pinned copy of a derived fact (which agents carry
`role: sentinel`), and `AGENTS.md:481`'s promoted ARCH_DECISION has already
caught the README count badges twice in this epic.

## Tests

`test-convene-check.sh` — V1–V9, registered in the Layer 0 roster.
Mutation-tested; every mutant killed:

| Mutant | Result |
| --- | --- |
| distinct-outcome rule removed | KILLED (V7) |
| `records_open` instead of `records_latest` | KILLED (V5b) |
| `pending` never reported | KILLED (V3b) |
| malformed record passes silently | KILLED (V6) |
| orphan record ignored | KILLED (V9) |
| missing outcome accepted | KILLED (V4) |
| outcome comparison not normalised | KILLED (V7c) |

Two of the first three "survivors" turned out to be broken mutations — one hit
a docstring, and `return [] or [...]` evaluates to the right-hand side. The
one real survivor was a `pending` voice carrying an outcome, which is the
abandoned conversation exactly. It is now V3b.

Full suite: **437 passed, 31 skipped**. Convention parity: 33 constraints
across 3 files.

## Note on a blocked write

A `PreToolUse` hook blocked the initial write of `convener.agent.md`, citing a
constraint named **"Agent File Immutability"**. No such constraint exists in
`HARNESS.md` — I grepped for it, and its stated rationale ("only `/convene`
should write consultation records") is about a different artefact entirely.
Three agent files shipped in this epic by the same path. The hook also
exceeded its own brief, which says *"Do not block — only warn."* Flagging it
as a harness issue rather than acting on it.

## Version

0.71.0 → 0.72.0 across all five CI-checked locations plus the README
plugin-table cell; counts 40→41 skills, 19→20 agents, 31→32 commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
