### PR TITLE
Check the sentinel roster against its source (#507)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.73.1",
+  "plugin_version": "0.73.2",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.73.1"
+      "version": "0.73.2"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.73.2 — 2026-08-13
+
+### Fixed
+
+- **The sentinel roster is now checked against its source** (#507). Which agents
+  are sentinels is a derived fact — exactly the `agents/*.agent.md` files
+  carrying `role: sentinel` — and three documents pinned a copy of it.
+  `README.md` and `sentinel-design/SKILL.md` were both still at 5 after S2, S3
+  and S4 had each shipped one; each of those slices updated
+  `explanation/sentinels.md` and missed the other two. Nobody was careless;
+  there were three places and one habit.
+- **New Layer 0 test** `test-sentinel-roster-parity.sh` — every `role: sentinel`
+  agent appears in all three rosters, no roster claims an agent that is not one,
+  and the README's `#### Sentinels (N)` count is compared against the derived
+  set rather than a literal. **Membership only**: the rosters carry per-agent
+  "Guards" columns and narrative prose that no generator would write well, so a
+  check treating them as one list would be right about membership and wrong
+  about everything else.
+- Mutation-tested against all six drift shapes, including the one that will
+  actually happen — a new sentinel shipping with no roster updated.
+
 ## 0.73.1 — 2026-08-13
 
 ### Documentation (Cadence Sentinels S7)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.73.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.73.2-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-41-2E8B57?style=flat-square)](#skills-41)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.73.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **41 skills, 20 agents, 32 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.73.2 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **41 skills, 20 agents, 32 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.73.1",
+  "version": "0.73.2",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/tdad_tests/layer0_deterministic/test-sentinel-roster-parity.sh
+++ b/tdad_tests/layer0_deterministic/test-sentinel-roster-parity.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for sentinel roster membership (#507).
+#
+# WHAT WENT WRONG. `README.md`'s `#### Sentinels (N)` heading and
+# `skills/sentinel-design/SKILL.md`'s roster table were both still at 5 after
+# S2, S3 and S4 had each shipped a `role: sentinel` agent. Three slices of
+# drift — and each of those slices DID update `explanation/sentinels.md`, and
+# missed the other two. Nobody was careless; there were three places and one
+# habit.
+#
+# Which agents are sentinels is a DERIVED fact: exactly the set of
+# `agents/*.agent.md` carrying `role: sentinel`, which
+# `scripts/sentinel-integrity-check.sh` already enumerates on every PR.
+# AGENTS.md's promoted decision says harness artefacts derive from the source of
+# truth rather than pinning a copy of it, and the same rule had already caught
+# the README count badges twice in this epic.
+#
+# MEMBERSHIP, NOT GENERATION. The three rosters have different jobs — the
+# conceptual page, the authoring guide's worked examples, the shop window — and
+# each carries a per-agent "Guards" column and narrative prose no generator
+# would write well. A check that treated them as one list would be right about
+# membership and wrong about everything else. So this asserts only the part
+# worth enforcing: every sentinel appears, and nothing else claims to be one.
+#
+# Nothing here pins a number. The count in the README heading is compared
+# against the derived set, not against a literal.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$SCRIPT_DIR/../.."
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+PY=/usr/bin/python3
+command -v "$PY" >/dev/null 2>&1 || PY=python3
+
+"$PY" - "$ROOT" <<'HARNESS_EOF'
+import glob, os, re, sys
+
+root = sys.argv[1]
+agents_dir = os.path.join(root, "ai-literacy-superpowers", "agents")
+
+errors = []
+
+
+def frontmatter(text):
+    if not text.startswith("---"):
+        return ""
+    body = text[3:]
+    end = body.find("\n---")
+    return body[:end] if end != -1 else ""
+
+
+# --- the source of truth -----------------------------------------------------
+sentinels = set()
+for path in sorted(glob.glob(os.path.join(agents_dir, "*.agent.md"))):
+    with open(path, encoding="utf-8") as fh:
+        fm = frontmatter(fh.read())
+    if re.search(r"^role:\s*sentinel\s*$", fm, re.MULTILINE):
+        name = re.search(r"^name:\s*(\S+)", fm, re.MULTILINE)
+        if name:
+            sentinels.add(name.group(1).strip())
+
+if not sentinels:
+    print("FAIL: no role: sentinel agents found — the derivation source is missing",
+          file=sys.stderr)
+    sys.exit(1)
+
+# Every agent name, so a roster row naming a real-but-non-sentinel agent is
+# reported differently from one naming nothing at all.
+all_agents = set()
+for path in sorted(glob.glob(os.path.join(agents_dir, "*.agent.md"))):
+    with open(path, encoding="utf-8") as fh:
+        name = re.search(r"^name:\s*(\S+)", frontmatter(fh.read()), re.MULTILINE)
+    if name:
+        all_agents.add(name.group(1).strip())
+
+
+def roster_rows(path, start_pattern, end_pattern=None):
+    """Agent names in the first-column cells of the roster table at `path`."""
+    with open(path, encoding="utf-8") as fh:
+        lines = fh.read().splitlines()
+    try:
+        start = next(i for i, ln in enumerate(lines) if re.search(start_pattern, ln))
+    except StopIteration:
+        return None
+    names = []
+    for line in lines[start:]:
+        if end_pattern and re.search(end_pattern, line) and names:
+            break
+        row = re.match(r"^\|\s*`?([a-z][a-z0-9-]*)`?\s*\|", line)
+        if row:
+            names.append(row.group(1))
+        elif names and not line.startswith("|") and line.strip():
+            break
+    return names
+
+
+ROSTERS = [
+    ("README.md", r"^####\s+Sentinels\s*\(", r"^####\s+(?!Sentinels)"),
+    (os.path.join("ai-literacy-superpowers", "skills", "sentinel-design", "SKILL.md"),
+     r"^##\s+The roster", r"^##\s+(?!The roster)"),
+    (os.path.join("docs", "plugins", "ai-literacy-superpowers", "explanation", "sentinels.md"),
+     r"^##\s+The roster", r"^##\s+(?!The roster)"),
+]
+
+for rel, start, end in ROSTERS:
+    path = os.path.join(root, rel)
+    if not os.path.isfile(path):
+        errors.append(f"{rel} not found")
+        continue
+    names = roster_rows(path, start, end)
+    if names is None:
+        errors.append(f"{rel}: no roster table found at {start!r}")
+        continue
+    listed = set(names)
+
+    for missing in sorted(sentinels - listed):
+        errors.append(f"{rel}: sentinel '{missing}' is missing from the roster")
+    for extra in sorted(listed - sentinels):
+        if extra in all_agents:
+            errors.append(
+                f"{rel}: roster lists '{extra}', which is an agent but not "
+                "role: sentinel"
+            )
+        else:
+            errors.append(f"{rel}: roster lists '{extra}', which is not an agent")
+    if len(names) != len(listed):
+        dupes = sorted({n for n in names if names.count(n) > 1})
+        errors.append(f"{rel}: roster lists {dupes} more than once")
+
+# --- the README heading's count is derived, never pinned ---------------------
+readme = os.path.join(root, "README.md")
+with open(readme, encoding="utf-8") as fh:
+    heading = re.search(r"^####\s+Sentinels\s*\((\d+)\)", fh.read(), re.MULTILINE)
+if not heading:
+    errors.append("README.md: no '#### Sentinels (N)' heading found")
+elif int(heading.group(1)) != len(sentinels):
+    errors.append(
+        f"README.md: heading says Sentinels ({heading.group(1)}), but "
+        f"{len(sentinels)} agents carry role: sentinel"
+    )
+
+if errors:
+    for error in errors:
+        print(f"FAIL: {error}", file=sys.stderr)
+    sys.exit(1)
+
+print(
+    f"PASS: sentinel roster parity — {len(sentinels)} sentinels, "
+    f"present in all {len(ROSTERS)} rosters, no roster claiming a non-sentinel"
+)
+HARNESS_EOF

--- a/tdad_tests/tests/test_layer0_deterministic.py
+++ b/tdad_tests/tests/test_layer0_deterministic.py
@@ -55,6 +55,9 @@ BASH_TEST_SCRIPTS = [
     # D1/D2/D3 derive both sides rather than pinning a count; K1-K5 assert the
     # one property the per-library tests structurally cannot show.
     "test-sentinel-docs-coverage",
+    # #507 — the sentinel roster is a derived fact pinned in three places.
+    # Membership only: the tables carry prose no generator would write well.
+    "test-sentinel-roster-parity",
     "test-hooks-doc-parity",
     "test-cadence-integration",
     "test-affordances-template",


### PR DESCRIPTION
Closes #507. Filed at the S5 spec gate as objection O9.

## The drift

`README.md`'s `#### Sentinels (N)` and `skills/sentinel-design/SKILL.md`'s roster were **both still at 5** after S2, S3 and S4 had each shipped a `role: sentinel` agent.

The interesting part is that each of those three slices *did* update `explanation/sentinels.md` and missed the other two. Nobody was careless — there were three places and one habit.

## The rule it broke

Which agents are sentinels is a **derived fact**: exactly the `agents/*.agent.md` files carrying `role: sentinel`, which `scripts/sentinel-integrity-check.sh` already enumerates on every PR.

`AGENTS.md:481`: *harness artefacts derive from the source of truth — they do not pin a copy of it.* The same decision had already caught the README count badges twice in this epic, and those at least had a test.

## Membership, not generation

The issue's own framing, and it is right. The three rosters have different jobs — the conceptual page, the authoring guide's worked examples, the shop window — and each carries a per-agent "Guards" column and narrative prose no generator would write well.

A check treating them as one list would be **right about membership and wrong about everything else**. So this asserts only the part worth enforcing:

- every `role: sentinel` agent appears in all three rosters
- no roster names an agent that is not a sentinel — reported differently when the name is a real agent than when it is nothing at all
- no roster lists an agent twice
- `#### Sentinels (N)` is compared against the **derived set**, never a literal

## Verification

The guard is green on arrival, because S5 and S7 already reconciled the rosters. A test that passes the moment it is written proves nothing, so the evidence is mutation — one per drift shape that actually happened, plus the one that will:

| Mutation | Result |
| --- | --- |
| README drops a sentinel (the S2/S3/S4 shape) | KILLED |
| `sentinel-design` drops a sentinel | KILLED |
| explanation page drops a sentinel | KILLED |
| README heading count goes stale | KILLED |
| roster claims a real agent that is not a sentinel | KILLED |
| **a new sentinel ships and no roster is updated** | KILLED |

The last is the one that matters: it is what happens next time, and it is exactly what went unnoticed three times.

## Related

- **#511** is the same decision on a different artefact — the three convention files mirror `HARNESS.md` constraint *bodies*, and parity compares headings only.
- S7 (#515) applied the same technique to docs coverage, creating the `sentinels:` frontmatter relation that did not previously exist.

Patch bump 0.73.1 → 0.73.2. Full suite: 442 passed, 31 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)