### PR TITLE
Point the epic's provenance at something retrievable (#514)

### DIFF
--- a/docs/superpowers/cadence-sentinels-charter.md
+++ b/docs/superpowers/cadence-sentinels-charter.md
@@ -1,0 +1,115 @@
+# The Cadence Sentinels — epic charter
+
+The constitutional constraints, non-goals, and working style that governed
+slices S1–S7 (2026-08-08 → 2026-08-13, plugin versions 0.67.0 → 0.73.2).
+
+## Why this file exists
+
+Seven specs in this epic cite these constraints **by number** — "constraint 3",
+"constraint 6", "constraint 7" — and the numbered list was nowhere in the
+repository. A reader meeting *"Constraint 7 says records are append-only"* had
+no way to see constraints 1 through 9.
+
+The specs also carried a provenance line naming *The Second Front — Arc
+Insertion Remit*, a slide deck that does not exist in this repository or in
+`ai-literacy-for-software-engineers`, and never did. The epic originated in a
+**build spec supplied in conversation** on 2026-08-08; the deck title was a
+label for that remit rather than a document anyone can retrieve.
+
+A second title, *Compulsive Continuation — A Research Exploration*, was cited by
+S1–S4 as the evidence base. It is not in either repository either. **The
+evidence itself is not missing** — every `<!-- evidence: ... -->` comment in the
+skills cites named, published work inline (distributed cognition, the vigilance
+decrement, task-switching cost, Ulysses pacts), and those citations are
+retrievable. What did not exist was the umbrella document.
+
+**This file is the transcription.** The constraints below are quoted verbatim
+from that build spec. Where a slice's own spec argues with one — S5's O2 on the
+enforcement enum, for instance — the slice's spec is the later and better
+authority, and says so.
+
+Per-slice scope lives in the epic's issues: **#491** (S1), **#492** (S2),
+**#493** (S3), **#501** (S3b), **#494** (S4), **#495** (S5), **#496** (S6),
+**#497** (S7).
+
+## The nine constitutional constraints
+
+Violations were review-blockers.
+
+1. **Sentinels are read-only.** No Write/Edit tools for any new agent, with one
+   narrowly scoped exception: the Coda may append to its own record files —
+   never to source, specs, or `HARNESS.md`.
+2. **Agents propose, humans dispose.** Every gate terminates in a human
+   disposition recorded in the relevant record file. No sentinel ever
+   auto-blocks silently or auto-approves.
+3. **Honesty flags.** Every observation a sentinel reports is tagged
+   `observed` / `inferred` / `asked`, exactly as the Reservoir Warden does. If a
+   value cannot be observed, the sentinel says so rather than estimating
+   silently.
+4. **Persist nothing about the person.** Records describe sessions, work,
+   budgets, and decisions — never assessments of the human's state, capacity, or
+   fatigue.
+5. **The Reservoir Warden is untouched.** It remains advisory-forever; gating
+   lives in the new sentinels. Do not add strict modes, thresholds-as-gates, or
+   new proxies to it in this work.
+6. **Progressive hardening.** Every new constraint ships at **Unverified** or
+   **Agent-verified** first. Deterministic enforcement is added only in the
+   slice that specifies it, and always with an escape hatch: an on-the-record
+   human override, never a bypass.
+7. **Records are append-only.** Superseded entries are marked superseded, never
+   edited.
+8. **Evidence comments.** Cite research grounding in `<!-- evidence: ... -->`
+   comments in skill files. **Language rule throughout all docs: "compulsive
+   pattern," never "addiction"; "reinforcing," never "dopamine."**
+9. **Category naming.** These four agents are documented under the **sentinel**
+   category.
+
+### Where a constraint was corrected in flight
+
+**Constraint 6's vocabulary was wrong.** It names an "Agent-verified" rung;
+`harness-md-format.md` gives the enforcement enum as
+`deterministic | agent | unverified`, with no such value. S5's spec gate raised
+this (objection O2) and the epic settled on a distinction the charter did not
+have: **the rung** is how a check runs, and **the reach** is what it demands.
+Progressive hardening applies to reach — a check may ship `deterministic` and
+still be *complete-if-present*. See
+`docs/plugins/ai-literacy-superpowers/explanation/progressive-hardening.md`.
+
+**Constraint 4 gained a third category.** S1 established *operational state* —
+permitted only when local and never committed, bounded, judging nothing, and
+disclosed and declinable. It is a narrow carve-out for plumbing, not a route
+around the rule; `skills/sentinel-design/SKILL.md` is authoritative, and it
+places parking records and consultation dispositions on the **by the person**
+side rather than inside the carve-out.
+
+## Non-goals
+
+- No changes to the Reservoir Warden beyond documentation cross-references.
+- No deterministic (CI/hook-blocking) enforcement beyond what each slice names.
+- No UI beyond existing surfaces; no platform notification enforcement;
+  **no contacting humans on anyone's behalf**.
+- No renaming or moving of existing agents.
+
+## Working style
+
+Quoted from the build spec:
+
+> Implement slice by slice, in order. Each slice ends with a human review gate —
+> do not proceed to the next slice without an explicit go. Where anything below
+> conflicts with established repo conventions, **the repo wins**: read the
+> existing agents, skills, and commands first, mirror their structure exactly,
+> and raise a note in the PR description for every divergence between this spec
+> and repo reality.
+
+*The repo wins* was load-bearing. It is why S5 shipped `deterministic` instead
+of the charter's `Agent-verified`, why S6 dropped a seventh objection category
+once the existing hunt-list mechanism was found, and why S7 shipped one
+discipline page rather than four per-agent pages.
+
+## What the epic shipped
+
+Four sentinels — `coda`, `mast`, `wip-warden`, `convener` — plus a
+`sentinel` category extension, five hooks, three record contracts, two
+deterministic constraints, and six derived parity checks.
+
+See `docs/plugins/ai-literacy-superpowers/explanation/cadence-discipline.md`.

--- a/docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md
@@ -14,9 +14,9 @@
 **Explicitly out of scope:** every sentinel that consumes this plumbing. S1
 ships plumbing only and gates nothing.
 
-**Provenance:** *The Second Front — Arc Insertion Remit* (slide S5, the roadmap
-sentinels) and *Compulsive Continuation — A Research Exploration* (evidence
-base), via the build spec *The Cadence Sentinels*.
+**Provenance:** the Cadence Sentinels build spec, supplied in conversation
+2026-08-08 — transcribed to `docs/superpowers/cadence-sentinels-charter.md`.
+Slice scope: issue #491.
 
 ---
 

--- a/docs/superpowers/specs/2026-08-09-cadence-sentinels-s2-coda-design.md
+++ b/docs/superpowers/specs/2026-08-09-cadence-sentinels-s2-coda-design.md
@@ -15,8 +15,9 @@ hook, and validator
 **Explicitly out of scope:** the Mast (S3), the WIP Warden (S4), the Convener
 (S5). S2 ships the ritual and the records it writes.
 
-**Provenance:** *The Second Front — Arc Insertion Remit* (slide S5) and
-*Compulsive Continuation — A Research Exploration*.
+**Provenance:** the Cadence Sentinels build spec, supplied in conversation
+2026-08-08 — transcribed to `docs/superpowers/cadence-sentinels-charter.md`.
+Slice scope: issue #492.
 
 ---
 

--- a/docs/superpowers/specs/2026-08-10-cadence-sentinels-s3-mast-design.md
+++ b/docs/superpowers/specs/2026-08-10-cadence-sentinels-s3-mast-design.md
@@ -15,8 +15,9 @@ and a write-side library. No hook, no session state, no new store.
 **Explicitly out of scope:** boundary notices and the hard stop, which are
 **#501** (see §3); the WIP Warden (S4); the Convener (S5).
 
-**Provenance:** *The Second Front — Arc Insertion Remit* (slide S5) and
-*Compulsive Continuation — A Research Exploration*.
+**Provenance:** the Cadence Sentinels build spec, supplied in conversation
+2026-08-08 — transcribed to `docs/superpowers/cadence-sentinels-charter.md`.
+Slice scope: issue #493.
 
 ---
 

--- a/docs/superpowers/specs/2026-08-10-cadence-sentinels-s4-wip-warden-design.md
+++ b/docs/superpowers/specs/2026-08-10-cadence-sentinels-s4-wip-warden-design.md
@@ -14,8 +14,9 @@ commit (§4.1).
 **Explicitly out of scope:** the override *record*, which is **#501**; the
 Convener (S5).
 
-**Provenance:** *The Second Front — Arc Insertion Remit* (slide S5) and
-*Compulsive Continuation — A Research Exploration*.
+**Provenance:** the Cadence Sentinels build spec, supplied in conversation
+2026-08-08 — transcribed to `docs/superpowers/cadence-sentinels-charter.md`.
+Slice scope: issue #494.
 
 ---
 

--- a/docs/superpowers/specs/2026-08-12-cadence-sentinels-s5-convener-design.md
+++ b/docs/superpowers/specs/2026-08-12-cadence-sentinels-s5-convener-design.md
@@ -12,7 +12,9 @@ in a carved commit (§6)
 `HARNESS.md` constraint
 **Explicitly out of scope:** contacting anyone, ever.
 
-**Provenance:** *The Second Front — Arc Insertion Remit* (slide S5).
+**Provenance:** the Cadence Sentinels build spec, supplied in conversation
+2026-08-08 — transcribed to `docs/superpowers/cadence-sentinels-charter.md`.
+Slice scope: issue #495.
 
 ---
 

--- a/docs/superpowers/specs/2026-08-13-cadence-sentinels-s6-embedded-assumptions-design.md
+++ b/docs/superpowers/specs/2026-08-13-cadence-sentinels-s6-embedded-assumptions-design.md
@@ -10,7 +10,9 @@
 agent rather than a new one.
 **Scope:** `skills/advocatus-diaboli/SKILL.md` and one new reference page.
 
-**Provenance:** *The Second Front — Arc Insertion Remit* (slide S6).
+**Provenance:** the Cadence Sentinels build spec, supplied in conversation
+2026-08-08 — transcribed to `docs/superpowers/cadence-sentinels-charter.md`.
+Slice scope: issue #496.
 
 ---
 

--- a/docs/superpowers/specs/2026-08-13-cadence-sentinels-s7-docs-design.md
+++ b/docs/superpowers/specs/2026-08-13-cadence-sentinels-s7-docs-design.md
@@ -10,9 +10,9 @@
 **Scope:** the docs site, `hooks.json`'s description, `README.md`, and one
 integration test
 
-**Provenance:** *The Second Front — Arc Insertion Remit* (slide S7) — **a
-document that is in neither repository.** See §3 and #514; the citation is
-recorded as unresolvable rather than repeated as though it were retrievable.
+**Provenance:** the Cadence Sentinels build spec, supplied in conversation
+2026-08-08 — transcribed to `docs/superpowers/cadence-sentinels-charter.md`.
+Slice scope: issue #497.
 
 ---
 
@@ -195,6 +195,13 @@ is to give the epic's results a durable home, is the last place anyone looks
 Revision 1 filed this as a blocked checklist item. It is the epic's own
 recurring defect at epic scale: a confident sentence describing something that
 is not there. **#514** records it, and this spec's own provenance line says so.
+
+> **Resolved 2026-08-13 (#514).** The deck does not exist *at all* — it was a
+> label for a build spec supplied in conversation, not a document that went
+> missing. Item 4 is therefore unverifiable by construction rather than blocked,
+> and #497 closed on that basis. The constraints the epic cites by number are
+> transcribed to `docs/superpowers/cadence-sentinels-charter.md`, and all seven
+> provenance lines now point there.
 
 ### 3.2 So this PR does not close #497
 


### PR DESCRIPTION
Closes #514. Resolves the outstanding item on #497.

## What was actually wrong

All seven Cadence Sentinels specs cited **The Second Front — Arc Insertion Remit**. It is in neither repository — and, confirmed with you, **it never existed**. It was a label for a build spec supplied in conversation on 2026-08-08, not a document that went missing.

A second cited title, *Compulsive Continuation — A Research Exploration*, is equally absent. **The evidence itself is not missing** — every `<!-- evidence: ... -->` comment in the skills names published work inline (distributed cognition, the vigilance decrement, task-switching cost, Ulysses pacts). What did not exist was the umbrella document.

## The half nobody had noticed

The specs cite the epic's constitutional constraints **by number** — and the numbered list was nowhere in the repository.

**Fifteen references across seven distinct constraints.** A reader meeting *"Constraint 7 says records are append-only"* in the S1 spec had no way to see constraints 1 through 9. That is a worse gap than the provenance line, and it only surfaced because the provenance question forced a look.

## The fix

**`docs/superpowers/cadence-sentinels-charter.md`** transcribes all nine constraints verbatim from the build spec, plus the non-goals and the working style — including the line that turned out to be load-bearing:

> Where anything below conflicts with established repo conventions, **the repo wins**.

That instruction is why S5 shipped `deterministic` instead of the charter's `Agent-verified`, why S6 dropped a seventh objection category once the existing hunt-list was found, and why S7 shipped one discipline page rather than four.

The charter also records **where two constraints were corrected in flight**, so the transcription does not read as still-current:

- **Constraint 6** names an "Agent-verified" rung that was never a value of the enforcement enum. S5's gate raised it; the epic settled on rung-vs-reach instead.
- **Constraint 4** gained the operational-state carve-out in S1 — and `sentinel-design/SKILL.md` remains authoritative on what falls inside it, which is what the #499 gate turned on.

**All seven provenance lines** now read:

```text
**Provenance:** the Cadence Sentinels build spec, supplied in conversation
2026-08-08 — transcribed to `docs/superpowers/cadence-sentinels-charter.md`.
Slice scope: issue #491.
```

Every element is retrievable: the charter is in the tree, and per-slice scope is in issues #491–#497 and #501.

## Also

S7's spec §3 gains a resolution note, so a reader does not find a section describing an open blocker that has since been answered. The S7 objection record is left untouched — records are append-only, and it was accurate when written.

## Scope

Docs only. **Nothing under `ai-literacy-superpowers/` changed, so no version bump** and no CHANGELOG entry — this corrects the provenance of specs, not the plugin.

`fix/` branch prefix for the spec-first exemption: this is a correction to existing documents, not a design change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)