### PR TITLE
Pin the clock in test-mast-boundary instead of racing it (#527)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.73.2",
+  "plugin_version": "0.73.3",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.73.2"
+      "version": "0.73.3"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.73.3 — 2026-08-14
+
+### Fixed
+
+- **`test-mast-boundary` no longer races the clock** (#527). MB3 built its
+  fixture with `date -v+300M +%H:%M`, which formats `HH:MM` and discards the
+  date — so a run after 19:00 produced a stop hour on the *following* day, which
+  the hook could only read as many hours behind. It emitted the reached notice
+  and the test failed, for roughly five hours in every twenty-four. CI never hit
+  it because pushes landed earlier in the day.
+- **The hook was correct throughout.** Its own comment says so: *"there is no
+  day-rollover puzzle because there is no interval."* A stop hour already past
+  today *should* produce the reached notice. The fixture was impossible, not the
+  behaviour — worth stating, because the obvious fix would have been to change
+  the hook.
+- **MB1 and MB2 carried smaller versions of the same defect** — 21-minute and
+  1-minute failure windows. Pinning the clock removes all three rather than
+  narrowing them.
+- **New `$CLAUDE_MAST_NOW` test-only override**, the fifth here beside
+  `$CLAUDE_PACTS_FILE`, `$CLAUDE_SESSIONS_DIR`, `$CLAUDE_MAST_DIR` and
+  `$CLAUDE_PARKED_DIR`. Malformed values fall through to the real clock: a
+  boundary notice must never break a `Stop` hook. `minutes_from_now` now refuses
+  to wrap rather than emitting a fixture the hook cannot satisfy.
+- Verified across eight timezones, including the two that reproduced the failure.
+  Three mutations killed.
+
 ## 0.73.2 — 2026-08-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.73.2-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.73.3-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-41-2E8B57?style=flat-square)](#skills-41)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.73.2 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **41 skills, 20 agents, 32 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.73.3 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **41 skills, 20 agents, 32 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.73.2",
+  "version": "0.73.3",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/hooks/scripts/mast-boundary-check.sh
+++ b/ai-literacy-superpowers/hooks/scripts/mast-boundary-check.sh
@@ -54,7 +54,21 @@ case "$lead" in ''|*[!0-9]*) lead=30 ;; esac
 
 # Minutes from now until the line, in local time — the same frame the human
 # declared it in.
-now_min=$(( 10#$(date +%H) * 60 + 10#$(date +%M) ))
+#
+# $CLAUDE_MAST_NOW pins the clock to an `HH:MM` for tests, and is TEST-ONLY —
+# the fifth such override in this codebase, beside $CLAUDE_PACTS_FILE,
+# $CLAUDE_SESSIONS_DIR, $CLAUDE_MAST_DIR and $CLAUDE_PARKED_DIR. It exists
+# because a test that builds its fixture from `date` races the clock: MB3 built
+# a stop hour five hours ahead, which wraps past midnight after 19:00 and comes
+# back as a bare HH:MM the hook can only read as many hours BEHIND. The hook was
+# right every time; the fixture was impossible. Malformed values fall through to
+# the real clock rather than failing — a boundary notice must never break a Stop
+# hook (#527).
+now_hhmm="$(date +%H:%M)"
+case "${CLAUDE_MAST_NOW:-}" in
+  [0-9][0-9]:[0-9][0-9]) now_hhmm="$CLAUDE_MAST_NOW" ;;
+esac
+now_min=$(( 10#${now_hhmm%%:*} * 60 + 10#${now_hhmm##*:} ))
 stop_min=$(( 10#${stop_hour%%:*} * 60 + 10#${stop_hour##*:} ))
 remaining=$(( stop_min - now_min ))
 

--- a/docs/plugins/ai-literacy-superpowers/reference/hooks.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/hooks.md
@@ -216,7 +216,7 @@ opt-in check — so removing your `Budgets` block cleans up rather than strandin
 files forever.
 
 **To switch it off**, remove the `mast-boundary-check.sh` entry from
-`hooks/hooks.json`. `$CLAUDE_MAST_DIR` relocates the store and is test-only.
+`hooks/hooks.json`. `$CLAUDE_MAST_DIR` relocates the store and is test-only, as is `$CLAUDE_MAST_NOW`, which pins the clock to an `HH:MM` so a test can build a stop hour deterministically instead of racing `date`. A malformed value falls through to the real clock — a boundary notice must never break a `Stop` hook.
 
 ### Reservoir check (command)
 

--- a/tdad_tests/layer0_deterministic/test-mast-boundary.sh
+++ b/tdad_tests/layer0_deterministic/test-mast-boundary.sh
@@ -37,7 +37,30 @@ pact() {
     printf '\nUnspent budget is not a debt.\n'; } > "$CLAUDE_PACTS_FILE"
 }
 at() { printf '%02d:%02d' "$1" "$2"; }   # a local HH:MM
-minutes_from_now() { date -v+"$1"M +%H:%M 2>/dev/null || date -d "+$1 minutes" +%H:%M; }
+
+# THE CLOCK IS PINNED (#527). Every stop hour below is arithmetic from NOW_MIN,
+# never from `date`.
+#
+# MB3 used to build its fixture with `date -v+300M +%H:%M`, which formats HH:MM
+# and throws the date away. Run after 19:00 that returns a time on the FOLLOWING
+# day, which the hook can only read as many hours behind — so it emitted the
+# reached notice and MB3 failed. The hook was correct every time; the fixture was
+# impossible. The failure window was about five hours in every twenty-four, and
+# CI never hit it only because pushes landed earlier in the day.
+#
+# MB1 (+20m) and MB2 (00:01, "already passed for any run after 00:01") carried
+# smaller versions of the same defect — 21-minute and 1-minute windows. Pinning
+# removes all three rather than narrowing them.
+export CLAUDE_MAST_NOW="12:00"
+NOW_MIN=$(( 12 * 60 ))
+
+# minutes_from_now <n> — an HH:MM <n> minutes after the pinned NOW.
+# Refuses to wrap: a fixture that crosses midnight is the bug this test has.
+minutes_from_now() {
+  local m=$(( NOW_MIN + $1 ))
+  [ "$m" -lt 1440 ] || fail "fixture error: +$1m from the pinned clock crosses midnight"
+  printf '%02d:%02d' $(( m / 60 )) $(( m % 60 ))
+}
 
 # --- MB4: no block, no output, AND no store ---------------------------------
 : > "$CLAUDE_PACTS_FILE"
@@ -61,7 +84,7 @@ run
 
 # --- MB2: reached fires once and recommends /coda ---------------------------
 rm -rf "${CLAUDE_MAST_DIR:?}" "${CLAUDE_ADVISORY_DIR:?}"
-pact "$(at 0 1)"   # 00:01 — already passed for any run after 00:01
+pact "$(at 0 1)"   # 00:01 — before the pinned 12:00, so unambiguously passed
 run
 echo "$OUT" | grep -qF '/coda' || fail "MB2: reached must recommend /coda. Got: $OUT"
 echo "$OUT" | grep -qiE 'stops you|keep going' \


### PR DESCRIPTION
Closes #527.

## The bug

MB3 built its fixture like this:

```bash
minutes_from_now() { date -v+"$1"M +%H:%M ...; }
pact "$(minutes_from_now 300)"
```

`+%H:%M` formats the time and **throws the date away**. Run at 19:47, `+300` returns `00:47` — a time on the *following* day, as a bare `HH:MM`. The hook then computes `47 - 1187 = -1140` and emits the reached notice, and MB3 fails.

**Roughly five hours in every twenty-four.** CI never caught it because pushes landed earlier in the day — at the moment I found it, UTC was 18:48, one hour short of the window, so CI was green with the bug fully present.

## The hook is not the bug

Worth stating plainly, because the obvious fix would have been wrong. `mast-boundary-check.sh` says it in its own comment:

> A session that begins after the line gets the reached notice, not a negative fraction. **There is no day-rollover puzzle because there is no interval.**

A stop hour already past today *should* produce the reached notice. The hook was right every time. **The test was asking for something impossible** — a stop hour it believed was five hours ahead, which the hook could only read as many hours behind.

## Two more scenarios had it

Found while fixing MB3:

| Scenario | Fixture | Failure window |
| --- | --- | --- |
| MB3 | `+300m` | ~5 hours/day |
| MB1 | `+20m` | 21 minutes/day |
| MB2 | `00:01`, *"already passed for any run after 00:01"* | 1 minute/day |

Same root cause, three sizes. Pinning removes all three rather than narrowing them.

## The fix

`$CLAUDE_MAST_NOW` pins the clock to an `HH:MM`. It is the **fifth** test-only override in this codebase, beside `$CLAUDE_PACTS_FILE`, `$CLAUDE_SESSIONS_DIR`, `$CLAUDE_MAST_DIR` and `$CLAUDE_PARKED_DIR` — consistent rather than novel, which is why I chose it over clamping the offset.

Malformed values fall through to the real clock. A boundary notice must never break a `Stop` hook, and that includes breaking on a bad test variable.

`minutes_from_now` now computes from the pinned clock and **refuses to wrap**, failing loudly rather than emitting a fixture the hook cannot satisfy.

## Verification

Green in all eight timezones tried, including the two that reproduced the failure:

```text
Pacific/Kiritimati  21:51  PASS   (failed before)
Pacific/Auckland    19:51  PASS   (failed before)
Australia/Sydney    17:51  PASS
Asia/Tokyo          16:51  PASS
UTC                 07:51  PASS
Europe/London       08:51  PASS
America/New_York    03:51  PASS
America/Los_Angeles 00:51  PASS
```

| Mutation | Result |
| --- | --- |
| hook ignores the override, falls back to the real clock | KILLED |
| test stops pinning the clock | KILLED |
| pinned clock and `NOW_MIN` disagree | KILLED |

The third matters most — it proves the two halves of the pin cannot silently drift apart.

Full suite: **443 passed, 31 skipped, 0 failed.**

Patch bump 0.73.2 → 0.73.3; `hooks.md` documents the new override alongside its four siblings.