### PR TITLE
Fix: the auto-enforcer hook cannot warn from PreToolUse (#509)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.72.0",
+  "plugin_version": "0.72.1",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.72.0"
+      "version": "0.72.1"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.72.1 — 2026-08-13
+
+### Fixed
+
+- **The auto-enforcer constraint hook no longer blocks writes** (#509). It was
+  a `type: prompt` hook on `PreToolUse` whose prompt ended *"Do not block —
+  only warn."* A `PreToolUse` prompt hook has exactly two channels — return
+  nothing (allow) or return text (deny) — so the instruction was addressed to a
+  model with no mechanism to comply: the text it returns **is** the block. Moved
+  to `PostToolUse`, where the write has landed, the file is still uncommitted,
+  and returned text is genuinely advisory. Two legitimate writes were denied
+  during the Cadence Sentinels epic.
+- **And no longer invents constraints.** Both denials named a constraint absent
+  from `HARNESS.md`; the second paraphrased an objection out of the payload it
+  was inspecting and reframed it as a violation — pattern-matching on the
+  content rather than reading the file. The prompt now requires the constraint
+  heading be quoted **verbatim** from `HARNESS.md` alongside the offending line,
+  and to return nothing when it cannot do both. Returning nothing is named as
+  the correct and common outcome.
+- **New Layer 0 test** `test-hooks-advisory-placement.sh` (H1–H4): no advisory
+  prompt hook may sit on `PreToolUse`, the constraint check must still exist and
+  live on `PostToolUse`, its prompt must demand a verbatim quote, and every hook
+  must declare a valid type and timeout. Structural rather than behavioural —
+  the same hook allowed three agent-file writes and denied the fourth, so a test
+  that ran the prompt would be flaky in exactly the way the bug is.
+
 ## 0.72.0 — 2026-08-12
 
 ### The Convener (Cadence Sentinels S5)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.72.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.72.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-41-2E8B57?style=flat-square)](#skills-41)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.72.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **41 skills, 20 agents, 32 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.72.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **41 skills, 20 agents, 32 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.72.0",
+  "version": "0.72.1",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/hooks/hooks.json
+++ b/ai-literacy-superpowers/hooks/hooks.json
@@ -6,11 +6,6 @@
         "matcher": "Write|Edit",
         "hooks": [
           {
-            "type": "prompt",
-            "prompt": "Check if HARNESS.md exists in the project root. If it does, read the Constraints section and identify any constraints with scope 'commit'. For each commit-scoped constraint, evaluate whether the file being written or edited would violate it. If violations are found, return a warning describing each violation with the constraint name. Do not block \u2014 only warn. If no HARNESS.md exists or no commit-scoped constraints apply, return nothing.",
-            "timeout": 30
-          },
-          {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/markdownlint-check.sh",
             "timeout": 15
@@ -26,6 +21,16 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/affordance-invocation-recorder.sh",
             "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Read HARNESS.md in the project root. If it does not exist, return nothing. Find the `## Constraints` section and list only the `### ` headings whose entry declares `Scope: commit`. For each, decide whether the file just written or edited breaks that specific rule.\n\nReport a violation ONLY when you can quote the constraint's `### ` heading verbatim from HARNESS.md and quote the line in the file that breaks it. If you cannot do both, return nothing. Never name a constraint you have not read in HARNESS.md, and never infer one from the content of the file being written \u2014 a document that discusses a rule is not a document that breaks one.\n\nThis runs after the write, so your output is advisory: the file is on disk and uncommitted, and the author decides what to do. Returning nothing is the correct and common outcome.",
+            "timeout": 30
           }
         ]
       }

--- a/tdad_tests/layer0_deterministic/test-hooks-advisory-placement.sh
+++ b/tdad_tests/layer0_deterministic/test-hooks-advisory-placement.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for hook placement in ai-literacy-superpowers/hooks/hooks.json
+# (issue #509).
+#
+# THE BUG THIS PINS. A `type: prompt` hook on PreToolUse has exactly two
+# channels: return nothing (allow the call) or return text (DENY it, surfaced
+# to the user as `PreToolUse:Write hook error`). There is no warn channel.
+#
+# The constraint-checking hook's prompt ended "Do not block — only warn." That
+# instruction was addressed to a model with no mechanism to comply: the text it
+# returns IS the block, whatever the text says. Two legitimate writes were
+# denied during the Cadence Sentinels epic, each citing a constraint that does
+# not exist in HARNESS.md.
+#
+# It is the same failure shape the epic keeps finding — a confident sentence
+# describing a capability that is not there. S5's spec claimed an
+# `agent-verified` enforcement rung that was never a value of the enum; S3
+# specified a `strict` mode requiring a disposition no hook could collect. Here
+# a hook config asked for advisory behaviour from a blocking position.
+#
+# So: an advisory prompt hook belongs on PostToolUse, where the write has
+# landed, the file is still uncommitted, and returned text is genuinely a
+# warning. That dissolves the mismatch rather than documenting it.
+#
+# WHY A STRUCTURAL TEST AND NOT A BEHAVIOURAL ONE. The failure is a property of
+# where the hook is registered, not of what the model says on any given run —
+# the same hook allowed three agent-file writes earlier in the epic and denied
+# the fourth. A test that ran the prompt would be flaky in exactly the way the
+# bug is.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOKS="$SCRIPT_DIR/../../ai-literacy-superpowers/hooks/hooks.json"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+[ -f "$HOOKS" ] || fail "hooks.json not found at $HOOKS"
+
+PY=/usr/bin/python3
+command -v "$PY" >/dev/null 2>&1 || PY=python3
+
+"$PY" - "$HOOKS" <<'HARNESS_EOF'
+import json, re, sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as fh:
+    config = json.load(fh)
+
+hooks = config.get("hooks", {})
+errors = []
+
+def entries(event):
+    for group in hooks.get(event, []):
+        for hook in group.get("hooks", []):
+            yield group.get("matcher", ""), hook
+
+# --- H1: no advisory prompt hook sits on PreToolUse --------------------------
+# A prompt hook there can only allow or deny. One whose text describes warning,
+# advising, or flagging is asking for a channel it does not have.
+ADVISORY = re.compile(
+    r"do not block|only warn|warn only|advisory|non-blocking|informational",
+    re.IGNORECASE,
+)
+for matcher, hook in entries("PreToolUse"):
+    if hook.get("type") != "prompt":
+        continue
+    prompt = hook.get("prompt", "")
+    if ADVISORY.search(prompt):
+        errors.append(
+            f"H1: PreToolUse prompt hook (matcher {matcher!r}) asks to warn "
+            "without blocking, but returning text on PreToolUse IS the block. "
+            "Move it to PostToolUse."
+        )
+
+# --- H2: the constraint check still exists somewhere -------------------------
+# The fix must relocate the hook, not delete it. A repo that silently lost its
+# commit-scoped constraint warning would pass H1 for the wrong reason.
+found_event = None
+for event in ("PreToolUse", "PostToolUse"):
+    for _, hook in entries(event):
+        if "HARNESS.md" in str(hook.get("prompt", "")):
+            found_event = event
+if found_event is None:
+    errors.append("H2: the HARNESS.md constraint check has gone missing entirely")
+elif found_event != "PostToolUse":
+    errors.append(f"H2: the constraint check must live on PostToolUse, found on {found_event}")
+
+# --- H3: the prompt forbids reporting an unquoted constraint -----------------
+# Both live failures invented a constraint name. The second paraphrased an
+# objection out of the payload it was inspecting and reframed it as a HARNESS
+# violation — it was pattern-matching on the content, not reading the file.
+# The prompt must require a verbatim heading and silence when it has none.
+for event in ("PreToolUse", "PostToolUse"):
+    for matcher, hook in entries(event):
+        prompt = str(hook.get("prompt", ""))
+        if "HARNESS.md" not in prompt:
+            continue
+        if not re.search(r"verbatim|quote|exact", prompt, re.IGNORECASE):
+            errors.append(
+                "H3: the constraint prompt must require the constraint heading "
+                "be quoted verbatim from HARNESS.md"
+            )
+        if not re.search(r"return nothing|say nothing|report nothing", prompt, re.IGNORECASE):
+            errors.append(
+                "H3: the constraint prompt must say to return nothing when it "
+                "cannot quote a real constraint"
+            )
+
+# --- H4: every hook declares a type and a timeout ----------------------------
+# Cheap structural guard; a typo in `type` silently disables a hook.
+VALID_TYPES = {"prompt", "command"}
+for event, groups in hooks.items():
+    for group in groups:
+        for hook in group.get("hooks", []):
+            if hook.get("type") not in VALID_TYPES:
+                errors.append(f"H4: {event} hook has invalid type {hook.get('type')!r}")
+            if not isinstance(hook.get("timeout"), int):
+                errors.append(f"H4: {event} hook is missing an integer timeout")
+
+if errors:
+    for error in errors:
+        print(f"FAIL: {error}", file=sys.stderr)
+    sys.exit(1)
+
+print("PASS: hook placement — no advisory prompt hook holds a blocking position")
+HARNESS_EOF

--- a/tdad_tests/tests/test_layer0_deterministic.py
+++ b/tdad_tests/tests/test_layer0_deterministic.py
@@ -48,6 +48,9 @@ BASH_TEST_SCRIPTS = [
     "test-archive-promoted-reflections",
     "test-migrate-reflection-log",
     "test-auto-enforcer",
+    # #509 — an advisory prompt hook must not hold a blocking position.
+    # PreToolUse prompt hooks can only allow or deny; there is no warn channel.
+    "test-hooks-advisory-placement",
     "test-affordances-template",
     "test-affordance-check",
     "test-affordance-staleness",


### PR DESCRIPTION
Closes #509.

## The bug

`ai-literacy-superpowers/hooks/hooks.json` registered a `type: prompt` hook on
**`PreToolUse`** matching `Write|Edit`, whose prompt ended:

> Do not block — only warn.

A `PreToolUse` prompt hook has exactly two channels: **return nothing** (allow)
or **return text** (deny, surfaced as `PreToolUse:Write hook error`). There is
no warn channel. The instruction was addressed to a model with no mechanism to
comply — the text it returns *is* the block, whatever the text says.

This is the same failure shape this epic keeps catching: a confident sentence
describing a capability that is not there. S5 O2 found an `agent-verified`
enforcement rung that was never a value of the enum; S3 specified a `strict`
mode requiring a disposition no hook could collect.

## The second defect

Both live denials named a constraint that does not exist in `HARNESS.md`:

| Denial | Invented constraint | Tell |
| --- | --- | --- |
| `agents/convener.agent.md` | "Agent File Immutability" | Rationale referenced consultation records — a different artefact |
| An objection record | "Objection record count stability (HARNESS.md line ~450)" | **Paraphrased objection O6 out of the payload it was inspecting** and reframed it as a violation |

The second is diagnostic: it pattern-matched on the content being written
rather than reading `HARNESS.md`. Line 450 is the docs-propagation rule. The
five real commit-scoped constraints are `Consistent markdown formatting`,
`No secrets in source`, and three shell-script rules — none can apply to a
markdown body.

A fabricated constraint is worse than a missing check: it is indistinguishable
from a real one without grepping, so the cooperative response is to comply with
a rule that does not exist.

## The fix

**Moved to `PostToolUse`** — the write has landed, the file is still
uncommitted, and returned text is genuinely advisory, which is what the hook
said it wanted. Dissolves the mismatch instead of documenting it.

**Prompt tightened** to require the constraint heading quoted *verbatim* from
`HARNESS.md` alongside the offending line, and to return nothing when it cannot
supply both. It now states that returning nothing is the correct and common
outcome, and that a document discussing a rule is not a document breaking one.

`markdownlint-check.sh` stays on `PreToolUse` — a **command** hook genuinely
can warn (exit 0 with output) or block (exit 2). Only the prompt hook lacked
the channel.

## Test

New `test-hooks-advisory-placement.sh`, H1–H4:

- **H1** no advisory prompt hook on `PreToolUse`
- **H2** the constraint check still exists, and lives on `PostToolUse` — so the
  fix cannot pass by deleting it
- **H3** the prompt demands a verbatim quote and silence without one
- **H4** every hook declares a valid type and an integer timeout

Structural, not behavioural, and deliberately so: the same hook allowed three
agent-file writes earlier in the epic and denied the fourth, so a test that ran
the prompt would be flaky in exactly the way the bug is. Mutation-tested —
moving the hook back to `PreToolUse` fails H1 and H2.

Patch bump 0.72.0 → 0.72.1. No component counts change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)