### PR TITLE
Correct AGENTS.md TEST_STRATEGY, which predated the TDAD suite (#529)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -505,10 +505,33 @@
 <!-- How tests are structured in this project. Helps agents write consistent
      tests without reading every test file from scratch. -->
 
-- This project has no application code or test suite. Content is
-  validated by markdownlint (CI), ShellCheck, bash -n syntax checks,
-  and gitleaks secret scanning. All validation is deterministic and
-  runs in the harness CI workflow.
+- There is no application code, but there is a substantial test suite
+  under `tdad_tests/`, run by pytest. Four layers:
+  - **Layer 0 — deterministic.** Bash scripts under
+    `tdad_tests/layer0_deterministic/`, each registered by stem in
+    `tdad_tests/tests/test_layer0_deterministic.py`. They exercise the
+    shipped hook scripts and checkers against temp fixtures. Adding one
+    means adding the file *and* the roster entry.
+  - **Layer 1 — structural.** Scenario files under
+    `tdad_tests/scenarios/<type>/<component>/`, asserting that agent,
+    skill and command files carry the charter clauses required of them.
+  - **Layer 2 — skill triggers.** Does a skill's description still fire
+    on the queries it should? Model-mediated, one inference per query,
+    skipped when no API key is present.
+  - **Layer 3 — behavioural.** Opt-in, case by case.
+- Write the failing test first and confirm it fails for the *right*
+  reason. A test that passes the moment it is written proves nothing.
+- Mutation-test anything that guards a property: break the thing
+  deliberately and confirm the test catches it. Several checks here were
+  found passing for the wrong reason that way, and a surviving mutant is
+  a hypothesis about the test — confirm the mutation actually applied
+  before believing it.
+- Tests that read the clock must pin it rather than race it. See
+  `$CLAUDE_MAST_NOW` and issue #527.
+- markdownlint, ShellCheck, `bash -n` and gitleaks still run in CI. They
+  are lint, not the test suite, and two constraints enforce the suite
+  separately: *TDAD fast-suite passes (Layers 0 + 1)* and *New plugin
+  components must ship with a TDAD scenario*.
 
 ## DESIGN_DECISIONS
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -142,8 +142,8 @@ Sixteen decisions are recorded in `AGENTS.md`. The four that shape most work:
 
 ## How We Test
 
-There is no application code, but there is a substantial test suite across the
-TDAD layers, run by `pytest`.
+There is no application code, but there is a substantial test suite under
+`tdad_tests/`, run by `pytest`, across four layers.
 
 - **Layer 0 — deterministic.** Bash scripts under
   `tdad_tests/layer0_deterministic/`, each registered by stem in
@@ -153,6 +153,9 @@ TDAD layers, run by `pytest`.
 - **Layer 1 — structural.** Scenario files under `tdad_tests/scenarios/`,
   one directory per component, asserting that agent and command files carry the
   charter clauses they are required to.
+- **Layer 2 — skill triggers.** Does a skill's description still fire on the
+  queries it should? Model-mediated, one inference per query, and skipped when
+  no API key is present — which accounts for most of the suite's skips.
 - **Layer 3 — behavioural.** Opt-in, case by case.
 
 Two habits are worth copying. **Write the test first and watch it fail for the

--- a/REFLECTION_LOG.md
+++ b/REFLECTION_LOG.md
@@ -889,3 +889,20 @@
   - Model tiers used: capable (100%) — Opus 5 throughout, including all advocatus-diaboli dispatches
   - Pipeline stages completed: spec-writer, advocatus-diaboli (spec gate, 5 slices), implement, integration — TDD applied per slice; carpaccio and choice-cartographer not dispatched, the build spec supplying the slicing
   - Agent delegation: partial
+
+---
+
+- **Date**: 2026-08-14
+- **Agent**: Claude Opus 5
+- **Task**: Corrected `AGENTS.md` → `TEST_STRATEGY`, which claimed the project had no test suite while 443 TDAD tests ran and two deterministic constraints enforced them (#529).
+- **Surprise**: The drift was invisible until a *generator* consumed it. `ONBOARDING.md` is built from `AGENTS.md`, and regenerating it surfaced a paragraph that had been wrong since the TDAD work landed — long enough that `HARNESS.md` and `AGENTS.md` had been contradicting each other in the same tree, without anything noticing. Nothing reads `TEST_STRATEGY` on a schedule, so nothing could. The sweep for siblings then found the opposite of what I expected: `STYLE`'s "all hook scripts are advisory only" and `DESIGN_DECISIONS`'s naming rules both verified clean. The drift was localised, not systemic — **the section that had a consumer was the section that had drifted**, which is the reverse of the intuition that unread prose rots fastest. And correcting it exposed one more instance in something I had shipped an hour earlier: the `ONBOARDING.md` I generated described three test layers when there are four. Layer 2 exists, is model-mediated, and accounts for most of the suite's 31 skips.
+- **Proposal**: none for `AGENTS.md` beyond the correction itself. Worth considering as a GC rule rather than a constraint: a periodic check that `AGENTS.md` sections making *checkable* claims still hold. The obstacle is that "checkable claim" is not machine-identifiable, so it would be an agent-enforced sweep, and the honest version of it is small — this sweep took four greps and found one defect in three sections.
+- **Improvement**: The generator caught what curation did not. That suggests a cheap general move: when a document is generated from a curated source, have the generator *verify* the source's checkable claims rather than transcribe them. I did this by hand here — writing the `ONBOARDING.md` test section from the tree rather than from `AGENTS.md`, then flagging the discrepancy — and it is what turned a docs task into a real finding. Doing it deliberately would make every regeneration a source audit.
+- **Signal**: context
+- **Constraint**: none — two deterministic constraints already enforce the behaviour (*TDAD fast-suite passes (Layers 0 + 1)*, *New plugin components must ship with a TDAD scenario*). `TEST_STRATEGY` is descriptive prose, not a rule; a constraint cannot fix a stale description, and "keep AGENTS.md accurate" would be unfalsifiable — the governance anti-pattern this repo already names.
+- **Promoted**: 2026-08-14 → AGENTS.md TEST_STRATEGY: "There is no application code, but there is a substantial test suite"
+- **Session metadata**:
+  - Duration: ~30 min
+  - Model tiers used: capable (100%)
+  - Pipeline stages completed: none — a documentation correction routed through the reflection path per #529, not a pipeline task
+  - Agent delegation: manual

--- a/reflections/active/2026-08-14-agents-md-test-strategy-drift.md
+++ b/reflections/active/2026-08-14-agents-md-test-strategy-drift.md
@@ -1,0 +1,14 @@
+- **Date**: 2026-08-14
+- **Agent**: Claude Opus 5
+- **Task**: Corrected `AGENTS.md` → `TEST_STRATEGY`, which claimed the project had no test suite while 443 TDAD tests ran and two deterministic constraints enforced them (#529).
+- **Surprise**: The drift was invisible until a *generator* consumed it. `ONBOARDING.md` is built from `AGENTS.md`, and regenerating it surfaced a paragraph that had been wrong since the TDAD work landed — long enough that `HARNESS.md` and `AGENTS.md` had been contradicting each other in the same tree, without anything noticing. Nothing reads `TEST_STRATEGY` on a schedule, so nothing could. The sweep for siblings then found the opposite of what I expected: `STYLE`'s "all hook scripts are advisory only" and `DESIGN_DECISIONS`'s naming rules both verified clean. The drift was localised, not systemic — **the section that had a consumer was the section that had drifted**, which is the reverse of the intuition that unread prose rots fastest. And correcting it exposed one more instance in something I had shipped an hour earlier: the `ONBOARDING.md` I generated described three test layers when there are four. Layer 2 exists, is model-mediated, and accounts for most of the suite's 31 skips.
+- **Proposal**: none for `AGENTS.md` beyond the correction itself. Worth considering as a GC rule rather than a constraint: a periodic check that `AGENTS.md` sections making *checkable* claims still hold. The obstacle is that "checkable claim" is not machine-identifiable, so it would be an agent-enforced sweep, and the honest version of it is small — this sweep took four greps and found one defect in three sections.
+- **Improvement**: The generator caught what curation did not. That suggests a cheap general move: when a document is generated from a curated source, have the generator *verify* the source's checkable claims rather than transcribe them. I did this by hand here — writing the `ONBOARDING.md` test section from the tree rather than from `AGENTS.md`, then flagging the discrepancy — and it is what turned a docs task into a real finding. Doing it deliberately would make every regeneration a source audit.
+- **Signal**: context
+- **Constraint**: none — two deterministic constraints already enforce the behaviour (*TDAD fast-suite passes (Layers 0 + 1)*, *New plugin components must ship with a TDAD scenario*). `TEST_STRATEGY` is descriptive prose, not a rule; a constraint cannot fix a stale description, and "keep AGENTS.md accurate" would be unfalsifiable — the governance anti-pattern this repo already names.
+- **Promoted**: 2026-08-14 → AGENTS.md TEST_STRATEGY: "There is no application code, but there is a substantial test suite"
+- **Session metadata**:
+  - Duration: ~30 min
+  - Model tiers used: capable (100%)
+  - Pipeline stages completed: none — a documentation correction routed through the reflection path per #529, not a pipeline task
+  - Agent delegation: manual


### PR DESCRIPTION
Closes #529. Routed through the reflection path, as the issue specified.

## The correction

`AGENTS.md` → `TEST_STRATEGY` said:

> This project has no application code or test suite… **All validation is deterministic**.

Both halves were false. There are 443 TDAD tests across four layers, two deterministic constraints enforce them, and 10 of 34 constraints are agent-enforced.

## What made it interesting

**The drift was invisible until a generator consumed it.** `ONBOARDING.md` is built from `AGENTS.md`; regenerating it in #526 surfaced a paragraph that had been wrong since the TDAD work landed. `HARNESS.md` and `AGENTS.md` had been contradicting each other in the same tree, and nothing noticed because **nothing reads `TEST_STRATEGY` on a schedule**.

**The sweep found the opposite of the intuition.** I checked the sibling sections expecting more rot in the parts nothing reads. `STYLE`'s *"all hook scripts are advisory only"* verifies — no hook script exits 1 or 2. `DESIGN_DECISIONS`' naming rules verify too. The drift was localised to the one section that *had* a consumer.

**And correcting it caught one of mine.** The `ONBOARDING.md` I generated an hour earlier described **three** test layers. There are four — Layer 2 is model-mediated skill-trigger testing, and it accounts for most of the suite's 31 skips. Corrected here.

## No new constraint, deliberately

The issue left this open. The answer is no:

- Two deterministic constraints already enforce the behaviour — *TDAD fast-suite passes (Layers 0 + 1)* and *New plugin components must ship with a TDAD scenario*
- `TEST_STRATEGY` is **descriptive prose, not a rule**. A constraint cannot fix a stale description
- *"Keep AGENTS.md accurate"* would be unfalsifiable — the governance anti-pattern this repo already names

The reflection records `Constraint: none` with that reasoning, and the `Promoted:` line points at the correction itself. It passes the shipped `verify_rhs`, so Path-1 archival can retire the fragment.

## On the human-curated boundary

`AGENTS.md` is human-curated and no agent writes to it. This edit was made under explicit direction after the exact text was reviewed — the curation decision is the human's; I held the keyboard. Flagging it rather than burying it, because the convention is load-bearing.

## Also worth your attention

While verifying that the reflection fragment would not trip CI, I found that **`markdownlint` in CI lints 9 root-level files, not the 741 in the repo** — the action's default glob is `*.{md,markdown}`, non-recursive, while the constraint declares `npx markdownlint-cli2 "**/*.md"`. 732 files are declared in scope and never checked.

Same shape as the Release traceability gap fixed in #525: a promise wider than its machinery. Filed separately rather than folded in here.

Suite: 443 passed, 31 skipped. No plugin files touched, so no version bump.