### PR TITLE
Check convention mirrors offer every constraint enum value (#511)

### DIFF
--- a/.cursor/rules/constraints.mdc
+++ b/.cursor/rules/constraints.mdc
@@ -226,9 +226,9 @@ alwaysApply: true
 
 ## Convention parity
 
-- **Rule**: Every active constraint heading in HARNESS.md's `## Constraints` section must appear verbatim in all three generated convention files (`.cursor/rules/constraints.mdc`, `.github/copilot-instructions.md`, `.windsurf/rules/constraints.md`). These files are generated from HARNESS.md by `/convention-sync` and can drift by whole constraints (content drift, not a stale mtime). This PR-time gate complements the weekly "Convention file sync" GC rule.
+- **Rule**: Every active constraint heading in HARNESS.md's `## Constraints` section must appear verbatim in all three generated convention files (`.cursor/rules/constraints.mdc`, `.github/copilot-instructions.md`, `.windsurf/rules/constraints.md`). These files are generated from HARNESS.md by `/convention-sync` and can drift by whole constraints (content drift, not a stale mtime). This PR-time gate complements the weekly "Convention file sync" GC rule. Headings alone are not enough: a change to a constraint's **body** passes the heading check untouched. Where a rule enumerates a closed set of valid values, every member must also appear in all three mirrors — a mirror listing five of six does not omit prose, it misleads about what is allowed. Mirrors may abridge explanation; they may not abridge a vocabulary.
 - **Enforcement**: deterministic
-- **Tool**: `python3 scripts/check-convention-parity.py` (CI: `.github/workflows/convention-parity-check.yml`)
+- **Tool**: `python3 scripts/check-convention-parity.py` and `python3 scripts/check-constraint-enum-parity.py` (CI: `.github/workflows/convention-parity-check.yml`)
 - **Scope**: pr
 
 ## Sentinel integrity

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -169,7 +169,7 @@ Every entry in the permissions allowlist should have a matching affordance in th
 
 ### Convention parity
 
-Every active constraint heading in HARNESS.md's Constraints section must appear verbatim in all three generated convention files (`.cursor/rules/constraints.mdc`, `.github/copilot-instructions.md`, `.windsurf/rules/constraints.md`). These files are generated from HARNESS.md by `/convention-sync` and can drift by whole constraints (content drift, not a stale mtime). This PR-time gate complements the weekly "Convention file sync" GC rule. Enforcement: deterministic (`python3 scripts/check-convention-parity.py`, CI `.github/workflows/convention-parity-check.yml`). Scope: pr.
+Every active constraint heading in HARNESS.md's Constraints section must appear verbatim in all three generated convention files (`.cursor/rules/constraints.mdc`, `.github/copilot-instructions.md`, `.windsurf/rules/constraints.md`). These files are generated from HARNESS.md by `/convention-sync` and can drift by whole constraints (content drift, not a stale mtime). This PR-time gate complements the weekly "Convention file sync" GC rule. Headings alone are not enough: a change to a constraint's **body** passes the heading check untouched. Where a rule enumerates a closed set of valid values, every member must also appear in all three mirrors — a mirror listing five of six does not omit prose, it misleads about what is allowed. Mirrors may abridge explanation; they may not abridge a vocabulary. Enforcement: deterministic (`python3 scripts/check-convention-parity.py`, CI `.github/workflows/convention-parity-check.yml`). Scope: pr.
 
 ### Sentinel integrity
 

--- a/.github/workflows/convention-parity-check.yml
+++ b/.github/workflows/convention-parity-check.yml
@@ -13,6 +13,15 @@
 # It is a whole-repo invariant (checked on HEAD, not a diff) because a
 # constraint can be added to HARNESS.md in one PR while the convention
 # files are updated — or forgotten — in another.
+#
+# HEADINGS ARE NOT ENOUGH (#511). The parity check above matches constraint
+# HEADINGS, so a change to a constraint's BODY passes untouched while the
+# mirrors keep the old wording. The S6 gate found that one step from shipping:
+# adding a seventh objection category would have left four files declaring a
+# six-value enum the deterministic checker no longer enforced, every gate
+# green. The second check closes that for the case where it is dangerous — an
+# enumeration, where a mirror listing five of six actively misleads. Mirrors
+# may abridge explanation; they may not abridge a vocabulary.
 
 name: Convention Parity Check
 
@@ -25,6 +34,7 @@ on:
       - ".github/copilot-instructions.md"
       - ".windsurf/rules/constraints.md"
       - "scripts/check-convention-parity.py"
+      - "scripts/check-constraint-enum-parity.py"
       - ".github/workflows/convention-parity-check.yml"
   workflow_dispatch:
 
@@ -45,3 +55,6 @@ jobs:
 
       - name: Verify convention files mirror HARNESS.md constraints
         run: python3 scripts/check-convention-parity.py
+
+      - name: Verify convention files offer every constraint enum value
+        run: python3 scripts/check-constraint-enum-parity.py

--- a/.windsurf/rules/constraints.md
+++ b/.windsurf/rules/constraints.md
@@ -220,9 +220,9 @@
 
 ## Convention parity
 
-- **Rule**: Every active constraint heading in HARNESS.md's `## Constraints` section must appear verbatim in all three generated convention files (`.cursor/rules/constraints.mdc`, `.github/copilot-instructions.md`, `.windsurf/rules/constraints.md`). These files are generated from HARNESS.md by `/convention-sync` and can drift by whole constraints (content drift, not a stale mtime). This PR-time gate complements the weekly "Convention file sync" GC rule.
+- **Rule**: Every active constraint heading in HARNESS.md's `## Constraints` section must appear verbatim in all three generated convention files (`.cursor/rules/constraints.mdc`, `.github/copilot-instructions.md`, `.windsurf/rules/constraints.md`). These files are generated from HARNESS.md by `/convention-sync` and can drift by whole constraints (content drift, not a stale mtime). This PR-time gate complements the weekly "Convention file sync" GC rule. Headings alone are not enough: a change to a constraint's **body** passes the heading check untouched. Where a rule enumerates a closed set of valid values, every member must also appear in all three mirrors — a mirror listing five of six does not omit prose, it misleads about what is allowed. Mirrors may abridge explanation; they may not abridge a vocabulary.
 - **Enforcement**: deterministic
-- **Tool**: `python3 scripts/check-convention-parity.py` (CI: `.github/workflows/convention-parity-check.yml`)
+- **Tool**: `python3 scripts/check-convention-parity.py` and `python3 scripts/check-constraint-enum-parity.py` (CI: `.github/workflows/convention-parity-check.yml`)
 - **Scope**: pr
 
 ## Sentinel integrity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@
 
 ### Fixed
 
+- **A constraint's enum values are now checked across the convention mirrors**
+  (#511). `check-convention-parity.py` matches constraint **headings**, so a
+  change to a rule's **body** passed untouched while `.cursor`, `.github` and
+  `.windsurf` kept the old wording. The S6 gate found that one step from
+  shipping: adding a seventh objection category would have left four files
+  declaring a six-value enum the deterministic checker no longer enforced,
+  with every gate green.
+- **New check** `scripts/check-constraint-enum-parity.py`, wired into the
+  existing Convention Parity workflow. Where a rule enumerates a closed set of
+  valid values, every member must appear in all three mirrors.
+- **Deliberately narrow.** The mirrors legitimately *abridge* — they drop
+  explanatory clauses that belong in `HARNESS.md` and would be noise in an
+  assistant's context, and 38 of 450 code literals in the rules differ today,
+  most of them correctly. A whole-body equality check would fail everywhere and
+  be switched off within a week. **Mirrors may abridge explanation; they may
+  not abridge a vocabulary** — a mirror listing five of six valid values does
+  not omit prose, it misleads about what is allowed.
+- Mutation-tested against both directions: a mirror dropping an enum member,
+  and `HARNESS.md` gaining a value the mirrors do not offer.
+
 - **The sentinel roster is now checked against its source** (#507). Which agents
   are sentinels is a derived fact — exactly the `agents/*.agent.md` files
   carrying `role: sentinel` — and three documents pinned a copy of it.

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -494,8 +494,14 @@
   complements the weekly "Convention file sync" GC rule, which only runs on
   cadence. Surfaced by the 2026-06-23 audit, which found two constraints
   missing from the convention files since 2026-06-01 (`/reflect` signal=failure).
+  Headings alone are not enough: a change to a constraint's **body** passes the
+  heading check untouched. Where a rule enumerates a closed set of valid values,
+  every member must also appear in all three mirrors — a mirror listing five of
+  six does not omit prose, it misleads about what is allowed. Mirrors may
+  abridge explanation; they may not abridge a vocabulary.
 - **Enforcement**: deterministic
-- **Tool**: `python3 scripts/check-convention-parity.py`
+- **Tool**: `python3 scripts/check-convention-parity.py` and
+  `python3 scripts/check-constraint-enum-parity.py`
   (CI: `.github/workflows/convention-parity-check.yml`)
 - **Scope**: pr
 

--- a/scripts/check-constraint-enum-parity.py
+++ b/scripts/check-constraint-enum-parity.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Verify the convention mirrors carry every member of every constraint enum.
+
+`check-convention-parity.py` requires each active `### ` constraint heading in
+`HARNESS.md` to appear in all three convention files. Matching is a substring
+test **of the heading**, so a change to a constraint's *body* — the rule text
+people and agents actually follow — passes untouched while the three mirrors
+keep the old wording (#511).
+
+The dangerous case is an **enumeration**. `HARNESS.md` names a closed set of
+valid values; a mirror listing five of six does not merely omit prose, it
+actively misleads, and it is the shape the S6 gate found one step from
+shipping: adding a seventh objection category to `HARNESS.md` would have left
+four files declaring a six-value enum that the deterministic checker no longer
+enforced, with every gate green.
+
+WHY ENUMS RATHER THAN WHOLE BODIES. The mirrors legitimately **abridge**. They
+drop explanatory clauses that belong in `HARNESS.md` and would be noise in an
+assistant's context — 38 of 450 code-formatted literals in the rules differ
+today, and most of those differences are correct. A whole-body equality check
+would fail everywhere and be switched off within a week; a check that fires
+only on enum members is one nobody has to argue with.
+
+So this is deliberately narrow: it does not ask the mirrors to say the same
+thing, only to offer the same *choices*.
+
+Enums are recognised as "one of [a few words] `a`, `b`, `c`" — three or more
+code-formatted literals in a run. Two-item pairs are excluded: they are
+usually a contrast ("`accepted` or `rejected`" in prose) rather than a
+declared vocabulary, and the false-positive cost is higher than the coverage.
+
+No third-party dependencies (CI-friendly).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+CONVENTION_FILES = [
+    ".cursor/rules/constraints.mdc",
+    ".github/copilot-instructions.md",
+    ".windsurf/rules/constraints.md",
+]
+
+# Three or more code literals in a run, introduced by "one of".
+ENUM = re.compile(
+    r"one of(?:\s+\w+){0,4}[:\s]\s*((?:`[^`]+`(?:\s*,\s*|\s+(?:or|and)\s+)?){3,})"
+)
+
+
+def flatten(text: str) -> str:
+    """Collapse whitespace, so a rule wrapped at 72 columns compares equal to
+    the same rule on one line. The mirrors do not wrap; `HARNESS.md` does."""
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def constraint_blocks(harness: str) -> list[tuple[str, str]]:
+    """(heading, body) for each `### ` constraint inside `## Constraints`."""
+    try:
+        start = harness.index("\n## Constraints\n")
+    except ValueError:
+        return []
+    section = harness[start:]
+    end = section.find("\n## ", 1)
+    if end != -1:
+        section = section[:end]
+    blocks = []
+    for chunk in re.split(r"\n### ", section)[1:]:
+        heading, _, body = chunk.partition("\n")
+        blocks.append((heading.strip(), body))
+    return blocks
+
+
+def rule_text(body: str) -> str:
+    """The `- **Rule**:` field, up to the next `- **` field."""
+    match = re.search(r"\*\*Rule\*\*:(.*?)(?=\n- \*\*|\Z)", body, re.S)
+    return flatten(match.group(1)) if match else ""
+
+
+def main() -> int:
+    harness = (REPO_ROOT / "HARNESS.md").read_text(encoding="utf-8")
+    mirrors = {}
+    for rel in CONVENTION_FILES:
+        path = REPO_ROOT / rel
+        if not path.is_file():
+            print(f"::error::convention file missing: {rel}")
+            return 1
+        mirrors[rel] = flatten(path.read_text(encoding="utf-8"))
+
+    failed = False
+    enums = 0
+    checks = 0
+
+    for heading, body in constraint_blocks(harness):
+        rule = rule_text(body)
+        if not rule:
+            continue
+        for run in ENUM.findall(rule):
+            members = re.findall(r"`([^`]+)`", run)
+            enums += 1
+            for rel, text in mirrors.items():
+                for member in members:
+                    checks += 1
+                    if f"`{member}`" not in text:
+                        print(
+                            f"::error file={rel}::constraint '{heading}' offers "
+                            f"`{member}` as a valid value; {rel} does not list it"
+                        )
+                        failed = True
+
+    if failed:
+        print(
+            "\nConstraint enum parity FAILED. HARNESS.md declares a set of valid "
+            "values that a convention mirror does not offer. A mirror listing "
+            "five of six does not omit prose — it misleads about what is "
+            "allowed. Mirrors may abridge explanation; they may not abridge a "
+            "vocabulary."
+        )
+        return 1
+
+    print(
+        f"Constraint enum parity passed ({enums} enums, {checks} member checks "
+        f"across {len(CONVENTION_FILES)} convention files)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #511. Surfaced at the S6 spec gate as objection O4.

## The gap

`check-convention-parity.py` requires each active `### ` constraint **heading** in `HARNESS.md` to appear in all three convention files. Matching is a substring test of the heading.

So a change to a constraint's **body** — the rule text people and agents actually follow — passes untouched while `.cursor`, `.github` and `.windsurf` keep the old wording.

The S6 gate found this one step from shipping. Adding a seventh objection category would have left **four files declaring a six-value enum** that the deterministic checker no longer enforced, with every gate green.

## Why enums and not whole bodies

The mirrors **legitimately abridge**. They drop explanatory clauses that belong in `HARNESS.md` and would be noise in an assistant's context window.

I measured it: **38 of 450 code-formatted literals** in the constraint rules already differ across the mirrors, and most of those differences are correct. A whole-body equality check would fail on nearly every constraint on day one and be switched off within a week.

An **enumeration** is different. When `HARNESS.md` names a closed set of valid values, a mirror listing five of six does not merely omit prose — it **misleads about what is allowed**, to exactly the agents the mirrors exist to inform.

> **Mirrors may abridge explanation; they may not abridge a vocabulary.**

Enums are recognised as `one of [a few words] \`a\`, \`b\`, \`c\`` — three or more code literals in a run. Two-item pairs are excluded: those are usually a prose contrast rather than a declared vocabulary, and the false-positive cost is higher than the coverage. Currently **3 enums, 45 member checks**, all passing.

Whitespace is flattened before comparison, because `HARNESS.md` wraps its rules at 72 columns and the mirrors do not — the same lesson S1 learned when a clause matcher failed on wrapped template text.

## Verification

| Mutation | Result |
| --- | --- |
| a mirror drops `specification quality` from the taxonomy enum | KILLED |
| `HARNESS.md` gains `embedded assumptions` and the mirrors do not | KILLED |

The second is the S6 near-miss reproduced exactly.

## Also

The `Convention parity` constraint's own body now says what the check covers, and that text is mirrored into all three files — the change this PR makes is the kind the check now guards.

## Not bumping the version

Nothing under `ai-literacy-superpowers/` changed: the new script is at repo root under `scripts/`, beside `check-convention-parity.py`. Per CLAUDE.md the CHANGELOG entry appends under the existing `0.73.2` heading rather than opening a new one.

## Related

- **#507** was the same decision on a different artefact — merged in #516.
- S7 (#515) applied it to docs coverage.

Full suite: 442 passed, 31 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)