### PR TITLE
chore: stamp HARNESS.md template marker to 0.73.2

### DIFF
--- a/HARNESS.md
+++ b/HARNESS.md
@@ -10,7 +10,7 @@
 
      Inspired by Birgitta Boeckeler's "Harness Engineering":
      https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html -->
-<!-- template-version: 0.66.2 -->
+<!-- template-version: 0.73.2 -->
 
 ## Context
 


### PR DESCRIPTION
`/harness-upgrade` run, 2026-08-13. **Nothing was adopted** — this is the marker stamp only.

## Result

```text
Upgrade scan — template (content v0.57.0) vs HARNESS.md

Constraints         template 10 · mine 36 · new: 0
Garbage Collection  template 31 · mine 36 · new: 0
Sections            template  7 · mine  8 · new: 0
```

**The harness already contains all current template content.**

## Why the version gap was misleading

The sync scan flagged `0.66.2` vs plugin `0.73.2` — seven minor versions, which looks alarming. It is entirely version-number movement:

- The template's own **content** marker has sat at `0.57.0` throughout.
- The `0.73.2` cache copy is **byte-identical** to the repo's `ai-literacy-superpowers/templates/HARNESS.md`.

So no template content has changed since 0.57.0, and the marker in `HARNESS.md` was tracking the *plugin* version rather than the template's.

## The one apparent finding, and why it was rejected

The template has a constraint this harness lacks by name:

| | Template | Here |
| --- | --- | --- |
| Heading | `Consistent formatting` | `Consistent markdown formatting` |
| Rule | all source files pass the configured formatter | all markdown passes markdownlint with `.markdownlint.json` |
| Enforcement | `unverified` | `deterministic` |
| Tool | `none yet` | `npx markdownlint-cli2` |
| Scope | `commit` | `commit + pr` |

Same constraint, already hardened. Adopting the template's version would replace a working deterministic check with an unverified placeholder — step 3's "the user's version takes precedence" rule.

## Two notes on the command itself

- **Its paths are baked to the `0.66.2` cache.** Caches exist through `0.73.2`. It did not matter here because the templates are identical, but on any release where they differ this command would compare against a stale template. Worth a follow-up if you want one.
- **This repo is the self-referential case** — it *is* the plugin, so the authoritative template is `ai-literacy-superpowers/templates/HARNESS.md` in-tree rather than any cache. That is what I compared against.

## Scope

One line. `.claude/.harness-upgrade-dismissed` was also written to silence the SessionStart nudge, but it is gitignored (per-machine) so it does not appear in the diff.

Advisory, no action taken: `## Cognitive reservoir` exists here and not in the template.