### PR TITLE
Give the sentinel docs a usage path (#519)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@
 
 ### Fixed
 
+- **The sentinel docs now have a usage path** (#519). They were written for
+  people who *build* sentinels rather than people who *use* them:
+  `explanation/sentinels.md` carried exactly one how-to link and it pointed at
+  `design-a-sentinel.md`, its roster's third column was "signature evidence"
+  (proof an agent qualifies), and two of its eight sections were for authors.
+  A reader who had just learned what the nine are had almost no path onward.
+- **New `Using them` section** on the sentinels page: one row per sentinel with
+  *reach for it when*, the command, and the guide — answering "which one",
+  "how", and "what is available" in one table. Plus what to try first, and the
+  distinction between the four that run in the pipeline and the five you call.
+- **Every sentinel's `reference/agents.md` entry now names its command.** Four
+  did; `coda` and `mast` passed only incidentally, with the command appearing in
+  prose. All nine now carry a structural `Run` field.
+- **New tutorial `your-first-sentinels.md`** — the Diataxis learning quadrant was
+  empty for this category. All nine tutorials mentioned no sentinel, and
+  `first-time-tour.md` presented `/diaboli` as freestanding rather than one of
+  nine. It now says so, and links onward.
+- **New Layer 0 test** `test-sentinel-usage-path.sh` (U1-U4). Three relations,
+  each derived from both ends: sentinels from `role: sentinel`, commands from
+  `reference/commands.md`'s own **Agents dispatched** field — a mapping that
+  already existed and nothing consumed — and guides from the new table. Six
+  mutations, all killed.
+
 - **A constraint's enum values are now checked across the convention mirrors**
   (#511). `check-convention-parity.py` matches constraint **headings**, so a
   change to a rule's **body** passed untouched while `.cursor`, `.github` and

--- a/docs/plugins/ai-literacy-superpowers/explanation/sentinels.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/sentinels.md
@@ -142,6 +142,47 @@ guards *the room* — a spec can be internally excellent and still be wrong
 because the person who wrote it never asked the one question that would
 have changed it, and that failure is invisible from inside.
 
+## Using them
+
+The roster above says what each sentinel *guards*. This says when to reach for
+one.
+
+| Sentinel | Reach for it when | Run | Guide |
+| --- | --- | --- | --- |
+| `carpaccio` | A task is big enough that you cannot hold the whole decision at once | `/carpaccio` | [Slicing a task](../how-to/slicing-a-task.md) |
+| `advocatus-diaboli` | A spec is about to be approved, or code is about to be integrated | `/diaboli` | [Review a spec adversarially](../how-to/review-a-spec-adversarially.md) |
+| `choice-cartographer` | A spec has made decisions nobody wrote down as decisions | `/choice-cartograph` | [Run choice-cartograph](../how-to/run-choice-cartograph.md) |
+| `convener` | A change reaches past the room — a published surface, a default, an error message | `/convene` | [Convening the voices](../how-to/convening-the-voices.md) |
+| `cost-estimator` | You want the token and time cost of a task **before** committing to it | `/cost-estimate` | [Estimate task cost](../how-to/estimate-task-cost.md) |
+| `reservoir-warden` | You have been at it a while and want the observable proxies, not a verdict | `/reservoir` | [Watch your cognitive reservoir](../how-to/watch-your-cognitive-reservoir.md) |
+| `wip-warden` | You suspect more is open at once than you can hold | `/wip` | [Watching your WIP](../how-to/watching-your-wip.md) |
+| `mast` | You want a limit you set in clear weather to survive the moment it governs | `/mast` | [Keeping a pact](../how-to/keeping-a-pact.md) |
+| `coda` | A session is ending and you would rather stop by decision than by attrition | `/coda` | [Closing a session](../how-to/closing-a-session.md) |
+
+### You do not have to adopt them all
+
+Nothing here is required, and nothing cascades. Each sentinel reads its own
+declaration surface and stays silent when you have not declared one — a
+`Session WIP` block you never wrote means `/wip` reports no limit rather than
+inventing one, and a project with no `## Stakeholders` section gets a shorter,
+`inferred`-flagged voice list rather than a warning.
+
+**The four in the pipeline run whether you ask or not.** `carpaccio`,
+`advocatus-diaboli`, `choice-cartographer` and `convener` have positions in the
+orchestrator's flow, because the failures they catch are invisible from inside
+the work — the people who most need them are the people who would not think to
+run them. The commands above are for running one on demand.
+
+**The other five are yours to call.** `/reservoir`, `/wip`, `/mast`, `/coda` and
+`/cost-estimate` answer when asked and otherwise stay out of the way.
+
+### If you only try one
+
+`/coda`, at the end of a session you would otherwise let trail off. It is the
+cheapest to adopt — no declaration surface to write first — and it produces the
+thing the others depend on: a session that ended on purpose, with what was left
+open written down rather than carried.
+
 ### A second declaration surface: the pact file
 
 The **cadence sentinels** now under construction — the Coda, the Mast,

--- a/docs/plugins/ai-literacy-superpowers/index.md
+++ b/docs/plugins/ai-literacy-superpowers/index.md
@@ -53,6 +53,7 @@ matches the kind of reading you're doing right now.
 
 Start here if you're new to the plugin.
 
+- [Your First Sentinels](tutorials/your-first-sentinels.md) — meet three of the nine in one session; the category that guards your understanding rather than your code
 - [Getting Started](tutorials/getting-started.md)
 - [First Time Tour](tutorials/first-time-tour.md)
 - [Harness From Scratch](tutorials/harness-from-scratch.md)

--- a/docs/plugins/ai-literacy-superpowers/reference/agents.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/agents.md
@@ -62,6 +62,7 @@ falling back to static where it is absent. The Plan Approval GATE and
 
 ### carpaccio
 
+- **Run**: `/carpaccio`
 - **Tools**: Read, Glob, Grep
 - **Dispatched by**: orchestrator (step 0, before spec-writer)
 - **Trust boundary**: Read-only
@@ -118,6 +119,7 @@ the TDD agent will translate into tests.
 
 ### advocatus-diaboli
 
+- **Run**: `/diaboli`
 - **Tools**: Read, Glob, Grep
 - **Dispatched by**: orchestrator (after spec-writer, before plan approval)
 - **Trust boundary**: Read-only
@@ -148,6 +150,7 @@ read-only trust boundary unchanged.
 
 ### choice-cartographer
 
+- **Run**: `/choice-cartograph`
 - **Tools**: Read, Glob, Grep
 - **Dispatched by**: orchestrator (after spec-mode advocatus-diaboli
   dispositions are resolved, before plan approval)
@@ -178,7 +181,7 @@ This release is spec-mode only. Code-mode behaviour is tracked under
 
 ### coda
 
-**Role:** sentinel · **Tools:** Read, Glob, Grep, Bash · **Trust boundary:** read-only
+**Role:** sentinel · **Tools:** Read, Glob, Grep, Bash · **Trust boundary:** read-only · **Run:** `/coda`
 
 Closes a session deliberately rather than by attrition. Surveys what landed and
 what is still live, proposes a thread grouping for the human to confirm, and
@@ -198,7 +201,7 @@ See the `coda` skill and [Closing a session](../how-to/closing-a-session.md).
 
 ### mast
 
-**Role:** sentinel · **Tools:** Read, Glob, Grep, Bash · **Trust boundary:** read-only
+**Role:** sentinel · **Tools:** Read, Glob, Grep, Bash · **Trust boundary:** read-only · **Run:** `/mast`
 
 Reads the pact a human authored for themselves and reports where they stand
 against it — reciting their own declared words first and annotating after,
@@ -221,7 +224,7 @@ See the `mast` skill and [Keeping a pact](../how-to/keeping-a-pact.md).
 
 ### wip-warden
 
-**Role:** sentinel · **Tools:** Read, Glob, Grep, Bash · **Trust boundary:** read-only
+**Role:** sentinel · **Tools:** Read, Glob, Grep, Bash · **Trust boundary:** read-only · **Run:** `/wip`
 
 Counts live sessions against the limit the human declared for themselves, lists
 which they are and how long since each last took a turn, and says when they are
@@ -243,7 +246,7 @@ See the `wip-warden` skill and [Watching your WIP](../how-to/watching-your-wip.m
 
 ### convener
 
-**Role:** sentinel · **Tools:** Read, Glob, Grep · **Trust boundary:** read-only
+**Role:** sentinel · **Tools:** Read, Glob, Grep · **Trust boundary:** read-only · **Run:** `/convene`
 
 Runs at plan approval beside the `choice-cartographer`. Maps the **voices** a
 spec affects — the roles and groups outside the room — drafts the one concrete
@@ -273,6 +276,7 @@ See the `convener` skill and [Convening the voices](../how-to/convening-the-voic
 
 ### cost-estimator
 
+- **Run**: `/cost-estimate`
 - **Tools**: Read, Glob, Grep
 - **Dispatched by**: a downstream `/cost-estimate` command / orchestrator
   fold-in (out of scope at this slice)
@@ -484,6 +488,7 @@ governance analysis requires nuanced judgement about meaning.
 
 ### reservoir-warden
 
+- **Run**: `/reservoir`
 - **Tools**: Read, Glob, Grep, Bash
 - **Model**: inherit (routed to an inexpensive tier — see `MODEL_ROUTING.md`)
 - **Dispatched by**: `/reservoir`

--- a/docs/plugins/ai-literacy-superpowers/tutorials/first-time-tour.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/first-time-tour.md
@@ -528,6 +528,13 @@ isolation from your main workspace.
 
 ### `/diaboli`
 
+> **One of nine.** `/diaboli` is a **sentinel** — an agent that informs,
+> challenges, surfaces or warns, and never fixes, writes, merges or decides.
+> There are nine, and this tour covers one. See
+> [Your first sentinels](your-first-sentinels.md) for three of them across a
+> session, or [Sentinels](../explanation/sentinels.md) for the full roster and
+> which to reach for when.
+
 **What it does.** Dispatches the advocatus-diaboli agent against a
 spec file and produces a structured objection record at
 `docs/superpowers/objections/<slug>.md`. The agent raises up to 12

--- a/docs/plugins/ai-literacy-superpowers/tutorials/your-first-sentinels.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/your-first-sentinels.md
@@ -1,0 +1,156 @@
+---
+title: Your first sentinels
+---
+# Your first sentinels
+
+Most agents in this plugin act on an artefact. Sentinels act on **you** — they
+inform, challenge, surface, or warn, and then stop. None of them writes code,
+merges anything, or decides.
+
+This tutorial runs three of them across one session, in the order you would
+meet them. It takes about twenty minutes and changes nothing you cannot undo.
+
+**You will need** a repository with the plugin installed. Any repository —
+these three need no setup and no declaration files.
+
+## What you are about to do
+
+1. Close a session on purpose with `/coda`
+2. Come back and see what it left for you
+3. Ask `/reservoir` what it can actually observe
+4. Attack a spec with `/diaboli` before approving it
+
+If you stop after step 2, you will still have got the most valuable one.
+
+## Step 1 — End a session deliberately
+
+Do some work first. Anything real: fix something small, start something and
+leave it half-done. Then:
+
+```text
+/coda
+```
+
+The Coda surveys what landed and what is still live, and asks you a question
+per open thread:
+
+```text
+Threads still live:
+
+  1. The retry backoff — you changed the constant but the test still
+     asserts the old value
+  2. Docs for the new flag
+
+What is the next action for thread 1?
+```
+
+**Answer it as if writing to yourself on Monday.** "Continue the retry work" is
+a label; "change the assertion in test_retry.py:44 to 500ms, then check whether
+the docs example still matches" is a next action.
+
+The Coda will push back once if what you wrote does not look like a starting
+point. It asks — it does not refuse, and it does not record that it asked.
+
+### What just happened
+
+- It **proposed** a thread grouping and you confirmed or changed it.
+- It **drafted** the records; the command wrote them after you agreed.
+- The agent itself holds no `Write`. That is not a policy — it is the tool
+  boundary, and it is why the words in the record are yours.
+
+## Step 2 — Come back
+
+Start a new session in the same repository. Before you type anything:
+
+```text
+You parked 2 threads in an earlier session:
+
+  · The retry backoff — change the assertion in test_retry.py:44 to 500ms,
+    then check whether the docs example still matches
+  · Docs for the new flag — write the upgrade note; the flag defaults
+    differently for existing users
+```
+
+**This is the payoff, and it is the whole argument for the ritual.** The value
+of writing a next action is not the writing; it is that a version of you with no
+context can act on it immediately.
+
+A record nobody ever sees again is a diary. This is a handoff — to yourself.
+
+## Step 3 — Ask what can actually be observed
+
+```text
+/reservoir
+```
+
+You get something like:
+
+```text
+Session span      4h 20m          observed
+Decision volume   31 commits      observed
+Context switches  3 repositories  inferred
+Wall-clock hour   21:40 local     observed
+```
+
+**Read the flags, not just the numbers.** `observed` means it counted
+something real. `inferred` means it derived it and could be wrong. There is no
+third thing where it guesses and does not say so.
+
+Notice what is *not* there: no score, no "you seem tired", no percentage of
+anything. The Reservoir Warden watches the one actor the harness cannot
+verify — you — and it is trustworthy precisely because it has no teeth and
+wants none. It will offer one recommendation if a threshold is crossed:
+**decide your stop before the next session begins.** That is all.
+
+It persists nothing about you. Run it, read it, and it is gone.
+
+## Step 4 — Have a spec attacked
+
+Now the other kind. Take a spec — a real one, or write three paragraphs
+describing something you are about to build:
+
+```text
+/diaboli docs/superpowers/specs/2026-08-20-my-feature.md
+```
+
+The Advocatus Diaboli reads it and raises the strongest objections it can, each
+in one of six categories, each with evidence quoted from the spec itself.
+
+Then it stops, and every objection sits at `disposition: pending`.
+
+**Nothing proceeds until you write a disposition in the file yourself.** Not
+because a rule says so — because the agent holds no `Write` and cannot fill
+that field. It is a hard gate, and the gate *is* the tool boundary.
+
+Open the record and write, per objection, `accepted`, `deferred` or `rejected`,
+with a rationale. Argue back where you disagree; a `rejected` with a reason is a
+complete answer and the record is better for containing it.
+
+### The thing worth noticing
+
+You just spent real thought on objections you did not have to engage with. That
+is the point of the whole category. An unchallenged spec is not a good spec — it
+is an untested assertion, and the friction you just felt is the quality.
+
+## What you have learned
+
+| | |
+| --- | --- |
+| **They propose; you dispose** | Every gate ends in a human writing something. No sentinel auto-approves or silently blocks. |
+| **The boundary is the mechanism** | They hold no `Write`. The disposition field cannot be filled by an agent, so engagement is structural rather than requested. |
+| **They say how they know** | `observed`, `inferred`, `asked`. When a value cannot be observed, they say so instead of estimating. |
+| **They persist nothing about you** | Records describe sessions, work and decisions — never an assessment of your state. |
+
+## Where to go next
+
+There are **nine** sentinels. You have met three.
+
+- **[Sentinels](../explanation/sentinels.md)** — the full roster and, in *Using
+  them*, which to reach for when
+- **[The cadence discipline](../explanation/cadence-discipline.md)** — `coda`,
+  `mast`, `wip-warden`, `convener`: the shape of the work around decisions
+- **[The decision-discipline triad](../explanation/decision-discipline-triad.md)**
+  — `carpaccio`, `advocatus-diaboli`, `choice-cartographer`
+
+If you adopt one more, make it `/mast`: write down a limit while you are calm,
+and find out whether it survives the moment it governs.

--- a/tdad_tests/layer0_deterministic/test-sentinel-usage-path.sh
+++ b/tdad_tests/layer0_deterministic/test-sentinel-usage-path.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for the sentinel usage path (#519).
+#
+# WHAT WENT WRONG. The sentinel documentation was written for people who BUILD
+# sentinels rather than people who USE them. `explanation/sentinels.md` — the
+# canonical page for the category, 219 lines — carried exactly one how-to link,
+# and it pointed at `design-a-sentinel.md`, a guide to authoring one. Its roster
+# columns were `Agent | Guards | Signature evidence`, the third being proof that
+# the agent qualifies. Two of its eight sections were explicitly for authors.
+#
+# The result: a reader who had just learned what the nine sentinels are had
+# almost no path onward. `reference/agents.md` named the command for two of
+# them. Nothing anywhere answered "which one should I reach for, and when".
+#
+# WHAT THIS ASSERTS, AND WHY IT IS DERIVED. Three relations, each read from both
+# ends so no list is pinned anywhere:
+#
+#   sentinel  <- `role: sentinel` frontmatter in agents/*.agent.md
+#   command   <- the `Agents dispatched` field in reference/commands.md
+#   guide     <- the usage table in explanation/sentinels.md
+#
+# The command relation is the one worth noting: reference/commands.md already
+# declared which agent each command dispatches, so the mapping existed and
+# nothing consumed it. Deriving from it means a new sentinel with a new command
+# is covered the day both are documented, and a renamed command fails here
+# rather than silently pointing readers at nothing.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$SCRIPT_DIR/../.."
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+PY=/usr/bin/python3
+command -v "$PY" >/dev/null 2>&1 || PY=python3
+
+"$PY" - "$ROOT" <<'HARNESS_EOF'
+import glob, os, re, sys
+
+root = sys.argv[1]
+agents_dir = os.path.join(root, "ai-literacy-superpowers", "agents")
+commands_dir = os.path.join(root, "ai-literacy-superpowers", "commands")
+docs = os.path.join(root, "docs", "plugins", "ai-literacy-superpowers")
+sentinels_page = os.path.join(docs, "explanation", "sentinels.md")
+commands_ref = os.path.join(docs, "reference", "commands.md")
+agents_ref = os.path.join(docs, "reference", "agents.md")
+
+errors = []
+
+
+def frontmatter(text):
+    if not text.startswith("---"):
+        return ""
+    body = text[3:]
+    end = body.find("\n---")
+    return body[:end] if end != -1 else ""
+
+
+# --- source of truth 1: who is a sentinel ------------------------------------
+sentinels = set()
+for path in sorted(glob.glob(os.path.join(agents_dir, "*.agent.md"))):
+    with open(path, encoding="utf-8") as fh:
+        fm = frontmatter(fh.read())
+    if re.search(r"^role:\s*sentinel\s*$", fm, re.MULTILINE):
+        name = re.search(r"^name:\s*(\S+)", fm, re.MULTILINE)
+        if name:
+            sentinels.add(name.group(1).strip())
+if not sentinels:
+    print("FAIL: no role: sentinel agents found", file=sys.stderr)
+    sys.exit(1)
+
+# --- source of truth 2: which command dispatches it ---------------------------
+# The field is not consistently backticked, so match bare words too.
+dispatch = {}
+current = None
+with open(commands_ref, encoding="utf-8") as fh:
+    for line in fh:
+        heading = re.match(r"^###\s+(/[a-z-]+)", line)
+        if heading:
+            current = heading.group(1)
+            continue
+        field = re.match(r"^-\s+\*\*Agents dispatched\*\*:\s*(.+)$", line)
+        if field and current:
+            for agent in re.findall(r"[a-z][a-z-]{2,}", field.group(1).replace("`", "")):
+                dispatch.setdefault(agent, set()).add(current)
+
+# --- U1: every sentinel has a documented command that exists ------------------
+for name in sorted(sentinels):
+    commands = dispatch.get(name)
+    if not commands:
+        errors.append(
+            f"U1: sentinel '{name}' is dispatched by no command in "
+            "reference/commands.md — a reader cannot learn how to run it"
+        )
+        continue
+    for command in sorted(commands):
+        target = os.path.join(commands_dir, command.lstrip("/") + ".md")
+        if not os.path.isfile(target):
+            errors.append(
+                f"U1: reference/commands.md says {command} dispatches '{name}', "
+                f"but {os.path.relpath(target, root)} does not exist"
+            )
+
+# --- U2: the usage table names every sentinel, its command and its guide ------
+with open(sentinels_page, encoding="utf-8") as fh:
+    page = fh.read()
+
+section = re.search(r"\n##\s+Using them\s*\n(.*?)(?=\n##\s|\Z)", page, re.S)
+if not section:
+    errors.append(
+        "U2: explanation/sentinels.md has no '## Using them' section — the "
+        "category page must answer which sentinel to reach for, not only what "
+        "one is"
+    )
+else:
+    body = section.group(1)
+    for name in sorted(sentinels):
+        if f"`{name}`" not in body:
+            errors.append(f"U2: '{name}' is missing from the Using them table")
+            continue
+        row = next((ln for ln in body.splitlines() if f"`{name}`" in ln), "")
+        for command in sorted(dispatch.get(name, [])):
+            if command not in row:
+                errors.append(
+                    f"U2: the '{name}' row does not name its command {command}"
+                )
+        if "how-to/" not in row:
+            errors.append(f"U2: the '{name}' row links to no how-to guide")
+
+# --- U3: every guide the table links to exists --------------------------------
+for target in re.findall(r"\.\./how-to/([a-z0-9-]+\.md)", page):
+    if not os.path.isfile(os.path.join(docs, "how-to", target)):
+        errors.append(f"U3: sentinels.md links to how-to/{target}, which does not exist")
+
+# --- U4: each sentinel's agents.md entry names its command --------------------
+# Someone reading the reference entry for an agent should not have to go
+# elsewhere to learn how to run it.
+with open(agents_ref, encoding="utf-8") as fh:
+    agents_text = fh.read()
+for name in sorted(sentinels):
+    entry = re.search(rf"\n###\s+{re.escape(name)}\s*\n(.*?)(?=\n###\s|\Z)", agents_text, re.S)
+    if not entry:
+        errors.append(f"U4: reference/agents.md has no '### {name}' entry")
+        continue
+    if not any(c in entry.group(1) for c in dispatch.get(name, [])):
+        commands = ", ".join(sorted(dispatch.get(name, []))) or "(none known)"
+        errors.append(
+            f"U4: the reference/agents.md entry for '{name}' never names its "
+            f"command ({commands})"
+        )
+
+if errors:
+    for error in errors:
+        print(f"FAIL: {error}", file=sys.stderr)
+    sys.exit(1)
+
+print(
+    f"PASS: sentinel usage path — {len(sentinels)} sentinels, each with a "
+    "command that exists, a row in Using them, and a guide"
+)
+HARNESS_EOF

--- a/tdad_tests/tests/test_layer0_deterministic.py
+++ b/tdad_tests/tests/test_layer0_deterministic.py
@@ -58,6 +58,9 @@ BASH_TEST_SCRIPTS = [
     # #507 — the sentinel roster is a derived fact pinned in three places.
     # Membership only: the tables carry prose no generator would write well.
     "test-sentinel-roster-parity",
+    # #519 — the sentinel docs were written for authors, not users. Derives
+    # the agent-command relation from reference/commands.md's own field.
+    "test-sentinel-usage-path",
     "test-hooks-doc-parity",
     "test-cadence-integration",
     "test-affordances-template",


### PR DESCRIPTION
Closes #519.

## The finding

The sentinel documentation was written for people who **build** sentinels, not people who **use** them.

`explanation/sentinels.md` is the canonical page for the category — 219 lines. It contained exactly **one** how-to link, and it pointed at `design-a-sentinel.md`, a guide to authoring one.

The orientation was consistent:

- Roster columns were `Agent | Guards | **Signature evidence**` — the third being *proof the agent qualifies as a sentinel*.
- Two of eight sections were explicitly for authors: **The near-miss gallery**, **Extending the category**.
- One `/command` reference in the whole page, incidental, inside a signature-evidence cell.

A reader who had just learned what the nine sentinels are had almost no path onward.

**What was already fine:** all nine have a dedicated how-to. I expected holes and found none — the guides existed, nothing connected them.

## Fixes

**1. A `Using them` section** — one row per sentinel with *reach for it when*, the command, and the guide. It answers "which one", "how do I run it", and "what is available" in one table.

It also says two things the docs never did: that **you do not have to adopt them all** (each stays silent when its declaration surface is absent), that **four run in the pipeline and five you call**, and — for someone deciding where to start — **if you only try one, `/coda`**.

**2. Every `reference/agents.md` entry names its command.** Four did. `coda` and `mast` passed only *incidentally*, with the command appearing in prose — the check would have passed for the wrong reason. All nine now carry a structural `Run` field.

**3. A tutorial.** The Diataxis learning quadrant was empty for this category: all nine tutorials mentioned no sentinel, and `first-time-tour.md` presented `/diaboli` as freestanding rather than one of nine. `your-first-sentinels.md` runs `/coda` → resume → `/reservoir` → `/diaboli` across one session, and the tour now says which category it is showing you.

## The check

`test-sentinel-usage-path.sh`, U1–U4. Three relations, **each derived from both ends** — nothing pinned:

| Relation | Source |
| --- | --- |
| who is a sentinel | `role: sentinel` frontmatter |
| which command runs it | `reference/commands.md`'s **Agents dispatched** field |
| which guide covers it | the new `Using them` table |

The command relation is worth noting: that mapping already existed in the docs and **nothing consumed it**. Deriving from it means a new sentinel is covered the day both are documented, and a renamed command fails here rather than silently pointing readers at nothing.

| Mutation | Result |
| --- | --- |
| an entry names a command that does not exist | KILLED |
| an entry loses its command | KILLED |
| a sentinel drops out of `Using them` | KILLED |
| a guide link dangles | KILLED |
| a row loses its command | KILLED |
| a command stops declaring its agent | KILLED |

## Scope

Docs plus one test. **Nothing under `ai-literacy-superpowers/` changed**, so no version bump; the CHANGELOG entry appends under the existing `0.73.2` heading.

Full suite: 443 passed, 31 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)