### PR TITLE
Make markdownlint check the 741 files it claims, not 9 (#531)

### DIFF
--- a/.cursor/rules/constraints.mdc
+++ b/.cursor/rules/constraints.mdc
@@ -11,7 +11,7 @@ alwaysApply: true
 
 ## Consistent markdown formatting
 
-- **Rule**: All markdown files must pass markdownlint with the project's `.markdownlint.json` configuration without warnings
+- **Rule**: Every markdown file in the repository must pass markdownlint with the project's `.markdownlint.json` configuration, **except the append-only record corpora** (`docs/superpowers/**`, `reflections/**`), the gitignored `REFLECTION_STAGING.md`, and untracked local artefacts under `.claude/**`. Records carry human dispositions and quote markdown as evidence, so style rules fight them by construction. Globs and ignores live in `.markdownlint-cli2.jsonc`, so a bare local run checks exactly what CI does
 - **Enforcement**: deterministic
 - **Tool**: `npx markdownlint-cli2 "**/*.md"`
 - **Scope**: commit + pr

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,7 +45,7 @@ a header comment block explaining purpose and behaviour.
 
 ### Consistent markdown formatting
 
-All markdown files must pass markdownlint with the project's `.markdownlint.json` configuration without warnings. Enforcement: deterministic (`npx markdownlint-cli2 "**/*.md"`). Scope: commit + pr.
+Every markdown file in the repository must pass markdownlint with the project's `.markdownlint.json` configuration, **except the append-only record corpora** (`docs/superpowers/**`, `reflections/**`), the gitignored `REFLECTION_STAGING.md`, and untracked local artefacts under `.claude/**`. Records carry human dispositions and quote markdown as evidence, so style rules fight them by construction. Globs and ignores live in `.markdownlint-cli2.jsonc`, so a bare local run checks exactly what CI does. Enforcement: deterministic (`npx markdownlint-cli2 "**/*.md"`). Scope: commit + pr.
 
 ### No secrets in source
 

--- a/.github/prompts/diaboli.prompt.md
+++ b/.github/prompts/diaboli.prompt.md
@@ -10,7 +10,7 @@ or implementation (code mode).
 
 ## Usage
 
-```
+```text
 /diaboli docs/superpowers/specs/<date>-<name>.md [--mode spec|code]
 ```
 

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,19 +1,39 @@
 {
-  // Rule configuration. ``config`` (cli2) merges with the legacy
-  // .markdownlint.json — keeping rules here means there is one source
-  // of truth for which markdownlint rules are on.
-  "config": {
-    "default": true,
-    "MD013": false,
-    "MD025": false,
-    "MD024": false
-  },
-  // Files to ignore. The TDAD Layer 0 fixtures are intentionally
-  // malformed test data — one fixture is named
-  // ``reflection-log-promoted-trailing-space.md`` precisely because
-  // its purpose is to verify the parser strips trailing whitespace.
-  // Linting them would fail by design and drown real regressions.
+  // MD033 (inline HTML) and MD038 (space in code span) are OFF in
+  // `.markdownlint.json`. Both fight deliberate content here: agent files use
+  // <task-slug>-style placeholders, and command files document YAML indentation
+  // with spans like `    evidence:` and `### ` where the SPACE IS THE SUBJECT.
+  // markdownlint --fix silently stripped four such spans before this was caught.
+  //
+  // Rule configuration lives in `.markdownlint.json`, NOT here. markdownlint-cli2
+  // gives that file precedence over this `config` key, so rules set here are
+  // silently ignored — this block's own comment used to claim the opposite and
+  // was wrong for as long as it existed (#531). Globs and ignores below are
+  // honoured, which is why they live here.
+
+  // Files to lint. Without this key the action falls back to its own default,
+  // `*.{md,markdown}` — TOP LEVEL ONLY — so CI linted 9 of 741 files while the
+  // constraint declared `**/*.md`. A bare local `markdownlint-cli2` linted
+  // zero. Stating globs here makes the local run and CI check the same set,
+  // which is the property that was actually missing (#531).
+  "globs": ["**/*.md"],
+
   "ignores": [
+    // Record corpora: append-only artefacts with human dispositions, not
+    // documents anyone formats. Objection records quote markdown as evidence,
+    // which trips style rules by construction, and reformatting a record edits
+    // something the append-only rule protects. 177 files, 620 findings, all of
+    // them noise.
+    "docs/superpowers/**",
+    // Reflection fragments legitimately begin `- **Date**:` rather than a
+    // heading, so MD041 is structurally wrong for them. REFLECTION_LOG.md is
+    // generated from them and lives at the root, where it IS linted.
+    "reflections/**",
+    // Gitignored staging, regenerated on every mining run.
+    "REFLECTION_STAGING.md",
+    // Untracked local working artefacts. CI never sees them, so linting them
+    // locally would put the two out of step again.
+    ".claude/**",
     "tdad_tests/layer0_deterministic/fixtures/**",
     "**/.venv/**",
     "site/**",

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,5 +2,7 @@
   "default": true,
   "MD013": false,
   "MD025": false,
-  "MD024": false
+  "MD024": false,
+  "MD033": false,
+  "MD038": false
 }

--- a/.windsurf/rules/constraints.md
+++ b/.windsurf/rules/constraints.md
@@ -5,7 +5,7 @@
 
 ## Consistent markdown formatting
 
-- **Rule**: All markdown files must pass markdownlint with the project's `.markdownlint.json` configuration without warnings
+- **Rule**: Every markdown file in the repository must pass markdownlint with the project's `.markdownlint.json` configuration, **except the append-only record corpora** (`docs/superpowers/**`, `reflections/**`), the gitignored `REFLECTION_STAGING.md`, and untracked local artefacts under `.claude/**`. Records carry human dispositions and quote markdown as evidence, so style rules fight them by construction. Globs and ignores live in `.markdownlint-cli2.jsonc`, so a bare local run checks exactly what CI does
 - **Enforcement**: deterministic
 - **Tool**: `npx markdownlint-cli2 "**/*.md"`
 - **Scope**: commit + pr

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -62,10 +62,18 @@
 
 ### Consistent markdown formatting
 
-- **Rule**: All markdown files must pass markdownlint with the
-  project's `.markdownlint.json` configuration without warnings
+- **Rule**: Every markdown file in the repository must pass markdownlint
+  with the project's `.markdownlint.json` configuration, **except the
+  append-only record corpora** — `docs/superpowers/**` and
+  `reflections/**` — the gitignored `REFLECTION_STAGING.md`, and
+  untracked local artefacts under `.claude/**`. Records carry human
+  dispositions and quote markdown as evidence, so style rules fight them
+  by construction; reformatting one would edit something the append-only
+  rule protects. The exclusions live in `.markdownlint-cli2.jsonc` and
+  are the same set locally and in CI (#531).
 - **Enforcement**: deterministic
-- **Tool**: npx markdownlint-cli2 "**/*.md"
+- **Tool**: `npx markdownlint-cli2` (globs and ignores come from
+  `.markdownlint-cli2.jsonc`, so a bare local run checks exactly what CI does)
 - **Scope**: commit + pr
 
 ### No secrets in source

--- a/ai-literacy-superpowers/agents/advocatus-diaboli.agent.md
+++ b/ai-literacy-superpowers/agents/advocatus-diaboli.agent.md
@@ -16,7 +16,7 @@ write dispositions — that is the human's job, and your tool boundary enforces 
 
 Read the `advocatus-diaboli` skill:
 
-```
+```text
 ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md
 ```
 

--- a/ai-literacy-superpowers/agents/carpaccio.agent.md
+++ b/ai-literacy-superpowers/agents/carpaccio.agent.md
@@ -17,7 +17,7 @@ the human's job, and your tool boundary enforces it.
 
 Read the `carpaccio` skill:
 
-```
+```text
 ai-literacy-superpowers/skills/carpaccio/SKILL.md
 ```
 

--- a/ai-literacy-superpowers/agents/orchestrator.agent.md
+++ b/ai-literacy-superpowers/agents/orchestrator.agent.md
@@ -122,6 +122,7 @@ message with multiple Agent tool calls.
            `gh issue create` and write the URL to `issue_url:` on
            that slice (audit trail). Then dispatch spec-writer against
            the progressed slice's `scope`, not the original task.
+
   1. SEQUENTIAL  — spec-writer        Update spec and plan files first.
   1a. SEQUENTIAL — advocatus-diaboli  Read the spec; produce objection record.
      GATE: Objection Adjudication — surface the objection record to the user.
@@ -370,7 +371,7 @@ the pipeline; the user can retry manually.
 
 Add to the orchestrator context:
 
-```
+```yaml
 progressed_slice_id: <S-id>
 carpaccio_slug: <task-slug>
 carpaccio_total_slices: N

--- a/ai-literacy-superpowers/agents/reservoir-warden.agent.md
+++ b/ai-literacy-superpowers/agents/reservoir-warden.agent.md
@@ -17,7 +17,7 @@ diagnose. You do not score. You do not choose for the engineer.
 
 Read the `cognitive-reservoir` skill in full:
 
-```
+```text
 ai-literacy-superpowers/skills/cognitive-reservoir/SKILL.md
 ```
 
@@ -68,22 +68,28 @@ error. Suggested commands (adapt to the repo):
 
 - **Continuous span** — first and last commit timestamps within the
   window:
+
   ```bash
   git log --since="<window_hours> hours ago" --format=%ct
   ```
+
   Span = (last − first) / 60 minutes. Treat sub-idle gaps as continuous;
   if 0 or 1 commits in the window, span is 0.
 - **Decision volume** — approval-like events in the window:
+
   ```bash
   git log --since="<window_hours> hours ago" --oneline | wc -l
   ```
+
   (commits + merges as the observable proxy for "times the human said yes").
 - **Context switches** — distinct streams touched. Prefer distinct
   top-level directories changed plus reflog branch switches:
+
   ```bash
   git log --since="<window_hours> hours ago" --name-only --format= | awk -F/ 'NF{print $1}' | sort -u | wc -l
   git reflog --since="<window_hours> hours ago" 2>/dev/null | grep -c 'checkout: moving' || true
   ```
+
   Combine conservatively; degrade to 0 on no match.
 - **Wall-clock hour** — `date +%H` (local). Map to a circadian band
   **only if** `chronotype` is declared; otherwise mark `asked` /

--- a/ai-literacy-superpowers/commands/diaboli.md
+++ b/ai-literacy-superpowers/commands/diaboli.md
@@ -26,7 +26,7 @@ before integration-agent.
 
 Confirm the spec file exists at the given path. If not, abort with:
 
-```
+```text
 Error: spec file not found at <path>. Pass a valid path under docs/superpowers/specs/.
 ```
 
@@ -37,6 +37,7 @@ Strip the date prefix and `.md` extension from the filename.
 Example: `docs/superpowers/specs/2026-04-19-advocatus-diaboli.md` → `advocatus-diaboli`
 
 Output path:
+
 - Spec mode: `docs/superpowers/objections/<slug>.md`
 - Code mode: `docs/superpowers/objections/<slug>-code.md`
 

--- a/ai-literacy-superpowers/commands/superpowers-init.md
+++ b/ai-literacy-superpowers/commands/superpowers-init.md
@@ -98,6 +98,7 @@ Copy CI templates from `${CLAUDE_PLUGIN_ROOT}/templates/`:
   REFLECTION_LOG.md merge=union
   reflections/archive/*.md merge=union
   ```
+
 - `HARNESS.md` → `.claude/HARNESS.md` if it does not exist
 
 Use the harness-engineering skill to verify the scaffold is coherent before

--- a/ai-literacy-superpowers/skills/ai-literacy-assessment/references/assessment-template.md
+++ b/ai-literacy-superpowers/skills/ai-literacy-assessment/references/assessment-template.md
@@ -118,4 +118,5 @@ addresses. Order by impact.}}
 Suggested re-assessment date: {{YYYY-MM-DD}} (quarterly)
 
 Previous assessment: {{link to previous if exists, or "first assessment"}}
-```
+
+```text

--- a/diagnostic-legibility/CHANGELOG.md
+++ b/diagnostic-legibility/CHANGELOG.md
@@ -484,8 +484,8 @@ per-plugin entry description is the plugin's own contract, not the
 listing contract — S1–S3 precedent).
 
 S4 of the parent slicing record at
-`docs/superpowers/slices/diagnostic-legibility-plugin.md`. Closes issue
-#333 and parent issue #327.
+`docs/superpowers/slices/diagnostic-legibility-plugin.md`. Closes issue #333 and
+parent issue #327.
 
 ## 0.4.0 — 2026-06-01
 
@@ -642,8 +642,8 @@ addressed in this PR, 2 deferred.
   `CLAUDE.md` so it governs every future PR without ceremony).
 
 Sub-S2b of the meta-iteration recorded at
-`docs/superpowers/slices/dl-s2-two-model-agent.md`. Closes issue
-#335; parent issue #331 auto-closes per its own comment.
+`docs/superpowers/slices/dl-s2-two-model-agent.md`. Closes issue #335;
+parent issue #331 auto-closes per its own comment.
 
 ## 0.2.0 — 2026-05-26
 

--- a/diagnostic-legibility/agents/diagnostic-legibility.agent.md
+++ b/diagnostic-legibility/agents/diagnostic-legibility.agent.md
@@ -149,7 +149,7 @@ consume the YAML block would not see a prose warning.
 
 **Refusal line shape (any precondition violation):**
 
-```
+```text
 diagnostic-legibility refusal: <single-sentence reason>.
 ```
 
@@ -702,7 +702,7 @@ an explicit per-element step:
 Where a question surfaces a change, revise the element and append a
 single string to `challenge_notes[]`:
 
-```
+```text
 Q<N> (question-name): <what surfaced and how it was resolved>
 ```
 
@@ -733,7 +733,7 @@ silently.
 When all five questions surface no changes for an element, append the
 single sentinel string verbatim:
 
-```
+```text
 Challenge applied; no questions surfaced changes
 ```
 
@@ -793,7 +793,7 @@ reasoning:
    surfaces a change to the **subject** element, revise the subject
    and append a single string to its `challenge_notes[]`:
 
-   ```
+   ```text
    CC<N> (question-name): <what surfaced and how it was resolved>
    ```
 
@@ -839,7 +839,7 @@ When all five cross-check questions surface no changes for a subject
 element, append the single sentinel string verbatim to that element's
 `challenge_notes[]`:
 
-```
+```text
 Cross-check applied; no questions surfaced changes
 ```
 

--- a/diagnostic-legibility/templates/conceptual-pipeline-map.md
+++ b/diagnostic-legibility/templates/conceptual-pipeline-map.md
@@ -109,7 +109,7 @@ not present a silent boundary as fact.
 
 ## Equivalent type signature (documentation only)
 
-```
+```yaml
 ConceptualPipelineMap = {
   task: string,
   scope_resolution: ScopeResolution,

--- a/diagnostic-legibility/templates/legibility-element.md
+++ b/diagnostic-legibility/templates/legibility-element.md
@@ -25,7 +25,7 @@ simpler.
 
 Equivalent type signature (for documentation only — not a committed type):
 
-```
+```yaml
 LegibilityElement = {
   name: string,
   description: string,

--- a/docs/plugins/diagnostic-legibility/explanation/cross-check-protocol.md
+++ b/docs/plugins/diagnostic-legibility/explanation/cross-check-protocol.md
@@ -173,7 +173,7 @@ and can be re-added in the same PR as its first named consumer
 When an input violates a precondition, the agent emits a structured
 refusal line and no YAML block:
 
-```
+```text
 diagnostic-legibility refusal: <single-sentence reason>.
 ```
 

--- a/docs/plugins/diagnostic-legibility/how-to/invoke-the-agent.md
+++ b/docs/plugins/diagnostic-legibility/how-to/invoke-the-agent.md
@@ -168,7 +168,7 @@ The agent does **not** write files. Your dispatcher is responsible
 for persisting the YAML to whatever path you choose. A common
 convention:
 
-```
+```text
 diagnostic-legibility/output/<YYYY-MM-DD>-<scope-slug>.legibility.yaml
 ```
 

--- a/docs/plugins/diagnostic-legibility/how-to/resolve-task-scope.md
+++ b/docs/plugins/diagnostic-legibility/how-to/resolve-task-scope.md
@@ -18,6 +18,8 @@ and process the task touches — and discloses the boundary it drew.
 > command with its Mermaid HTML render (P5) are later slices. Until P5
 > lands, scope-resolution and pipeline modes are the agent-output surface.
 
+---
+
 > **Want the flow, not just the bound?** Since **v0.8.0** the agent also
 > has **`mode: pipeline`** — it resolves the same bound and then *traces
 > the control flow within it*, emitting a `ConceptualPipelineMap` (stages,

--- a/docs/plugins/diagnostic-legibility/reference/pipeline-map-command.md
+++ b/docs/plugins/diagnostic-legibility/reference/pipeline-map-command.md
@@ -107,7 +107,7 @@ failure direction when < high) · **Mermaid flowchart** (inlined bundle)
 | `stage.kind: decision` | diamond `id{"… "}` |
 | `stage.kind: outcome` | stadium `id(["… "])` |
 | `transition` | `from --> to` |
-| `transition.condition_label` | `from -->|label| to` |
+| `transition.condition_label` | `from -->\|label\| to` |
 | `part_of` | `subgraph` / indentation |
 | context vs touched | `classDef context` |
 

--- a/tdad_tests/scenarios/agents/cost-estimator/tool-boundary-and-charter.md
+++ b/tdad_tests/scenarios/agents/cost-estimator/tool-boundary-and-charter.md
@@ -81,6 +81,6 @@ disclosure sections are all present and reference (not redefine) the S1 contract
 ## Notes
 
 Scope is S2 only. This scenario asserts the agent's structural shape; it does
-**not** assert anything about the S3 command, the S4 orchestrator wiring, or the
-#377 per-stage `cost_usd` format change. S2 makes no change to
+**not** assert anything about the S3 command, the S4 orchestrator wiring, or
+issue #377's per-stage `cost_usd` format change. S2 makes no change to
 `estimate-record-format.md`.


### PR DESCRIPTION
Closes #531.

## The gap

The constraint declared `npx markdownlint-cli2 "**/*.md"`. The workflow ran the action with **no `globs` input**, so it fell back to the action default `*.{md,markdown}` — **top level only**:

```text
Finding: *.{md,markdown} !tdad_tests/…
Linting: 8 file(s)
Summary: 0 error(s)
```

**9 of 741 files.** A bare local `markdownlint-cli2` linted **zero**.

Nothing broke — because every PR here runs markdownlint manually with explicit globs before committing. **That habit, not the constraint, is what kept the docs clean.** The gate was green throughout while looking at nine already-clean files.

## Promise narrowed to match machinery — not the reverse

Widening to all 741 surfaces 620 findings in `docs/superpowers/**` and `reflections/**`. Those are **append-only records carrying human dispositions**, and objection records quote markdown as evidence, so style rules fight them by construction. Reformatting one would edit something the append-only rule protects.

So the exclusions are **stated in the constraint** and in all three mirrors, rather than hidden in a config:

| Excluded | Why |
| --- | --- |
| `docs/superpowers/**` | append-only records, 177 files / 620 findings, all noise |
| `reflections/**` | fragments legitimately start `- **Date**:`, so MD041 is structurally wrong |
| `REFLECTION_STAGING.md` | gitignored, regenerated each mining run |
| `.claude/**` | untracked local artefacts CI never sees |

**472 files now linted, 0 issues**, and a bare local run checks exactly what CI does — the property that was actually missing.

## Two defects found on the way

**The `config` block in `.markdownlint-cli2.jsonc` was dead.** `.markdownlint.json` takes precedence, so rules set in the `.jsonc` were silently ignored — while its own comment claimed *"keeping rules here means there is one source of truth"*. Rules moved to the file that wins; the comment now says so.

**`markdownlint --fix` twice made things worse**, and both were caught only by reading the diff:

- It turned `#377` — an **issue reference** at the start of a wrapped line — into `# 377`, a heading.
- It stripped spaces *inside* code spans in four places where **the space is the subject**: `` `### ` `` (a heading prefix), `` `  - id:` `` and `` `    evidence:` `` (documenting YAML indentation).

MD033 and MD038 are now off with those reasons recorded. MD033 was flagging `<task-slug>`-style placeholders in agent instructions as HTML.

## Content changes, all verified meaning-preserving

Fifteen lines outside config. Each checked individually:

- 16 code fences given languages
- two issue references rewrapped so `#` no longer starts a line (`diagnostic-legibility/CHANGELOG.md`)
- one table cell's pipes escaped — **without** altering the Mermaid syntax. My first attempt added spaces to `from -->|label| to`; `A -->|label| B` is the correct form and has none. Reverted to `` `from -->\|label\| to` ``.
- one `---` separating two adjacent blockquotes
- `#377` restored as an issue reference

## Scope

`no-bump`: the plugin-file changes are code-fence languages and restored whitespace — the formatting-only case CLAUDE.md names explicitly.

Suite: 443 passed, 31 skipped. Parity 34/34; enum parity 3 enums / 45 checks.

## Worth a follow-up

Nothing systematically compares a constraint's declared `Tool` against what its workflow actually runs. This was found by accident, and it is the third instance of that shape today after #509 and #525.