### PR TITLE
Harness evolution S1 — the Harness Registrar, record-keeping only

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.74.0",
+  "plugin_version": "0.75.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.74.0"
+      "version": "0.75.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,66 @@
 # Changelog
 
+## 0.75.0 — 2026-08-23
+
+### Added
+
+- **`harness-registrar` agent** — keeps the record of how governance itself
+  changes. Applies human-approved decisions and never authors them.
+  Deliberately **not** tagged `role: sentinel`: it holds `Write` and `Edit`, so
+  claiming a read-only trust boundary would be a lie
+  `sentinel-integrity-check.sh` would catch, and the exact category error the
+  two-role separation exists to prevent (#533, #535).
+- **`/harness-propose <assay> <finding>`** — drafts a Harness Decision Record
+  from an assay finding at `status: proposed`, with `cost` left empty for the
+  approver.
+- **`/harness-accept <hdr>`** — the single write transaction. Runs every
+  cost-independent refusal *before* prompting for the cost, then accepts and
+  regenerates the index.
+- **`scripts/harness-registrar.py`** — the deterministic write path behind both
+  commands: `propose`, `precheck`, `accept`, `index`.
+- **The assay-finding contract** — owned by this slice and consumed by the
+  Assayer in a later one, because `/harness-propose` has no input without it.
+  Documented at
+  `docs/plugins/ai-literacy-superpowers/reference/assay-finding-format.md`.
+- **`harness/decisions/index.md`** — generated, sorted by id, byte-identical on
+  re-run so a later drift check can treat any difference as drift.
+- **How-to guide** at
+  `docs/plugins/ai-literacy-superpowers/how-to/record-a-governance-change.md`.
+- **Layer-0 suite** `test-harness-registrar.sh` (R1–R16), mutation-tested
+  against 22 deliberately broken implementations.
+
+### Changed
+
+- The rule-text copy is performed by a **script**, not by the agent. The build
+  spec asks `/harness-propose` to copy proposed rule text verbatim, and a model
+  asked to copy text usually copies it and occasionally improves it — a typo
+  fixed, a bullet tidied, a line rewrapped. Each of those is a silent edit to a
+  rule a human is about to approve believing it to be the Assayer's words.
+  Verbatim by construction, not verbatim by instruction.
+- Acceptance validates a **staged copy of the whole corpus** and writes only on
+  success. Two S0 refusals are corpus-level — the three-per-cycle cap and the
+  two-assay promotion threshold compare records against each other — so neither
+  can be evaluated from the candidate alone. "Nothing is written and the HDR
+  stays proposed" is now a property of the mechanism rather than a promise.
+- The cost is passed as `--cost-file`, never as a command-line argument: it is
+  multi-line prose, and an argument would put the approver's own words into
+  shell history one copy-paste from the next HDR.
+- Assay findings are parsed **lazily**. One malformed finding costs one finding,
+  not the whole report — an assay is written by an agent under a materiality
+  test, not by a compiler.
+
+### Fixed
+
+- Three weaknesses in the S1 tests, all found by mutation testing rather than by
+  review. The rule-text fixture was too clean to catch a copier that strips
+  trailing whitespace, so its first line now ends in two spaces — a markdown
+  hard line break, meaningful syntax that a well-meaning `rstrip()` destroys
+  silently. The `## Cost` section replacement was untested because the
+  assertion grepped the whole file and the frontmatter satisfied it alone. And
+  an assertion for "a finding with no observation is refused" passed against a
+  validator with that check removed, because the refused **filename** —
+  `HDR-…-no-observation-at-all.md` — contained the word being grepped for.
+
 ## 0.74.0 — 2026-08-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.74.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.75.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-41-2E8B57?style=flat-square)](#skills-41)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.74.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **41 skills, 20 agents, 32 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.75.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **41 skills, 21 agents, 34 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.74.0",
+  "version": "0.75.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/harness-registrar.agent.md
+++ b/ai-literacy-superpowers/agents/harness-registrar.agent.md
@@ -1,0 +1,95 @@
+---
+name: harness-registrar
+description: Use to apply a human-approved governance change — drafts a Harness Decision Record from an assay finding, runs the acceptance transaction after the approver has written the cost, and regenerates the decision index. Holds write authority over governance artifacts and no authority to author them; every refusal is enforced by a validator it cannot argue with.
+tools: [Read, Write, Edit, Glob, Grep, Bash]
+model: inherit
+---
+
+# Harness Registrar Agent
+
+You keep the record of how this project's governance changes.
+
+`HARNESS.md` governs the loop. `AGENTS.md` governs the turn. You govern the
+act of changing either one — which, before this mechanism existed, nothing did.
+
+**You apply. You do not author.** The Harness Assayer proposes, a human
+approves, and you write it down. If an approved decision record is ambiguous,
+you stop and ask rather than filling the gap.
+
+## You are not a sentinel, and the absence of the tag is the point
+
+Every read-only advisory agent in this plugin carries `role: sentinel`, which
+`sentinel-integrity-check.sh` enforces by failing CI on a sentinel granted
+`Write`.
+
+You hold `Write` and `Edit`. You are therefore **not** a sentinel, you do not
+carry the tag, and you must never add it. Claiming a read-only trust boundary
+you do not have would be a lie CI would catch — and worse, it would be the
+exact category error the two-role separation exists to prevent.
+
+The Assayer diagnoses. You legislate. An agent that did both could rationalise
+its own findings into rules that make its next diagnosis easier.
+
+## The mechanism does the work you would be trusted to do
+
+You have write authority over governance artifacts, so wherever a guarantee can
+be made mechanical rather than instructed, it has been:
+
+| Guarantee | How it is kept |
+| --- | --- |
+| Rule text is copied **verbatim** | `harness-registrar.py propose` extracts the four-backtick block byte for byte. You never retype it. |
+| Every refusal fires | `check-harness-decisions.py` runs inside the acceptance transaction. You cannot talk past it. |
+| Nothing is half-written | `accept` validates a staged copy of the whole corpus and writes only on exit 0. |
+| The cost is the human's | The validator refuses a `cost` identical to `proposed_cost`. |
+
+**Do not reimplement any of this in prose.** If you find yourself about to write
+rule text, evidence references, or a cost into a file by hand, stop: that is the
+script's job, and doing it yourself removes the only guarantee that matters.
+
+## Your first action
+
+Read the two commands you serve:
+
+```text
+ai-literacy-superpowers/commands/harness-propose.md
+ai-literacy-superpowers/commands/harness-accept.md
+```
+
+And the record format:
+
+```text
+docs/plugins/ai-literacy-superpowers/reference/harness-decision-records.md
+```
+
+## What you actually do
+
+1. **Locate the assay** and read it — for the human's benefit, not to copy from.
+2. **Present the findings** with their id, title, classification, enforcement and
+   priority, so the human can choose one.
+3. **Run the script.** `propose`, then `precheck`, then `accept`.
+4. **Read refusals back in plain language.** A refusal is not a failure to work
+   around; it is the mechanism doing its job. Say what was refused, why, and
+   what the two or three real options are.
+5. **Never retry a refusal by changing the input to satisfy it.** Reclassifying
+   an HDR because the loop-layer threshold refused it is a decision for the
+   human, not a repair for you to apply.
+
+## What you never do
+
+- Author rule text, or edit an existing `## Rule` block. From acceptance onward
+  it is the byte-for-byte source the compiler applies.
+- Write the `cost`. The approver writes it, in their own words.
+- Edit an accepted HDR. An accepted record is frozen; a later decision
+  supersedes it.
+- Commit, push, or open a pull request. That is a separate approval.
+- Touch `HARNESS.md`, `AGENTS.md`, or any control surface. Not in this phase.
+
+## When a refusal is the right outcome
+
+Most of them are. The design assumes rules should be hard to add and easy to
+retire, so a refused proposal that carries forward to the next cycle is the
+system working, not a blocked task.
+
+The one thing that would defeat all of it is helpfulness: rewording a rule until
+it applies, filling in an argument the human owes, or paraphrasing a cost to get
+past a check. Refuse to be that helpful.

--- a/ai-literacy-superpowers/commands/harness-accept.md
+++ b/ai-literacy-superpowers/commands/harness-accept.md
@@ -1,0 +1,136 @@
+---
+name: harness-accept
+description: The single write transaction of the harness evolution loop — runs every cost-independent refusal first, prompts the approver to write the cost in their own words, then accepts the HDR and regenerates the decision index; transactional, so a refusal leaves the record proposed and nothing else written
+---
+
+# /harness-accept \<hdr-path\>
+
+Accept a proposed Harness Decision Record. This is the gate where a human
+decides, and the only place the `cost` is ever written.
+
+## When to use
+
+- On a `proposed` HDR you have read and want in force
+- Never in a batch. Each acceptance is one decision, and approval for one HDR
+  never generalises to another
+
+## The order matters: refuse first, then ask
+
+Every refusal that does not depend on the cost runs **before** the human is
+asked to write one.
+
+Making someone compose a considered cost for a rule that is about to be refused
+for citing a single assay spends exactly the human attention this whole
+mechanism exists to protect. So the sequence is fixed, and you must not reorder
+it for convenience.
+
+## Process
+
+### 1. Validate input
+
+Confirm the HDR exists and is `status: proposed`. An accepted HDR is frozen — a
+later decision supersedes it rather than editing it. If the status is anything
+else, abort and say so.
+
+### 2. Show the human what they are approving
+
+Print the HDR's `title`, `classification`, `enforcement`, `surfaces`, its
+`## Finding`, and the **full** `## Rule` block. Not a summary of the rule. The
+verbatim text, because that is what is about to be in force.
+
+### 3. Pre-flight — run every cost-independent refusal
+
+```bash
+python3 ai-literacy-superpowers/scripts/harness-registrar.py precheck \
+  --hdr <hdr-path>
+```
+
+If this exits non-zero, **stop here**. Report each refusal in plain language and
+name the real options. Do not prompt for a cost.
+
+The refusals you will actually meet:
+
+| Refusal | What it means | The options |
+| --- | --- | --- |
+| Tier-2 sections are still placeholders | The argument for this layer was never written | The human writes them, or the HDR waits |
+| `harness-loop` citing fewer than two distinct assays | One incident cannot reach the loop layer | Wait for a second assay to corroborate, or reclassify to the layer that owns the behaviour |
+| A fourth accepted HDR from one assay | The cycle cap | Leave it `proposed`; it carries forward |
+| An undeclared surface | A typo, or a surface missing from `surfaces.yaml` | Fix the name, or declare the surface |
+
+**Never resolve a refusal by editing the HDR to satisfy it.** Reclassifying a
+rule because the loop-layer threshold refused it is a decision the human makes,
+not a repair you apply.
+
+### 4. Prompt for the cost
+
+Only once step 3 is clean. Ask exactly this:
+
+```text
+Cost of this rule, in your own words. What will it demand of whoever
+works here next, and how might it be gamed?
+>
+```
+
+Write the answer to a scratch file and pass it as `--cost-file`. Never pass the
+cost as a command-line argument: it is multi-line prose, and an argument would
+put the approver's own words into shell history one copy-paste away from being
+reused verbatim on the next HDR.
+
+If the human asks you to write the cost for them, decline. Explain that the
+validator refuses a cost identical to the Assayer's proposal, and that the
+reason is not procedural — a copy-pasted cost reads exactly like a considered
+one, so nothing downstream can tell the difference. Offer to discuss what the
+rule will actually demand; do not offer words.
+
+### 5. Run the transaction
+
+```bash
+python3 ai-literacy-superpowers/scripts/harness-registrar.py accept \
+  --hdr <hdr-path> --cost-file <scratch-path> \
+  --approver <identity> --now <ISO-8601>
+```
+
+Acceptance is all-or-nothing. The script validates a staged copy of the whole
+corpus and writes only on success, so a refusal here leaves the HDR `proposed`
+and the corpus byte-identical.
+
+Delete the scratch cost file afterwards.
+
+### 6. Validation checkpoint
+
+Read the accepted HDR back and check:
+
+- **A1** — `status: accepted`, with `approver` and `approved_at` present
+- **A2** — frontmatter `cost` carries the human's words and differs from
+  `proposed_cost`
+- **A3** — the `## Cost` section carries the same words, and no longer carries
+  the Assayer's proposal or its `_Proposed by the Assayer_` label
+- **A4** — the `## Rule` block is **unchanged** from before acceptance. From
+  here it is the byte-for-byte source the compiler applies
+- **A5** — `harness/decisions/index.md` lists the HDR with its new status
+- **A6** — `provisional: true` with an `expires` or a `review_trigger`, unless
+  the HDR is `no-change` or `imported`
+
+If A4 deviates, that is serious: report it as a defect and do not proceed.
+For the rest, report rather than patch — a hand-edit to an accepted record is
+the one thing the append-only rule forbids.
+
+### 7. Present the result
+
+```text
+Accepted <id>.
+
+  Enforcement intended: <level>
+  Surfaces: <list>
+  Provisional until <expires> — permanence is earned at review, not at
+  creation. An expired rule still in force will fail CI.
+
+Nothing has been committed. Review the diff and commit when you are ready.
+```
+
+## What this command does not do
+
+- It does not write rule text into `HARNESS.md`, `AGENTS.md`, or any control
+  surface. That lands in a later slice, folded into this same command.
+- It does not commit, push, or open a pull request. Three gates exist —
+  drafting, accepting, and committing — and none is implied by another.

--- a/ai-literacy-superpowers/commands/harness-propose.md
+++ b/ai-literacy-superpowers/commands/harness-propose.md
@@ -1,0 +1,124 @@
+---
+name: harness-propose
+description: Draft a Harness Decision Record from an assay finding — copies the proposed rule text and evidence verbatim into harness/decisions/HDR-<date>-<slug>.md at status proposed, leaving the cost for the approver to write at the acceptance gate; never authors a rule
+---
+
+# /harness-propose \<assay-path\> \<finding-id\>
+
+Draft an HDR from one finding in an assay. The record lands at
+`status: proposed` with `cost` deliberately empty — the approver writes that at
+the `/harness-accept` gate, in their own words.
+
+## When to use
+
+- After reading an assay, on a finding you actually want to act on
+- Never on every finding an assay produced. Three accepted HDRs per cycle is the
+  cap, and a proposal that cannot win a slot twice running probably was not
+  worth a rule
+
+## The copy is deterministic, and you must not do it yourself
+
+The rule text and the evidence list are extracted from the assay **by the
+script**, byte for byte.
+
+This is not a convenience. A model asked to copy text usually copies it and
+occasionally improves it — fixes a typo, tidies an inconsistent bullet, rewraps
+a line — and every one of those is a silent edit to a rule a human is about to
+approve believing it to be the Assayer's words.
+
+**Never write rule text or evidence references into the HDR by hand.**
+
+## Process
+
+### 1. Validate input
+
+Confirm the assay exists at the given path. If not, abort with:
+
+```text
+Error: assay not found at <path>. Pass a valid path under harness/assay/.
+```
+
+### 2. Show the findings
+
+Read the assay and list its findings so the human can confirm the choice:
+
+```text
+Findings in 2026-08-21T16-02Z-assay.md:
+
+  finding-3   P1  agent-instruction  validated  Unevidenced completion claims
+  finding-5   P3  no-change          advisory   Context files capture narration
+  finding-7   P0  harness-loop       validated  Completion claims across surfaces
+```
+
+If the human named a finding id already, confirm it exists and move on.
+
+### 3. Run the script
+
+```bash
+python3 ai-literacy-superpowers/scripts/harness-registrar.py propose \
+  --assay <assay-path> --finding <finding-id>
+```
+
+Add `--slug <slug>` only when the derived slug collides with an existing HDR.
+The script never overwrites, and a collision means two findings resolved to the
+same name.
+
+### 4. Report what was written
+
+State the path, the classification, and the enforcement level. Then, if the
+classification is `harness-loop`, `script-validator` or `new-agent`, say this
+plainly:
+
+```text
+This is a tier-2 classification. Four sections are placeholders:
+
+  ## Why this layer
+  ## Enforcement
+  ## Validation
+  ## Rejected alternatives
+
+A human writes these. Acceptance is refused until they are filled, and
+neither the Assayer nor the Registrar is entitled to write the argument
+for why a rule belongs at the loop layer.
+```
+
+### 5. Validation checkpoint
+
+Read the written file back and check:
+
+- **P1** — frontmatter carries `id`, `title`, `status: proposed`,
+  `classification`, `enforcement`, `surfaces`, `provisional`, `evidence`,
+  `proposed_cost`, `cost`, `proposer`, `supersedes`, `superseded_by`
+- **P2** — `cost` is empty. A pre-filled cost is the anti-theatre gate defeated
+  before it opens. If it is not empty, that is a bug in the script; report it
+  rather than editing the file
+- **P3** — the `## Rule` section holds exactly one four-backtick block, and its
+  contents match the assay finding's proposed-rule block **character for
+  character**. Diff them; do not eyeball them
+- **P4** — `evidence` is the finding's evidence plus the assay anchor
+  `<assay-path>#<finding-id>`
+- **P5** — for a tier-2 classification, all four extra sections are present
+
+If P3 or P4 deviates, **do not fix it in place** — that would be you doing the
+copy the script exists to prevent. Report the deviation as a defect.
+
+For P1, P2 and P5, a deviation is also a script defect. Report, do not patch.
+
+### 6. Suggest next steps
+
+```text
+Next: /harness-accept harness/decisions/<id>.md
+
+That gate is where you write the cost — what this rule will demand of
+whoever works here next, and how it might be gamed. Every refusal that
+does not need a cost runs first, so you will not be asked to compose one
+for a rule that is about to be refused.
+```
+
+## Refusals
+
+The script refuses, and writes nothing, on: a missing assay; an unknown finding
+id; a finding missing its metadata block, its observation prose, its proposed
+rule, or its cost estimate; and a target filename that already exists.
+
+Report the refusal. Do not construct the HDR by hand to work around it.

--- a/ai-literacy-superpowers/scripts/harness-registrar.py
+++ b/ai-literacy-superpowers/scripts/harness-registrar.py
@@ -1,0 +1,669 @@
+#!/usr/bin/env python3
+"""The Harness Registrar's write path: propose, precheck, accept, index.
+
+The Registrar applies human-approved governance changes and keeps the decision
+record. It has write authority over governance artifacts and **no interpretive
+authority** — it never authors a rule, and it never decides that one is a good
+idea.
+
+WHY THE COPY IS A SCRIPT AND NOT AN AGENT. The build spec says
+`/harness-propose` copies the proposed rule text verbatim. The Registrar is a
+plugin agent, so the obvious implementation is to let it read the assay and
+write the HDR — and that implementation cannot deliver what the sentence
+promises. A model asked to copy text usually copies it and occasionally
+*improves* it: fixes a typo, tidies an inconsistent bullet, rewraps a line.
+Every one of those is a silent edit to a rule a human is about to approve
+believing it to be the Assayer's words.
+
+    Verbatim by construction, not verbatim by instruction.
+
+So the rule block and the evidence list are extracted here, byte for byte, and
+the agent never holds them in its output at all. Its job is to locate the assay,
+present the findings, run this script, and read refusals back in plain language.
+
+WHY ACCEPTANCE STAGES THE WHOLE CORPUS. Acceptance must be all-or-nothing, and
+two of the S0 refusals are corpus-level: the three-per-cycle cap and the
+two-assay promotion threshold compare HDRs against each other, so neither can be
+evaluated from the candidate alone. `accept` therefore copies the entire
+`harness/` tree to a temporary root with the candidate substituted, runs the S0
+validator there, and writes the real file only on exit 0. "Nothing is written
+and the HDR stays proposed" is then a property of the mechanism rather than a
+promise in a document.
+
+WHY THE S0 MODULE IS IMPORTED RATHER THAN REIMPLEMENTED. `check-harness-
+decisions.py` already knows what frontmatter is, what a section is, and — most
+importantly — where a four-backtick rule block ends. A second implementation
+here would be a second opinion about the shape of a rule, and the two would
+diverge on exactly the input that matters.
+
+Spec: docs/superpowers/specs/2026-08-23-harness-evolution-s1-registrar-design.md
+Tests: tdad_tests/layer0_deterministic/test-harness-registrar.sh (R1-R16)
+No third-party dependencies (CI-friendly).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import importlib.util
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+VALIDATOR = os.path.join(HERE, "check-harness-decisions.py")
+
+# The marker a proposed tier-2 section carries until a human fills it in. It has
+# to be recognisable to a machine and obvious to a reader, because the failure it
+# guards against is somebody accepting an HDR whose argument was never made.
+PLACEHOLDER_PREFIX = "_TODO —"
+
+GENERATED_BEGIN = "<!-- BEGIN GENERATED: harness-registrar — do not edit by hand -->"
+GENERATED_END = "<!-- END GENERATED: harness-registrar -->"
+
+DEFAULT_PROVISIONAL_DAYS = 90
+
+TIER2_PLACEHOLDERS = [
+    ("Why this layer",
+     "why this change belongs at this layer and not one layer down"),
+    ("Enforcement",
+     "how the rule binds on each listed surface, and where it is only advisory"),
+    ("Validation",
+     "how anyone would know later whether this rule helped"),
+    ("Rejected alternatives",
+     "including the 'no change' option, with the reason it was not taken"),
+]
+
+
+def _load_validator_module():
+    """Import the S0 validator as a module, hyphenated filename and all."""
+    spec = importlib.util.spec_from_file_location("harness_decisions", VALIDATOR)
+    if spec is None or spec.loader is None:  # pragma: no cover - packaging error
+        die(f"cannot load the S0 validator at {VALIDATOR}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def die(message: str, code: int = 1) -> None:
+    print(f"FAIL: {message}")
+    sys.exit(code)
+
+
+S0 = _load_validator_module()
+
+
+# --------------------------------------------------------------------------- #
+# Fence-aware markdown scanning                                                #
+# --------------------------------------------------------------------------- #
+#
+# A heading inside a fenced block is not a heading. This matters more here than
+# it usually would: the thing being copied IS markdown, routinely containing its
+# own fences and occasionally its own headings, and a naive split would cut a
+# rule in half at the exact moment the mechanism is supposed to be preserving it
+# byte for byte.
+
+
+def fence_aware_lines(text: str):
+    """Yield (line, inside_fence) for each line, tracking backtick fences."""
+    open_len = 0
+    for line in text.splitlines():
+        stripped = line.strip()
+        match = re.match(r"^(`{3,})", stripped)
+        if open_len:
+            # A closing fence is a run of at least as many backticks, alone.
+            if match and len(match.group(1)) >= open_len and stripped == match.group(1):
+                yield line, True
+                open_len = 0
+                continue
+            yield line, True
+            continue
+        if match:
+            open_len = len(match.group(1))
+            yield line, True
+            continue
+        yield line, False
+
+
+def split_on_heading(text: str, prefix: str) -> list[tuple[str, str]]:
+    """Split into (heading_text, block_text) on `prefix` headings outside fences."""
+    out: list[tuple[str, str]] = []
+    current: str | None = None
+    buf: list[str] = []
+    for line, in_fence in fence_aware_lines(text):
+        if not in_fence and line.startswith(prefix):
+            if current is not None:
+                out.append((current, "\n".join(buf)))
+            current = line[len(prefix):].strip()
+            buf = []
+            continue
+        if current is not None:
+            buf.append(line)
+    if current is not None:
+        out.append((current, "\n".join(buf)))
+    return out
+
+
+def first_info_fence(text: str, info: str) -> str | None:
+    """The contents of the first ```<info> block, or None."""
+    collecting = False
+    buf: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not collecting and re.match(r"^`{3,}" + re.escape(info) + r"\s*$", stripped):
+            collecting = True
+            continue
+        if collecting:
+            if re.match(r"^`{3,}\s*$", stripped):
+                return "\n".join(buf)
+            buf.append(line)
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# The assay-finding contract                                                   #
+# --------------------------------------------------------------------------- #
+#
+# S1 owns this contract; S3's Assayer writes to it. It is deliberately narrow —
+# only what `propose` must read. Everything else in an assay report (the
+# executive summary, what created friction, rejected candidates, unresolved
+# questions) is prose for a human, and the Registrar never parses it.
+
+FINDING_HEADING = re.compile(r"^([a-z0-9]+(?:-[a-z0-9]+)*)\s*[—–-]\s*(.+)$")
+
+FINDING_REQUIRED_KEYS = ["classification", "enforcement", "surfaces", "evidence", "priority"]
+
+
+class Finding:
+    def __init__(self, fid, title, observation, meta, rule_block, cost_estimate):
+        self.id = fid
+        self.title = title
+        self.observation = observation
+        self.meta = meta
+        self.rule_block = rule_block
+        self.cost_estimate = cost_estimate
+
+
+def parse_assay(path: str) -> tuple[dict, list[Finding]]:
+    with open(path, encoding="utf-8") as handle:
+        text = handle.read()
+
+    raw_fm, body = S0.split_frontmatter(text)
+    if raw_fm is None:
+        die(f"{path}: no YAML frontmatter block.")
+    try:
+        fm = S0.parse_yaml(raw_fm)
+    except S0.YamlError as exc:
+        die(f"{path}: frontmatter could not be read: {exc}")
+
+    for key in ("agent", "model"):
+        if not fm.get(key):
+            die(
+                f"{path}: assay frontmatter must declare '{key}'. An HDR records "
+                "which model proposed it, because a rule proposed by a model that "
+                "has since been replaced is a rule whose evidence deserves "
+                "re-reading."
+            )
+
+    findings_block = None
+    for heading, block in split_on_heading(body, "## "):
+        if heading.lower() == "findings":
+            findings_block = block
+            break
+    if findings_block is None:
+        die(f"{path}: no '## Findings' section.")
+
+    # Headings only. Findings are parsed LAZILY, one at a time, because a single
+    # malformed finding must not block proposing from a well-formed one — an
+    # assay is written by an agent under a materiality test, not by a compiler,
+    # and one bad block should cost one finding rather than the whole report.
+    raw = []
+    for heading, block in split_on_heading(findings_block, "### "):
+        match = FINDING_HEADING.match(heading)
+        if not match:
+            continue
+        raw.append((match.group(1), match.group(2), block))
+    return fm, raw
+
+
+def _parse_finding(path: str, fid: str, title: str, block: str) -> Finding:
+    where = f"{path} finding '{fid}'"
+
+    subsections = dict(split_on_heading(block, "#### "))
+    # Everything before the first `#### ` — prose then the metadata block.
+    preamble = block
+    for line, in_fence in fence_aware_lines(block):
+        if not in_fence and line.startswith("#### "):
+            preamble = block[: block.index(line)]
+            break
+
+    raw_meta = first_info_fence(preamble, "yaml")
+    if raw_meta is None:
+        die(f"{where}: no ```yaml metadata block.")
+    try:
+        meta = S0.parse_yaml(raw_meta)
+    except S0.YamlError as exc:
+        die(f"{where}: metadata block could not be read: {exc}")
+    for key in FINDING_REQUIRED_KEYS:
+        if key not in meta:
+            die(f"{where}: metadata is missing '{key}'.")
+
+    # The observation prose is everything before the metadata block. A finding
+    # with no observation is not a finding — it is a rule with a citation, and
+    # the HDR's `## Finding` section would have nothing to say.
+    observation = preamble.split("```", 1)[0].strip()
+    if not observation:
+        die(
+            f"{where}: no observation prose between the heading and the metadata "
+            "block. A finding must say what was observed."
+        )
+
+    if "Proposed rule" not in subsections:
+        die(f"{where}: no '#### Proposed rule' section.")
+    if "Cost estimate" not in subsections:
+        die(f"{where}: no '#### Cost estimate' section.")
+
+    cost_estimate = subsections["Cost estimate"].strip()
+    if not cost_estimate:
+        die(f"{where}: '#### Cost estimate' is empty.")
+
+    rule_text = subsections["Proposed rule"]
+    if meta.get("classification") == "no-change":
+        if "No change." not in rule_text:
+            die(f"{where}: a no-change finding's proposed rule must say 'No change.'")
+        rule_block = None
+    else:
+        blocks = S0.rule_blocks(rule_text)
+        if len(blocks) != 1:
+            die(
+                f"{where}: '#### Proposed rule' must hold exactly one "
+                f"four-backtick block, found {len(blocks)}."
+            )
+        rule_block = blocks[0]
+
+    return Finding(fid, title.strip(), observation, meta, rule_block, cost_estimate)
+
+
+# --------------------------------------------------------------------------- #
+# Writing an HDR                                                               #
+# --------------------------------------------------------------------------- #
+
+
+def slugify(title: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+    return re.sub(r"-{2,}", "-", slug)
+
+
+def block_scalar(value: str, indent: str = "  ") -> str:
+    lines = value.rstrip("\n").split("\n")
+    return "\n".join(indent + line if line.strip() else "" for line in lines)
+
+
+def render_hdr(hdr_id: str, finding: Finding, assay_path: str, assay_fm: dict,
+               today: datetime.date) -> str:
+    meta = finding.meta
+    classification = meta["classification"]
+    is_no_change = classification == "no-change"
+
+    # The finding's evidence, plus the assay anchor. This is what makes the
+    # two-assay promotion threshold behave as the worked cycle describes: a
+    # first-time loop-layer finding cites one assay and is refused at
+    # acceptance; a corroborated one names the prior assay in its own evidence,
+    # reaches two, and passes.
+    evidence = [str(item) for item in (meta.get("evidence") or [])]
+    anchor = f"{assay_path}#{finding.id}"
+    if anchor not in evidence:
+        evidence.append(anchor)
+
+    surfaces = meta.get("surfaces") or []
+
+    lines = ["---"]
+    lines.append(f"id: {hdr_id}")
+    lines.append(f"title: {finding.title}")
+    lines.append("status: proposed")
+    lines.append(f"classification: {classification}")
+    lines.append(f"enforcement: {meta['enforcement']}")
+    lines.append("surfaces: [" + ", ".join(str(s) for s in surfaces) + "]")
+    if is_no_change:
+        lines.append("provisional: false")
+    else:
+        lines.append("provisional: true")
+        expires = today + datetime.timedelta(days=DEFAULT_PROVISIONAL_DAYS)
+        lines.append(f"expires: {expires.isoformat()}")
+    lines.append("evidence:")
+    for item in evidence:
+        lines.append(f"  - {item}")
+    lines.append("proposed_cost: |")
+    lines.append(block_scalar(finding.cost_estimate))
+    lines.append('cost: ""')
+    lines.append("proposer:")
+    lines.append(f"  agent: {assay_fm['agent']}")
+    lines.append(f"  model: {assay_fm['model']}")
+    lines.append(f"  assay: {assay_path}")
+    lines.append("supersedes: null")
+    lines.append("superseded_by: null")
+    lines.append("---")
+    lines.append("")
+
+    lines.append("## Finding")
+    lines.append("")
+    lines.append(finding.observation)
+    lines.append("")
+
+    lines.append("## Rule")
+    lines.append("")
+    if is_no_change:
+        lines.append("No change.")
+    else:
+        lines.append("````markdown")
+        lines.append(finding.rule_block)
+        lines.append("````")
+    lines.append("")
+
+    # The body Cost section must be non-empty from the moment the HDR exists —
+    # S0 refuses an empty required section. So it carries the Assayer's estimate,
+    # explicitly labelled as not yet the approver's, and acceptance replaces it
+    # wholesale. The frontmatter `cost` stays empty, which is what makes the gap
+    # visible rather than merely absent.
+    lines.append("## Cost")
+    lines.append("")
+    lines.append("_Proposed by the Assayer. To be replaced at acceptance by the "
+                 "approver's own words:_")
+    lines.append("")
+    lines.append(finding.cost_estimate)
+    lines.append("")
+
+    if classification in S0.TIER2_CLASSIFICATIONS:
+        for heading, prompt in TIER2_PLACEHOLDERS:
+            lines.append(f"## {heading}")
+            lines.append("")
+            lines.append(f"{PLACEHOLDER_PREFIX} {prompt}._")
+            lines.append("")
+
+    return "\n".join(lines).rstrip("\n") + "\n"
+
+
+# --------------------------------------------------------------------------- #
+# Staging: the transaction                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def validate_staged(root: str, candidate_rel: str, candidate_text: str) -> tuple[int, str]:
+    """Validate the corpus as it WOULD be, without writing anything to it."""
+    with tempfile.TemporaryDirectory() as staging:
+        shutil.copytree(os.path.join(root, "harness"),
+                        os.path.join(staging, "harness"))
+        target = os.path.join(staging, candidate_rel)
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with open(target, "w", encoding="utf-8") as handle:
+            handle.write(candidate_text)
+        result = subprocess.run(
+            [sys.executable, VALIDATOR, staging],
+            capture_output=True, text=True, check=False,
+        )
+        return result.returncode, (result.stdout + result.stderr).strip()
+
+
+# --------------------------------------------------------------------------- #
+# Subcommands                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def cmd_propose(args) -> int:
+    root = args.root
+    assay_abs = os.path.join(root, args.assay)
+    if not os.path.isfile(assay_abs):
+        die(f"assay not found at {args.assay}")
+
+    assay_fm, raw_findings = parse_assay(assay_abs)
+    selected = next((r for r in raw_findings if r[0] == args.finding), None)
+    if selected is None:
+        available = ", ".join(r[0] for r in raw_findings) or "none"
+        die(f"finding '{args.finding}' is not in {args.assay} (found: {available})")
+    match = _parse_finding(assay_abs, selected[0], selected[1], selected[2])
+
+    today = datetime.date.fromisoformat(args.today) if args.today \
+        else datetime.date.today()
+    slug = args.slug or slugify(match.title)
+    if not slug:
+        die(f"could not derive a slug from the finding title {match.title!r}; "
+            "pass --slug")
+    hdr_id = f"HDR-{today.isoformat()}-{slug}"
+    rel = os.path.join("harness", "decisions", hdr_id + ".md")
+    target = os.path.join(root, rel)
+
+    # Never overwrite. A collision means two findings resolved to one slug, and
+    # silently replacing the first would destroy a proposal nobody knew existed.
+    if os.path.exists(target):
+        die(f"{rel} already exists — pass --slug to give this one a distinct name.")
+
+    text = render_hdr(hdr_id, match, args.assay, assay_fm, today)
+
+    code, output = validate_staged(root, rel, text)
+    if code != 0:
+        print(output)
+        die(f"the proposed HDR would not validate; nothing was written.")
+
+    os.makedirs(os.path.dirname(target), exist_ok=True)
+    with open(target, "w", encoding="utf-8") as handle:
+        handle.write(text)
+    print(f"proposed {rel}")
+    if match.meta["classification"] in S0.TIER2_CLASSIFICATIONS:
+        print("  tier-2 classification: four sections are placeholders and must "
+              "be filled by a human before acceptance.")
+    return 0
+
+
+def unfilled_placeholders(text: str) -> list[str]:
+    _, body = S0.split_frontmatter(text)
+    return [heading for heading, content in S0.sections(body).items()
+            if content.strip().startswith(PLACEHOLDER_PREFIX)]
+
+
+def build_accepted(text: str, cost: str, approver: str, now: str) -> str:
+    """Return the HDR as it would look accepted. Purely textual, no I/O."""
+    raw_fm, body = S0.split_frontmatter(text)
+    fm_lines = raw_fm.split("\n")
+
+    out: list[str] = []
+    skipping_block = False
+    for line in fm_lines:
+        if skipping_block:
+            if line.startswith("  ") or not line.strip():
+                continue
+            skipping_block = False
+        if line.startswith("status:"):
+            out.append("status: accepted")
+            continue
+        if line.startswith("cost:"):
+            out.append("cost: |")
+            out.append(block_scalar(cost))
+            skipping_block = line.rstrip().endswith("|")
+            continue
+        if line.startswith("supersedes:"):
+            out.append(f"approver: {approver}")
+            out.append(f"approved_at: {now}")
+            out.append(line)
+            continue
+        out.append(line)
+
+    # The `## Cost` section carried the Assayer's estimate. Acceptance replaces
+    # it wholesale — the record must read as the approver's decision, not as a
+    # proposal with an annotation.
+    body = re.sub(
+        r"(?ms)^## Cost\n.*?(?=^## |\Z)",
+        "## Cost\n\n" + cost.rstrip("\n") + "\n\n",
+        body,
+        count=1,
+    )
+    return "---" + "\n".join(out) + "\n---" + body.rstrip("\n") + "\n"
+
+
+def _accept_common(args, cost: str, label: str) -> tuple[str, str, str]:
+    root = args.root
+    hdr_abs = os.path.join(root, args.hdr)
+    if not os.path.isfile(hdr_abs):
+        die(f"HDR not found at {args.hdr}")
+    with open(hdr_abs, encoding="utf-8") as handle:
+        text = handle.read()
+
+    raw_fm, _ = S0.split_frontmatter(text)
+    if raw_fm is None:
+        die(f"{args.hdr}: no YAML frontmatter block.")
+    fm = S0.parse_yaml(raw_fm)
+    if fm.get("status") != "proposed":
+        die(f"{args.hdr}: status is '{fm.get('status')}', not 'proposed'. An "
+            "accepted HDR is frozen; a later decision supersedes it rather than "
+            "editing it.")
+
+    # Placeholders first. A tier-2 HDR whose argument was never written is not a
+    # validation problem — the sections are present and non-empty — so S0 cannot
+    # see it. Neither the Assayer nor the Registrar is entitled to write that
+    # argument, so acceptance is where it has to be caught.
+    missing = unfilled_placeholders(text)
+    if missing:
+        die(f"{args.hdr}: these sections are still placeholders and must be "
+            f"written by a human: {', '.join(missing)}.")
+
+    candidate = build_accepted(text, cost, args.approver, args.now)
+    code, output = validate_staged(root, args.hdr, candidate)
+    if code != 0:
+        print(output)
+        die(f"{label} refused; nothing was written and the HDR is still proposed.")
+    return hdr_abs, candidate, text
+
+
+def cmd_precheck(args) -> int:
+    # A cost that is non-empty and cannot collide with any proposed_cost, so the
+    # cost rule passes vacuously and every OTHER refusal is reported. Asking
+    # someone to compose a considered cost for a rule that is about to be
+    # refused spends exactly the attention this mechanism exists to protect.
+    args.approver = "precheck@example.invalid"
+    args.now = "1970-01-01T00:00Z"
+    _accept_common(args, "(cost pending — precheck only)", "precheck")
+    print(f"{args.hdr}: no refusal stands in the way of acceptance.")
+    return 0
+
+
+def cmd_accept(args) -> int:
+    cost_abs = os.path.join(args.root, args.cost_file)
+    if not os.path.isfile(cost_abs):
+        die(f"cost file not found at {args.cost_file}")
+    with open(cost_abs, encoding="utf-8") as handle:
+        cost = handle.read().strip()
+    if not cost:
+        die("the cost is empty. The approver writes what this rule will demand "
+            "of whoever works here next, and how it might be gamed.")
+
+    hdr_abs, candidate, _ = _accept_common(args, cost, "acceptance")
+    with open(hdr_abs, "w", encoding="utf-8") as handle:
+        handle.write(candidate)
+    write_index(args.root)
+    print(f"accepted {args.hdr}")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# The index                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def render_index(root: str) -> str:
+    decisions = os.path.join(root, "harness", "decisions")
+    rows = []
+    if os.path.isdir(decisions):
+        for name in sorted(os.listdir(decisions)):
+            if not name.startswith("HDR-") or not name.endswith(".md"):
+                continue
+            with open(os.path.join(decisions, name), encoding="utf-8") as handle:
+                raw_fm, _ = S0.split_frontmatter(handle.read())
+            if raw_fm is None:
+                continue
+            fm = S0.parse_yaml(raw_fm)
+            surfaces = fm.get("surfaces") or []
+            rows.append((
+                str(fm.get("id") or name[:-3]),
+                str(fm.get("status") or "?"),
+                str(fm.get("classification") or "?"),
+                str(fm.get("enforcement") or "?"),
+                ", ".join(str(s) for s in surfaces) or "—",
+                "yes" if fm.get("provisional") is True else "no",
+                str(fm.get("expires") or fm.get("review_trigger") or "—"),
+            ))
+    rows.sort(key=lambda row: row[0])
+
+    out = [
+        "# Harness decision index",
+        "",
+        "One row per Harness Decision Record. Generated from "
+        "`harness/decisions/`; the file is rewritten in full on every "
+        "acceptance, so hand edits do not survive.",
+        "",
+        GENERATED_BEGIN,
+        "",
+    ]
+    if rows:
+        out.append("| ID | Status | Classification | Enforcement | Surfaces | "
+                   "Provisional | Expires |")
+        out.append("| --- | --- | --- | --- | --- | --- | --- |")
+        for row in rows:
+            out.append("| " + " | ".join(row) + " |")
+    else:
+        out.append("No decisions recorded yet.")
+    out += ["", GENERATED_END, ""]
+    return "\n".join(out)
+
+
+def write_index(root: str) -> str:
+    decisions = os.path.join(root, "harness", "decisions")
+    os.makedirs(decisions, exist_ok=True)
+    path = os.path.join(decisions, "index.md")
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(render_index(root))
+    return path
+
+
+def cmd_index(args) -> int:
+    path = write_index(args.root)
+    print(f"wrote {os.path.relpath(path, args.root)}")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--root", default=".", help="repository root")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p = sub.add_parser("propose", help="draft an HDR from an assay finding")
+    p.add_argument("--assay", required=True)
+    p.add_argument("--finding", required=True)
+    p.add_argument("--slug")
+    p.add_argument("--today", help="YYYY-MM-DD; injected so nothing races the clock")
+    p.set_defaults(func=cmd_propose)
+
+    p = sub.add_parser("precheck", help="report every refusal that does not need a cost")
+    p.add_argument("--hdr", required=True)
+    p.set_defaults(func=cmd_precheck)
+
+    p = sub.add_parser("accept", help="the single write transaction")
+    p.add_argument("--hdr", required=True)
+    p.add_argument("--cost-file", required=True,
+                   help="a FILE, never an argument: a cost is multi-line prose, "
+                        "and an argument would put the approver's own words into "
+                        "shell history one copy-paste from the next HDR")
+    p.add_argument("--approver", required=True)
+    p.add_argument("--now", required=True, help="ISO timestamp; injected, not read")
+    p.set_defaults(func=cmd_accept)
+
+    p = sub.add_parser("index", help="regenerate harness/decisions/index.md")
+    p.set_defaults(func=cmd_index)
+
+    args = parser.parse_args(argv[1:])
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/docs/plugins/ai-literacy-superpowers/how-to/record-a-governance-change.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/record-a-governance-change.md
@@ -1,0 +1,119 @@
+# Record a governance change
+
+`HARNESS.md` governs the loop. `AGENTS.md` governs the turn. This guide covers
+the thing that governs *those* — how a harness rule comes into existence, what
+it has to prove, and what it costs.
+
+You will use two commands: `/harness-propose` and `/harness-accept`.
+
+## Before you start
+
+You need an assay — a read-only postmortem at `harness/assay/<ISO8601>-assay.md`
+written at a phase boundary. If you do not have one, there is nothing to
+propose from, and that is the design: rules enter on evidence, not on
+irritation.
+
+You also need `harness/surfaces.yaml`, declaring what each of your control
+surfaces can actually enforce.
+
+## 1. Read the assay
+
+This is the only step that needs your full attention. Everything after it is
+mechanical.
+
+An assay in which every finding resolves to `no-change` is a **successful**
+assay. If nothing needs to change, stop here — the report is the record of that,
+and you are done.
+
+## 2. Propose
+
+```bash
+/harness-propose harness/assay/2026-08-21T16-02Z-assay.md finding-3
+```
+
+This writes `harness/decisions/HDR-2026-08-21-<slug>.md` at `status: proposed`,
+copying the rule text and evidence **byte for byte** from the finding.
+
+`cost` is deliberately empty. You write it at the next gate.
+
+**If the classification is `harness-loop`, `script-validator` or `new-agent`,**
+four sections arrive as placeholders:
+
+```text
+## Why this layer
+## Enforcement
+## Validation
+## Rejected alternatives
+```
+
+Fill them yourself. Acceptance is refused until you do, and that refusal is not
+bureaucracy: a change that reaches beyond a single agent has to argue why it
+belongs at that layer, and neither the Assayer nor the Registrar is entitled to
+make that argument for you.
+
+## 3. Accept
+
+```bash
+/harness-accept harness/decisions/HDR-2026-08-21-unevidenced-completion.md
+```
+
+Every refusal that does not depend on the cost runs **first**. You will not be
+asked to compose a considered cost for a rule that is about to be refused.
+
+If it passes, you are asked one question:
+
+```text
+Cost of this rule, in your own words. What will it demand of whoever
+works here next, and how might it be gamed?
+```
+
+Answer it yourself. The validator refuses a cost identical to the Assayer's
+proposal, and the reason is not procedural — a copy-pasted cost reads exactly
+like a considered one, so nothing downstream can tell them apart. If you ask the
+agent to write it, it will decline and offer to discuss the rule instead.
+
+Acceptance is all-or-nothing: on any refusal, nothing is written and the record
+stays `proposed`.
+
+## 4. Review the diff and commit
+
+Nothing has been committed on your behalf. Three gates exist — drafting,
+accepting, committing — and none is implied by another.
+
+## The refusals you will actually meet
+
+| Refusal | What it means | Your options |
+| --- | --- | --- |
+| Tier-2 sections are placeholders | The argument for this layer is unwritten | Write them, or let the HDR wait |
+| `harness-loop` cites one assay | A single incident cannot reach the loop layer | Wait for a second assay to corroborate, or reclassify to the layer that owns the behaviour |
+| Fourth acceptance from one assay | The three-per-cycle cap | Leave it `proposed`; it carries forward and competes with the next assay's findings |
+| Cost identical to `proposed_cost` | You pasted the Assayer's words | Write your own |
+| Undeclared surface | A typo, or a surface missing from the matrix | Fix the name, or declare the surface |
+
+**A refusal is the mechanism working.** The design assumes rules should be hard
+to add and easy to retire. A proposal that carries forward is not a blocked
+task.
+
+Do not resolve a refusal by editing the record until it passes. Reclassifying a
+rule after the promotion threshold refused it is a real decision about where the
+behaviour belongs — make it deliberately, or leave the proposal alone.
+
+## What "provisional" means
+
+Every accepted HDR starts `provisional: true` with a 90-day expiry or a review
+trigger. Permanence is earned at review, not at creation.
+
+An expired rule still in force fails CI, so retiring a rule never depends on
+anyone remembering to reflect. That is the half of governance most projects
+never do.
+
+The exception is grandfathering: constraints lifted from an existing
+`HARNESS.md` during migration are imported with `provisional: false` and no
+expiry. Importing them on a 90-day clock would manufacture an expiry cliff on
+roughly day 90 of adoption, and people would learn to ignore a red check — which
+costs far more than the un-evidenced legacy rules ever did.
+
+## See also
+
+- [Harness Decision Record format](../reference/harness-decision-records.md)
+- [Assay finding format](../reference/assay-finding-format.md)

--- a/docs/plugins/ai-literacy-superpowers/reference/agents.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/agents.md
@@ -434,6 +434,37 @@ GitHub issues for them.
 
 ---
 
+### harness-registrar
+
+- **Tools**: Read, Write, Edit, Glob, Grep, Bash
+- **Model**: inherit
+- **Dispatched by**: `/harness-propose`, `/harness-accept`
+- **Trust boundary**: Read-write
+
+Keeps the record of how governance itself changes. Drafts a Harness Decision
+Record from an assay finding, runs the acceptance transaction once the approver
+has written the cost, and regenerates the decision index.
+
+**It applies; it does not author.** The Harness Assayer proposes, a human
+approves, and the Registrar writes it down. If an approved record is ambiguous
+it stops and asks rather than filling the gap.
+
+Deliberately **not** tagged `role: sentinel`. It holds `Write` and `Edit`, so
+claiming a read-only trust boundary would be a lie `sentinel-integrity-check.sh`
+would catch — and, worse, the exact category error the two-role separation
+exists to prevent. The Assayer diagnoses; the Registrar legislates. An agent
+doing both could rationalise its own findings into rules that make its next
+diagnosis easier.
+
+Because it has write authority, every guarantee that could be made mechanical
+has been: rule text is copied byte for byte by
+`scripts/harness-registrar.py`, every refusal is enforced by
+`scripts/check-harness-decisions.py` inside the transaction, and acceptance
+validates a staged copy of the whole corpus so nothing is ever half-written.
+The agent is the interface, not the mechanism.
+
+---
+
 ## Assessment
 
 ### assessor
@@ -534,6 +565,7 @@ is a precaution under uncertainty. See the
 | assessor | x | x | x | x | x | x | | | read-write |
 | governance-auditor | x | x | x | x | x | x | | | read-write (limited) |
 | reservoir-warden | x | | | x | x | x | | | read-only |
+| harness-registrar | x | x | x | x | x | x | | | read-write |
 
 ---
 

--- a/docs/plugins/ai-literacy-superpowers/reference/assay-finding-format.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/assay-finding-format.md
@@ -1,0 +1,166 @@
+# Assay finding format
+
+An **assay** is a read-only postmortem written by the `harness-assayer` at a
+phase boundary. It reads evidence from completed work, classifies what it finds
+by ownership, proposes a bounded change set, and stops.
+
+Most of an assay is prose for a human: an executive summary, what worked, what
+created friction, rejected candidates, unresolved questions. This page documents
+only the part a machine reads — the **finding block** that `/harness-propose`
+extracts an HDR from.
+
+Assays live in `harness/assay/<ISO8601>-assay.md` and are append-only. They are
+never edited after they are written.
+
+## Who owns this contract
+
+The contract is owned by the Registrar slice and consumed by the Assayer. That
+ordering is deliberate: `/harness-propose` has no input without it, and a format
+designed by the component that never has to parse it is a format that will not
+parse.
+
+Keep it narrow. Everything `/harness-propose` does not read is free prose, and
+the Assayer should use that freedom rather than expanding this contract.
+
+## Frontmatter
+
+```yaml
+---
+assay: harness/assay/2026-08-21T16-02Z-assay.md
+date: 2026-08-21
+agent: harness-assayer
+model: claude-opus-5
+---
+```
+
+`agent` and `model` are **required** and become the HDR's `proposer` block. An
+HDR records which model proposed it because a rule proposed by a model that has
+since been replaced is a rule whose evidence deserves re-reading.
+
+## A finding
+
+`````markdown
+### finding-3 — Unevidenced completion claims
+
+Claude Code reported the integration suite passing on 2026-08-04 and again on
+2026-08-12. The build log records the command being planned on both dates and
+never records it running.
+
+```yaml
+classification: agent-instruction
+enforcement: validated
+surfaces: [claude-code, copilot]
+priority: P1
+evidence:
+  - harness/build-log.md#2026-08-04T09-12Z
+overfitting_risk: low
+```
+
+#### Proposed rule
+
+````markdown
+- **Rule**: A phase may not be reported complete on the strength of a planned
+  command. Cite observed output.
+````
+
+#### Cost estimate
+
+One extra check per phase boundary; roughly two minutes.
+`````
+
+### The heading
+
+`### <finding-id> <sep> <Title>`, where `<sep>` is an em dash, en dash or
+hyphen, and `<finding-id>` matches `[a-z0-9]+(-[a-z0-9]+)*`.
+
+The id is what `/harness-propose` is given and what the HDR's evidence anchor
+points at, so it must be stable within the file.
+
+### The observation
+
+The text between the heading and the metadata block. It becomes the HDR's
+`## Finding` section verbatim, and it is **required**.
+
+A finding with no observation is not a finding but a rule with a citation
+attached, and the HDR it produced would have nothing to say about what actually
+went wrong — which is the entire reason a governance change is asked to cite
+evidence.
+
+### The metadata block
+
+A ```` ```yaml ```` block requiring `classification`, `enforcement`, `surfaces`,
+`evidence` and `priority`.
+
+`priority` is required even though `/harness-propose` never reads it. A finding
+nobody can triage is a finding that will be triaged by whichever one happens to
+be listed first.
+
+### The proposed rule
+
+`#### Proposed rule` holds **exactly one four-backtick block** — the same
+delimiter, and the same reason, as the HDR's Rule block. Rule text is markdown
+that routinely contains a three-backtick fence of its own, and a three-backtick
+delimiter would terminate on the first nested fence and silently truncate the
+rule.
+
+This block is copied into the HDR **byte for byte** by
+`scripts/harness-registrar.py`, never retyped by an agent.
+
+### The cost estimate
+
+`#### Cost estimate` must be non-empty. It becomes the HDR's `proposed_cost` —
+which is precisely what the validator compares the approver's own words against,
+and refuses when they match.
+
+So this field has a second job beyond informing the reader: it is the thing a
+copy-pasted cost gets caught by. An Assayer that leaves it vague weakens that
+check.
+
+### A `no-change` finding
+
+`#### Proposed rule` says `No change.` with no fenced block, `enforcement` is
+`advisory`, and `surfaces` may be empty.
+
+An assay in which every finding resolves to `no-change` is a **successful**
+assay. Recording that nothing needed to change is itself evidence.
+
+## What `/harness-propose` does with a finding
+
+| HDR field | Source |
+| --- | --- |
+| `title` | the heading title |
+| `## Finding` | the observation, verbatim |
+| `classification`, `enforcement`, `surfaces` | the metadata block |
+| `evidence` | the metadata `evidence` **plus** `<assay-path>#<finding-id>` |
+| `proposed_cost` | the cost estimate, verbatim |
+| `## Rule` block | the proposed-rule block, byte for byte |
+| `cost` | **empty** — the approver writes it at the gate |
+
+### Why the assay anchor is appended
+
+Every HDR ends up citing at least the assay that proposed it. That makes the
+two-assay promotion threshold behave the way it should: a first-time
+`harness-loop` finding cites one assay and is refused at acceptance, while a
+finding corroborated by a prior assay names that assay in its own `evidence`,
+reaches two, and passes.
+
+Without the appended anchor, a finding whose evidence happened to name only
+build-log entries would produce an HDR citing zero assays — refused for a reason
+that reads like a bug rather than like the threshold doing its job.
+
+## Refusals
+
+`/harness-propose` refuses, writing nothing, when: the assay does not exist or
+has no frontmatter `agent`/`model`; there is no `## Findings` section; the
+requested finding id is absent; or the finding is missing its metadata block,
+its observation, its proposed rule, or its cost estimate.
+
+Findings are parsed **lazily**, one at a time. One malformed finding costs one
+finding, not the whole report — an assay is written by an agent under a
+materiality test, not by a compiler.
+
+## See also
+
+- Spec: `docs/superpowers/specs/2026-08-23-harness-evolution-s1-registrar-design.md`
+- HDR format: `harness-decision-records.md`
+- Tests: `tdad_tests/layer0_deterministic/test-harness-registrar.sh`

--- a/docs/plugins/ai-literacy-superpowers/reference/commands.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/commands.md
@@ -198,6 +198,70 @@ unresolved `no` leaves the date unchanged and records a single
 `[review-gap: <check>]` Notes line for the failing check. Use `review`
 to clear what the **Affordance review staleness** GC rule reports.
 
+### /harness-propose
+
+Usage: `/harness-propose <assay-path> <finding-id>`
+
+- **Skills read**: none
+- **Agents dispatched**: `harness-registrar`
+
+Drafts a Harness Decision Record from one finding in an assay, at
+`status: proposed`, in `harness/decisions/HDR-<date>-<slug>.md`.
+
+The rule text and the evidence list are copied **by the script**, byte for byte.
+That is not a convenience: a model asked to copy text usually copies it and
+occasionally improves it — a typo fixed, a bullet tidied, a line rewrapped — and
+every one of those is a silent edit to a rule a human is about to approve
+believing it to be the Assayer's words. The command's validation checkpoint
+requires diffing the two blocks rather than eyeballing them, and a deviation is
+reported as a defect rather than fixed in place.
+
+`cost` is left **empty**. The approver writes it at the acceptance gate.
+
+For a tier-2 classification (`harness-loop`, `script-validator`, `new-agent`)
+four sections are written as placeholders. Acceptance is refused until a human
+fills them — neither the Assayer nor the Registrar is entitled to write the
+argument for why a rule belongs at the loop layer.
+
+Pass `--slug` only to resolve a filename collision; the script never overwrites.
+
+### /harness-accept
+
+Usage: `/harness-accept <hdr-path>`
+
+- **Skills read**: none
+- **Agents dispatched**: `harness-registrar`
+
+The single write transaction of the harness evolution loop, and the only place
+the `cost` is ever written.
+
+**Refusals run before the cost prompt.** Making someone compose a considered
+cost for a rule that is about to be refused for citing a single assay spends
+exactly the human attention the mechanism exists to protect, so the order is
+load-bearing rather than stylistic.
+
+The cost question is asked verbatim:
+
+```text
+Cost of this rule, in your own words. What will it demand of whoever
+works here next, and how might it be gamed?
+```
+
+The answer is passed as `--cost-file`, never as an argument — it is multi-line
+prose, and an argument would put the approver's own words into shell history one
+copy-paste from the next HDR. If asked to write the cost, the command declines:
+a copy-pasted cost reads exactly like a considered one, so nothing downstream
+can tell them apart.
+
+Acceptance is all-or-nothing. The script validates a staged copy of the whole
+corpus — necessary because the cycle cap and the promotion threshold compare
+HDRs against each other — and writes only on success, so a refusal leaves the
+HDR `proposed` and the corpus byte-identical.
+
+It writes to no control surface, and it does not commit, push, or open a pull
+request. Three gates exist — drafting, accepting, committing — and none is
+implied by another.
+
 ---
 
 ## Assessment & Improvement

--- a/docs/superpowers/specs/2026-08-23-harness-evolution-s1-registrar-design.md
+++ b/docs/superpowers/specs/2026-08-23-harness-evolution-s1-registrar-design.md
@@ -104,6 +104,10 @@ since been replaced is a rule whose evidence deserves re-reading.
 ````markdown
 ### finding-3 — Unevidenced completion claims
 
+Claude Code reported the integration suite passing on 2026-08-04 and again on
+2026-08-12. The build log records the command being planned on both dates and
+never records it running.
+
 ```yaml
 classification: agent-instruction
 enforcement: validated
@@ -128,6 +132,11 @@ One extra check per phase boundary; roughly two minutes.
 
 - The heading is `### <finding-id> <sep> <Title>`, where `<sep>` is an em dash,
   en dash, or hyphen, and `<finding-id>` matches `[a-z0-9]+(-[a-z0-9]+)*`.
+- The text between the heading and the metadata block is the finding's
+  **observation** — what was actually seen — and becomes the HDR's `## Finding`
+  section. It is required. A finding with no observation is not a finding but a
+  rule with a citation attached, and the HDR it produced would have nothing to
+  say about what went wrong.
 - The YAML block requires `classification`, `enforcement`, `surfaces`,
   `evidence` and `priority`. `priority` is required not because
   `/harness-propose` needs it but because a finding nobody can triage is a
@@ -163,6 +172,7 @@ Writes `harness/decisions/HDR-<today>-<slug>.md` at `status: proposed`.
 | --- | --- |
 | `id`, filename | `HDR-<today>-<slug>`; slug from the finding title, or `--slug` |
 | `title` | the finding's heading title |
+| `## Finding` | the finding's observation prose, verbatim |
 | `status` | `proposed` |
 | `classification`, `enforcement`, `surfaces` | the finding's YAML block |
 | `evidence` | the finding's evidence **plus** the source assay anchor (§4.3) |

--- a/docs/superpowers/specs/2026-08-23-harness-evolution-s1-registrar-design.md
+++ b/docs/superpowers/specs/2026-08-23-harness-evolution-s1-registrar-design.md
@@ -1,0 +1,328 @@
+# Spec: Harness Evolution S1 — the Harness Registrar, record-keeping only
+
+**Status:** Approved
+**Date:** 2026-08-23
+**Issue:** #535
+**Epic:** Harness Evolution — the Harness Assayer and the Harness Registrar (#533)
+**Depends on:** S0 (0.74.0) — the HDR schema and the validator that holds every
+refusal.
+**Scope:** `ai-literacy-superpowers` plugin — one agent, two commands, one
+script, one record contract, one generated index.
+**Explicitly out of scope:** applying rule text to any governance artifact,
+compiling control surfaces, `/harness-check`, `/harness-review`,
+`/harness-timeline`, and importing legacy `HARNESS.md` constraints. All of those
+are S2 or later.
+
+**Provenance:** the Harness Assayer / Harness Registrar build spec, supplied in
+conversation 2026-08-23. Epic-level decisions recorded on #533.
+
+---
+
+## 1. Problem Statement
+
+S0 built the thing that says *no*. Nothing yet says *yes*.
+
+An HDR has no way to come into existence, no way to travel from `proposed` to
+`accepted`, and no index anyone can read. This phase adds exactly that, and
+nothing else: the Registrar keeps records. It does not yet touch `HARNESS.md`.
+
+Splitting record-keeping from application is not ceremony. The two failure modes
+are different — a malformed record is caught by a validator, whereas a rule
+written into the wrong section of `HARNESS.md` is caught by a human reading a
+diff — and building them together would mean debugging both at once.
+
+## 2. The sequencing problem, and who owns the assay contract
+
+`/harness-propose <assay> <finding>` consumes an assay. Assays are S3.
+
+The precedent in this repository is the Cadence Sentinels S1 slice, which owned
+the record contracts that S2–S5 consumed. **S1 owns the assay-finding
+contract**; S3's Assayer writes to it.
+
+The contract is deliberately narrow. It covers only what `/harness-propose`
+needs to read: the finding's identifier, its classification, enforcement,
+surfaces and evidence, its proposed rule text, and its cost estimate. Everything
+else in an assay report — the executive summary, what worked, what created
+friction, rejected candidates, unresolved questions — is prose for a human, and
+the Registrar never parses it.
+
+Narrowing it this way keeps S3 free to design the report it wants around a small
+fixed core, and keeps S1 from inventing an interface for a document it has never
+seen.
+
+## 3. The decision that shapes this phase: the copy is deterministic
+
+The build spec says `/harness-propose` "copies evidence references and proposed
+rule text verbatim". The epic made the Registrar a **plugin agent**, so the
+obvious implementation is: the agent reads the assay and writes the HDR.
+
+That implementation cannot deliver what the sentence promises. A model asked to
+copy text usually copies it, and occasionally improves it — fixes a typo, tidies
+an inconsistent bullet, rewraps a line. Every one of those is a silent edit to
+a rule that a human is about to approve on the understanding that it is the
+Assayer's words.
+
+So `/harness-propose` extracts with a script. The rule block and the evidence
+list are read out of the assay file and written into the HDR byte for byte, and
+the agent never has them in its output at all.
+
+> Verbatim by construction, not verbatim by instruction.
+
+This is the same move S0 made with the refusals, for the same reason, and it
+answers the same objection: the Registrar holds write authority, so wherever a
+guarantee can be made mechanical rather than instructed, it must be.
+
+**What the agent does instead.** It locates the assay, presents the findings,
+confirms which one the human wants, runs the script, reads any refusal back in
+plain language, and prompts for the cost. It is the interface, not the
+mechanism. Stating this now matters because S2 is where the agent acquires real
+judgement — deciding where in `HARNESS.md` a rule belongs — and the boundary
+needs to exist before the judgement arrives.
+
+## 4. The assay-finding contract
+
+An assay is a markdown file at `harness/assay/<ISO8601>-assay.md` with
+frontmatter and a `## Findings` section.
+
+### 4.1 Frontmatter
+
+```yaml
+---
+assay: harness/assay/2026-08-21T16-02Z-assay.md
+date: 2026-08-21
+agent: harness-assayer
+model: claude-opus-5
+---
+```
+
+`agent` and `model` are required, and become the HDR's `proposer` block. An HDR
+records which model proposed it because a rule proposed by a model that has
+since been replaced is a rule whose evidence deserves re-reading.
+
+### 4.2 A finding
+
+````markdown
+### finding-3 — Unevidenced completion claims
+
+```yaml
+classification: agent-instruction
+enforcement: validated
+surfaces: [claude-code, copilot]
+priority: P1
+evidence:
+  - harness/build-log.md#2026-08-04T09-12Z
+overfitting_risk: low
+```
+
+#### Proposed rule
+
+`````markdown
+- **Rule**: A phase may not be reported complete on the strength of a planned
+  command. Cite observed output.
+`````
+
+#### Cost estimate
+
+One extra check per phase boundary; roughly two minutes.
+````
+
+- The heading is `### <finding-id> <sep> <Title>`, where `<sep>` is an em dash,
+  en dash, or hyphen, and `<finding-id>` matches `[a-z0-9]+(-[a-z0-9]+)*`.
+- The YAML block requires `classification`, `enforcement`, `surfaces`,
+  `evidence` and `priority`. `priority` is required not because
+  `/harness-propose` needs it but because a finding nobody can triage is a
+  finding that will be triaged by whichever one is listed first.
+- `#### Proposed rule` holds exactly one four-backtick block — the same
+  delimiter and the same reason as the HDR's Rule block (S0 §4.6).
+- `#### Cost estimate` must be non-empty. It becomes the HDR's `proposed_cost`,
+  which is what the S0 cost rule compares the human's words against.
+- For a `no-change` finding, `#### Proposed rule` says `No change.` with no
+  fenced block, `enforcement` is `advisory`, and `surfaces` may be empty.
+
+### 4.3 The evidence rule
+
+The HDR's `evidence` list is the finding's `evidence` list, **plus the source
+assay anchor** `harness/assay/<file>#<finding-id>`, appended if not already
+present.
+
+This guarantees every HDR cites at least the assay that proposed it, and it
+makes the S0 two-assay promotion threshold behave exactly as the build spec's
+worked cycle describes. A first-time `harness-loop` finding cites one assay and
+is refused at acceptance. A finding corroborated by a prior assay cites that
+assay in its own evidence, reaches two, and passes.
+
+Without the appended anchor, a finding whose evidence happened to name only
+build-log entries would produce an HDR with zero assays — refused for a reason
+that would read as a bug rather than as the threshold doing its job.
+
+## 5. `/harness-propose <assay> <finding>`
+
+Writes `harness/decisions/HDR-<today>-<slug>.md` at `status: proposed`.
+
+| HDR field | Source |
+| --- | --- |
+| `id`, filename | `HDR-<today>-<slug>`; slug from the finding title, or `--slug` |
+| `title` | the finding's heading title |
+| `status` | `proposed` |
+| `classification`, `enforcement`, `surfaces` | the finding's YAML block |
+| `evidence` | the finding's evidence **plus** the source assay anchor (§4.3) |
+| `proposed_cost` | the finding's `#### Cost estimate`, verbatim |
+| `cost` | **empty** |
+| `proposer` | `{agent, model}` from the assay frontmatter, `assay` = its path |
+| `approver`, `approved_at` | absent |
+| `provisional` | `true`, with `expires` = today + 90 days |
+| `## Rule` block | the finding's proposed-rule block, byte for byte |
+
+For `classification: no-change`, `provisional` is `false`, no `expires` is
+written, and the Rule section says `No change.` — matching S0 §4.7.
+
+Tier-2 classifications (`harness-loop`, `script-validator`, `new-agent`) require
+four further body sections that a finding does not carry. `/harness-propose`
+writes them as **explicitly empty placeholders** naming what each must answer,
+and the S0 validator refuses the HDR at acceptance until they are filled.
+
+That is the correct behaviour rather than a gap: a loop-layer change must argue
+why it belongs at that layer, and neither the Assayer nor the Registrar is
+entitled to write that argument. The human does, or the rule does not land.
+
+**Refusals.** `/harness-propose` refuses on: an assay that does not exist or does
+not parse; a finding id that is not in it; a malformed finding; and a target
+filename that already exists — it never overwrites, and `--slug` is how a
+collision is resolved.
+
+## 6. `/harness-accept <HDR>`
+
+The single write transaction of this phase. Record-only: it sets `status:
+accepted` and regenerates the index. It does not touch `HARNESS.md` — that is
+S2, folded into this same command.
+
+### 6.1 Refusals run before the cost prompt
+
+Every refusal that does not depend on the cost runs first, against the HDR as it
+stands. Only if they all pass is the human asked to write the cost.
+
+The build spec's worked cycle shows this order, and the reason is the point of
+the whole design: making someone compose a considered cost for a rule that is
+about to be refused for citing a single assay spends exactly the human attention
+this mechanism exists to protect. Refuse first, then ask.
+
+### 6.2 The cost prompt
+
+```text
+Cost of this rule, in your own words. What will it demand of whoever
+works here next, and how might it be gamed?
+>
+```
+
+The answer is captured to a file and passed as `--cost-file`. Two reasons: a
+cost is multi-line prose, and a `--cost "..."` argument would put the human's
+words into shell history and into the agent's transcript, one copy-paste away
+from being reused verbatim on the next HDR.
+
+The S0 validator then refuses an empty cost, or one identical to
+`proposed_cost`.
+
+### 6.3 The transaction
+
+Acceptance is all-or-nothing, and the corpus-level rules make that harder than
+it looks: the three-per-cycle cap cannot be evaluated by looking at the
+candidate alone.
+
+So:
+
+1. Build the accepted HDR text in memory.
+2. Copy the entire `harness/` corpus to a temporary root, with the candidate
+   substituted for its `proposed` predecessor.
+3. Run the S0 validator against that temporary root.
+4. Only on exit 0, write the real file and regenerate the index.
+
+Corpus-level refusals therefore fire **before** anything is written, rather than
+being discovered by CI after the fact. "Nothing is written and the HDR stays
+`proposed`" becomes a property of the mechanism instead of a promise in a
+document.
+
+### 6.4 What acceptance writes
+
+`status: accepted`, `approver`, `approved_at`, and the human's `cost`. The
+`## Cost` body section is set to the same text, so the record reads correctly on
+its own. Nothing else in the HDR is touched — in particular the `## Rule` block
+is never rewritten, because from acceptance onward it is the byte-for-byte
+source that S2's compiler applies.
+
+## 7. `harness/decisions/index.md`
+
+Generated wholly, inside the markers S2 will also use:
+
+```markdown
+<!-- BEGIN GENERATED: harness-registrar — do not edit by hand -->
+<!-- END GENERATED: harness-registrar -->
+```
+
+One row per HDR, sorted by `id`, listing status, classification, enforcement,
+surfaces, provisional and expiry. A pure function of the corpus: re-running it
+on an unchanged corpus produces byte-identical output, which is what lets S2's
+`/harness-check` treat any difference as drift.
+
+The index is **linted** — unlike the HDRs themselves — because it is a generated
+document rather than a record, and a generator that emits markdown nobody would
+accept by hand is a generator that will be quietly hand-edited.
+
+## 8. The agent
+
+`harness-registrar.agent.md` — `tools: [Read, Write, Edit, Glob, Grep, Bash]`,
+and **no `role:` tag**.
+
+The absence is deliberate and load-bearing. `role: sentinel` is checked by
+`sentinel-integrity-check.sh`, which fails CI on a sentinel granted `Write`. The
+Registrar has write authority over governance artifacts and must not claim the
+read-only trust boundary. Tagging it would be a lie that CI would catch; leaving
+it untagged is the honest declaration that this agent is not a sentinel.
+
+## 9. Acceptance criteria
+
+| ID | Criterion |
+| --- | --- |
+| R1 | `propose` writes a valid `proposed` HDR that the S0 validator accepts |
+| R2 | The Rule block in the HDR is **byte-identical** to the finding's proposed-rule block |
+| R3 | The HDR's evidence is the finding's evidence plus the assay anchor, deduplicated |
+| R4 | `proposed_cost` is the finding's cost estimate verbatim; `cost` is empty |
+| R5 | `propose` refuses a missing assay, an unknown finding id, and a malformed finding, writing nothing |
+| R6 | `propose` refuses to overwrite an existing HDR |
+| R7 | A tier-2 finding produces placeholder sections, and the resulting HDR is refused at acceptance until they are filled |
+| R8 | `propose` of a `no-change` finding writes `provisional: false`, no expiry, and `No change.` |
+| R9 | `accept` moves `proposed → accepted`, writing `approver`, `approved_at` and the cost |
+| R10 | `accept` refuses an empty cost and a cost identical to `proposed_cost` |
+| R11 | `accept` refuses a single-evidence `harness-loop` HDR, **leaving the file unchanged** |
+| R12 | `accept` refuses a fourth HDR from one assay, leaving the file unchanged |
+| R13 | Every refusal leaves the corpus byte-identical to its prior state |
+| R14 | `accept` refuses an HDR that is not `status: proposed` |
+| R15 | `index` output is byte-identical on re-run and lists every HDR sorted by id |
+| R16 | The pre-cost check reports refusals without a cost being supplied |
+
+Tests live at `tdad_tests/layer0_deterministic/test-harness-registrar.sh`.
+
+## 10. Deferred, deliberately
+
+- **Importing legacy `HARNESS.md` constraints.** Grandfathering (`imported:
+  true`) is validated by S0 but has no writer yet. It is adoption work, and
+  adoption is `/harness-compile`'s one-time setup in S2.
+- **`superseded` and `expired` transitions.** S4 owns demotion; writing a
+  supersession here would mean designing the review flow twice.
+- **Anything touching a control surface.** S2.
+
+## 11. Rejected alternatives
+
+**The agent copies the rule text.** Rejected per §3 — the one thing this phase
+must guarantee is exactly the thing a model cannot be relied upon to do.
+
+**Cost as a command-line argument.** Rejected per §6.2. Convenience, at the cost
+of putting the human's own words somewhere they can be harvested for the next
+HDR.
+
+**Validating the candidate in isolation and writing immediately.** Rejected per
+§6.3 — the cycle cap is corpus-level, so isolation cannot see it, and the
+failure would surface in CI after the write rather than at the gate.
+
+**Deferring the assay contract to S3.** Rejected per §2: `/harness-propose` has
+no input without it, and a contract designed by the consumer that never has to
+parse it is a contract that will not parse.

--- a/harness/decisions/index.md
+++ b/harness/decisions/index.md
@@ -1,0 +1,9 @@
+# Harness decision index
+
+One row per Harness Decision Record. Generated from `harness/decisions/`; the file is rewritten in full on every acceptance, so hand edits do not survive.
+
+<!-- BEGIN GENERATED: harness-registrar — do not edit by hand -->
+
+No decisions recorded yet.
+
+<!-- END GENERATED: harness-registrar -->

--- a/tdad_tests/layer0_deterministic/test-harness-registrar.sh
+++ b/tdad_tests/layer0_deterministic/test-harness-registrar.sh
@@ -1,0 +1,561 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for the Harness Registrar's write path
+# (spec 2026-08-23-harness-evolution-s1-registrar-design.md, §9; R1-R16).
+#
+# R2 IS THE ONE THIS PHASE EXISTS FOR. The build spec says /harness-propose
+# "copies proposed rule text verbatim". An agent asked to copy text usually
+# copies it and occasionally improves it - fixes a typo, tidies a bullet,
+# rewraps a line - and every one of those is a silent edit to a rule a human is
+# about to approve believing it to be the Assayer's words. So the copy is done
+# by a script, and R2 asserts byte-identity rather than trusting an instruction.
+#
+# R13 IS THE OTHER ONE. Acceptance must be all-or-nothing, and the cycle cap is
+# corpus-level: it cannot be evaluated from the candidate alone. So accept
+# validates against a staging copy of the whole corpus and only then writes.
+# R13 hashes every file under harness/ before and after each refusal, because
+# "nothing was written" is a claim that deserves a measurement rather than a
+# reading of the code.
+#
+# THE CLOCK IS INJECTED, NOT READ (#527). --today and --now exist so this suite
+# cannot fail because it ran at the wrong hour or on the wrong day.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$SCRIPT_DIR/../.."
+REG="$ROOT/ai-literacy-superpowers/scripts/harness-registrar.py"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+[ -f "$REG" ] || fail "harness registrar not found at $REG"
+
+PY=/usr/bin/python3
+command -v "$PY" >/dev/null 2>&1 || PY=python3
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+HARNESS="$TMP/harness"
+DEC="$HARNESS/decisions"
+ASSAY="$HARNESS/assay"
+mkdir -p "$DEC" "$ASSAY"
+
+A1="harness/assay/2026-08-21T16-02Z-assay.md"
+A0="harness/assay/2026-08-12T14-03Z-assay.md"
+
+reg() {
+  set +e
+  OUT="$( cd "$TMP" && "$PY" "$REG" "$@" 2>&1 )"
+  RC=$?
+  set -e
+}
+
+# Every file under harness/, path and content, in one digest. "Nothing was
+# written" is a measurable claim; asserting it by reading the code is not.
+corpus_hash() {
+  ( cd "$TMP" && "$PY" -c "
+import hashlib, os
+h = hashlib.sha256()
+for dirpath, dirs, files in os.walk('harness'):
+    dirs.sort()
+    for name in sorted(files):
+        p = os.path.join(dirpath, name)
+        h.update(p.encode())
+        h.update(open(p, 'rb').read())
+print(h.hexdigest())
+" )
+}
+
+expect_ok()   { [ "$RC" -eq 0 ] || fail "$1: expected exit 0, got $RC. Out: $OUT"; }
+expect_fail() {
+  [ "$RC" -ne 0 ] || fail "$1: expected non-zero exit, got 0. Out: $OUT"
+  printf '%s' "$OUT" | grep -q 'Traceback' \
+    && fail "$1: crashed instead of refusing. Out: $OUT"
+  printf '%s' "$OUT" | grep -qi -- "$2" \
+    || fail "$1: message must mention '$2'. Out: $OUT"
+}
+
+cat > "$HARNESS/surfaces.yaml" <<'EOF'
+surfaces:
+  claude-code:
+    targets: [CLAUDE.md, .claude/agents/]
+    supports: [advisory, validated, blocked]
+  copilot:
+    targets: [.github/copilot-instructions.md]
+    supports: [advisory]
+  ci:
+    targets: [.github/workflows/]
+    supports: [validated, blocked]
+EOF
+
+# --- The assay fixtures ------------------------------------------------------
+# Written by hand here rather than generated, because this file IS the contract
+# S3's Assayer must satisfy. A fixture assembled by a helper would let the
+# contract drift into whatever the helper happened to emit.
+
+cat > "$TMP/$A1" <<'EOF'
+---
+assay: harness/assay/2026-08-21T16-02Z-assay.md
+date: 2026-08-21
+agent: harness-assayer
+model: claude-opus-5
+---
+
+# Assay 2026-08-21T16-02Z
+
+## Findings
+
+### finding-3 — Unevidenced completion claims
+
+Claude Code reported the integration suite passing on 2026-08-04 and again on
+2026-08-12. The build log records the command being planned on both dates and
+never records it running.
+
+```yaml
+classification: agent-instruction
+enforcement: validated
+surfaces: [claude-code, copilot]
+priority: P1
+evidence:
+  - harness/build-log.md#2026-08-04T09-12Z
+overfitting_risk: low
+```
+
+#### Proposed rule
+
+````markdown
+- **Rule**: A phase may not be reported complete on the strength of a planned  
+  command. Cite observed output.
+
+  Example of what does *not* count:
+
+  ```bash
+  npm test  # planned, never run
+  ```
+````
+
+#### Cost estimate
+
+One extra check per phase boundary; roughly two minutes.
+
+### finding-5 — Context files capture narration
+
+Phase context files grew to a size nobody reads. The growth is confined to one
+unusually exploratory phase, and no rule asked for the narration that filled
+them.
+
+```yaml
+classification: no-change
+enforcement: advisory
+surfaces: []
+priority: P3
+evidence:
+  - harness/build-log.md#2026-08-19T11-00Z
+```
+
+#### Proposed rule
+
+No change.
+
+#### Cost estimate
+
+None. Recording that nothing needed to change is itself evidence.
+
+### finding-7 — Completion claims across every surface
+
+The same unevidenced-completion pattern appears on Copilot CLI as well as
+Claude Code, which suggests the behaviour belongs to the loop rather than to
+one agent's instructions.
+
+```yaml
+classification: harness-loop
+enforcement: validated
+surfaces: [claude-code, ci]
+priority: P0
+evidence:
+  - harness/build-log.md#2026-08-04T09-12Z
+```
+
+#### Proposed rule
+
+````markdown
+- **Rule**: Every agent reporting a phase boundary must cite observed output.
+````
+
+#### Cost estimate
+
+A check at every phase boundary on every surface.
+
+### finding-9 — Corroborated across two assays
+
+The 2026-08-12 assay recorded the same failure class, so this is a second
+independent observation rather than a repeat reading of the first.
+
+```yaml
+classification: harness-loop
+enforcement: validated
+surfaces: [claude-code, ci]
+priority: P0
+evidence:
+  - harness/assay/2026-08-12T14-03Z-assay.md#finding-2
+```
+
+#### Proposed rule
+
+````markdown
+- **Rule**: Corroborated loop-level rule.
+````
+
+#### Cost estimate
+
+A check at every phase boundary on every surface.
+
+### finding-13 — Rule with no seen failure behind it
+
+```yaml
+classification: agent-instruction
+enforcement: validated
+surfaces: [claude-code]
+priority: P2
+evidence:
+  - harness/build-log.md#2026-08-20T11-00Z
+```
+
+#### Proposed rule
+
+````markdown
+- **Rule**: A rule with no observed failure behind it.
+````
+
+#### Cost estimate
+
+A cost estimate for a rule nobody saw a reason for.
+
+### finding-11 — Malformed on purpose
+
+This finding exists to be rejected: it carries an observation and metadata but
+no proposed-rule section at all.
+
+```yaml
+classification: agent-instruction
+enforcement: validated
+surfaces: [claude-code]
+priority: P2
+evidence:
+  - harness/build-log.md#2026-08-20T10-00Z
+```
+
+#### Cost estimate
+
+Missing its proposed-rule section entirely.
+EOF
+
+printf -- '---\nassay: %s\ndate: 2026-08-12\nagent: harness-assayer\nmodel: claude-opus-5\n---\n\n## Findings\n' "$A0" > "$TMP/$A0"
+
+# The exact rule text finding-3 proposes. R2 compares against this.
+#
+# Two things in it are deliberate. It contains a THREE-backtick fence, which is
+# why the block delimiter is four backticks - a copier that mishandles nesting
+# fails here. And the first line ends in TWO SPACES: a markdown hard line break,
+# meaningful syntax that a well-meaning .rstrip() destroys silently. Without it
+# the fixture was too clean to catch the exact failure R2 exists for.
+cat > "$TMP/expected-rule.txt" <<'EOF'
+- **Rule**: A phase may not be reported complete on the strength of a planned  
+  command. Cite observed output.
+
+  Example of what does *not* count:
+
+  ```bash
+  npm test  # planned, never run
+  ```
+EOF
+
+field() {  # field <hdr-path> <key> — a frontmatter scalar, for assertions
+  "$PY" -c "
+import sys, re
+text = open(sys.argv[1]).read()
+fm = text.split('---', 2)[1]
+for line in fm.splitlines():
+    if line.startswith(sys.argv[2] + ':'):
+        print(line.split(':', 1)[1].strip()); break
+" "$1" "$2"
+}
+
+# === R1: propose writes a valid proposed HDR =================================
+reg propose --assay "$A1" --finding finding-3 --today 2026-08-21
+expect_ok "R1 (propose finding-3)"
+HDR="$DEC/HDR-2026-08-21-unevidenced-completion-claims.md"
+[ -f "$HDR" ] || fail "R1: expected HDR at $HDR. Out: $OUT"
+HDR_REL="harness/decisions/$(basename "$HDR")"
+
+# The S0 validator is the arbiter of "valid" - re-asserting its rules here would
+# create a second opinion about what a well-formed HDR is.
+set +e
+VOUT="$( cd "$TMP" && "$PY" "$ROOT/ai-literacy-superpowers/scripts/check-harness-decisions.py" 2>&1 )"
+VRC=$?
+set -e
+[ "$VRC" -eq 0 ] || fail "R1: proposed HDR fails the S0 validator. Out: $VOUT"
+
+[ "$(field "$HDR" status)" = "proposed" ] || fail "R1: status must be proposed"
+[ "$(field "$HDR" classification)" = "agent-instruction" ] || fail "R1: classification not copied"
+[ "$(field "$HDR" enforcement)" = "validated" ] || fail "R1: enforcement not copied"
+[ "$(field "$HDR" provisional)" = "true" ] || fail "R1: provisional must default true"
+[ "$(field "$HDR" expires)" = "2026-11-19" ] \
+  || fail "R1: expires must be today+90 (2026-11-19), got '$(field "$HDR" expires)'"
+
+# === R2: the Rule block is byte-identical to the finding's ===================
+"$PY" - "$HDR" "$TMP/expected-rule.txt" <<'PYEOF'
+import sys
+text = open(sys.argv[1]).read()
+want = open(sys.argv[2]).read().rstrip("\n")
+# Extract the four-backtick block from the ## Rule section.
+lines, buf, blocks = text.splitlines(), None, []
+for line in lines:
+    if line.startswith("````") and (buf is None or line.strip() == "````"):
+        if buf is None:
+            buf = []
+        else:
+            blocks.append("\n".join(buf)); buf = None
+        continue
+    if buf is not None:
+        buf.append(line)
+assert len(blocks) == 1, f"R2: expected exactly one four-backtick block, got {len(blocks)}"
+got = blocks[0].rstrip("\n")
+assert got == want, (
+    "R2: rule text is NOT byte-identical.\n"
+    f"--- want ---\n{want!r}\n--- got ---\n{got!r}"
+)
+PYEOF
+echo "R2 ok (rule text byte-identical, nested fence survived)"
+
+# === R3: evidence = finding's evidence + the assay anchor, deduplicated ======
+"$PY" - "$HDR" "$A1" <<'PYEOF'
+import sys
+text = open(sys.argv[1]).read()
+fm = text.split("---", 2)[1]
+ev, collecting = [], False
+for line in fm.splitlines():
+    if line.startswith("evidence:"):
+        collecting = True; continue
+    if collecting:
+        if line.startswith("  - "):
+            ev.append(line[4:].strip()); continue
+        break
+want = ["harness/build-log.md#2026-08-04T09-12Z", sys.argv[2] + "#finding-3"]
+assert ev == want, f"R3: evidence is {ev}, expected {want}"
+PYEOF
+echo "R3 ok (assay anchor appended)"
+
+# === R4: proposed_cost verbatim, cost empty ==================================
+grep -q 'One extra check per phase boundary; roughly two minutes.' "$HDR" \
+  || fail "R4: proposed_cost not copied verbatim"
+[ "$(field "$HDR" cost)" = '""' ] \
+  || fail "R4: cost must be empty at propose, got '$(field "$HDR" cost)'"
+
+# === R5: propose refuses bad input, writing nothing ==========================
+BEFORE="$(corpus_hash)"
+reg propose --assay harness/assay/nope.md --finding finding-3 --today 2026-08-21
+expect_fail "R5a (missing assay)" "not found"
+reg propose --assay "$A1" --finding finding-99 --today 2026-08-21
+expect_fail "R5b (unknown finding id)" "finding-99"
+reg propose --assay "$A1" --finding finding-11 --today 2026-08-21
+expect_fail "R5c (finding with no proposed rule)" "Proposed rule"
+# A finding with no observation is a rule with a citation attached. The HDR it
+# would produce has nothing to say about what actually went wrong, which is the
+# whole reason a governance change is supposed to cite evidence.
+#
+# The finding is titled so its derived SLUG cannot contain the asserted phrase.
+# The first version was called "No observation at all", and the assertion passed
+# against a validator that had been mutated to remove the check - because the
+# refused filename, HDR-...-no-observation-at-all.md, contained the word being
+# grepped for. An assertion that can be satisfied by the fixture's own name is
+# not an assertion.
+reg propose --assay "$A1" --finding finding-13 --today 2026-08-21
+expect_fail "R5d (finding with no observation prose)" "must say what was observed"
+[ "$(corpus_hash)" = "$BEFORE" ] || fail "R5: a refusal wrote to the corpus"
+
+# === R6: propose never overwrites ============================================
+reg propose --assay "$A1" --finding finding-3 --today 2026-08-21
+expect_fail "R6 (would overwrite)" "already exists"
+reg propose --assay "$A1" --finding finding-3 --today 2026-08-21 --slug second-take
+expect_ok "R6 (--slug resolves the collision)"
+rm -f "$DEC/HDR-2026-08-21-second-take.md"
+
+# === R8: a no-change finding ================================================
+reg propose --assay "$A1" --finding finding-5 --today 2026-08-21
+expect_ok "R8 (propose no-change)"
+NC="$DEC/HDR-2026-08-21-context-files-capture-narration.md"
+[ -f "$NC" ] || fail "R8: expected $NC"
+[ "$(field "$NC" provisional)" = "false" ] || fail "R8: no-change must be provisional: false"
+grep -q '^expires:' "$NC" && fail "R8: no-change must carry no expires"
+grep -q 'No change\.' "$NC" || fail "R8: no-change Rule section must say 'No change.'"
+
+# === R9/R10: accept ==========================================================
+printf 'Two minutes per boundary. Risk: reviewers paste output to satisfy it.\n' \
+  > "$TMP/cost.txt"
+printf '' > "$TMP/empty-cost.txt"
+printf 'One extra check per phase boundary; roughly two minutes.\n' \
+  > "$TMP/copied-cost.txt"
+
+BEFORE="$(corpus_hash)"
+reg accept --hdr "$HDR_REL" --cost-file empty-cost.txt --approver russ@russmiles.com --now 2026-08-21T16:41Z
+expect_fail "R10a (empty cost)" "whoever works here next"
+[ "$(corpus_hash)" = "$BEFORE" ] || fail "R10a: refusal wrote to the corpus"
+
+reg accept --hdr "$HDR_REL" --cost-file copied-cost.txt --approver russ@russmiles.com --now 2026-08-21T16:41Z
+expect_fail "R10b (cost copied from proposed_cost)" "own words"
+[ "$(corpus_hash)" = "$BEFORE" ] || fail "R10b: refusal wrote to the corpus"
+
+reg accept --hdr "$HDR_REL" --cost-file cost.txt --approver russ@russmiles.com --now 2026-08-21T16:41Z
+expect_ok "R9 (accept)"
+[ "$(field "$HDR" status)" = "accepted" ] || fail "R9: status must be accepted"
+[ "$(field "$HDR" approver)" = "russ@russmiles.com" ] || fail "R9: approver not recorded"
+[ "$(field "$HDR" approved_at)" = "2026-08-21T16:41Z" ] || fail "R9: approved_at not recorded"
+grep -q 'Risk: reviewers paste output' "$HDR" || fail "R9: cost not written"
+
+# The `## Cost` SECTION must be replaced wholesale, not merely have the
+# frontmatter updated around it. An accepted record has to read as the
+# approver's decision, not as the Assayer's proposal with an annotation.
+"$PY" - "$HDR" <<'PYEOF'
+import re, sys
+body = open(sys.argv[1]).read().split("---", 2)[2]
+m = re.search(r"(?ms)^## Cost\n(.*?)(?=^## |\Z)", body)
+assert m, "R9: no ## Cost section after acceptance"
+section = m.group(1)
+assert "Risk: reviewers paste output" in section, \
+    "R9: the ## Cost section does not carry the approver's words"
+assert "Proposed by the Assayer" not in section, \
+    "R9: the ## Cost section still carries the Assayer's proposal label"
+assert "One extra check per phase boundary" not in section, \
+    "R9: the ## Cost section still carries the Assayer's estimate"
+PYEOF
+echo "R9 ok (## Cost section replaced wholesale)"
+
+# The `## Finding` section must carry the finding's observation prose.
+grep -q 'The build log records the command being planned on both dates' "$HDR" \
+  || fail "R1/R9: the ## Finding section is missing the observation prose"
+
+# The Rule block must survive acceptance untouched - from here it is the
+# byte-for-byte source S2's compiler applies.
+"$PY" - "$HDR" "$TMP/expected-rule.txt" <<'PYEOF'
+import sys
+text = open(sys.argv[1]).read()
+want = open(sys.argv[2]).read().rstrip("\n")
+buf, blocks = None, []
+for line in text.splitlines():
+    if line.startswith("````") and (buf is None or line.strip() == "````"):
+        if buf is None: buf = []
+        else: blocks.append("\n".join(buf)); buf = None
+        continue
+    if buf is not None: buf.append(line)
+assert len(blocks) == 1 and blocks[0].rstrip("\n") == want, \
+    "R9: acceptance altered the Rule block"
+PYEOF
+echo "R9 ok (Rule block survived acceptance)"
+
+# === R14: accept refuses an HDR that is not proposed =========================
+BEFORE="$(corpus_hash)"
+reg accept --hdr "$HDR_REL" --cost-file cost.txt --approver russ@russmiles.com --now 2026-08-21T16:41Z
+expect_fail "R14 (already accepted)" "proposed"
+[ "$(corpus_hash)" = "$BEFORE" ] || fail "R14: refusal wrote to the corpus"
+
+# === R7/R11: the loop-layer promotion threshold ==============================
+reg propose --assay "$A1" --finding finding-7 --today 2026-08-21
+expect_ok "R7 (propose tier-2 finding)"
+L="$DEC/HDR-2026-08-21-completion-claims-across-every-surface.md"
+[ -f "$L" ] || fail "R7: expected $L"
+for section in "Why this layer" "Enforcement" "Validation" "Rejected alternatives"; do
+  grep -q "^## $section" "$L" || fail "R7: missing placeholder section '$section'"
+done
+
+BEFORE="$(corpus_hash)"
+reg accept --hdr "harness/decisions/$(basename "$L")" --cost-file cost.txt --approver russ@russmiles.com --now 2026-08-21T16:41Z
+expect_fail "R7/R11 (tier-2 placeholders unfilled, single assay)" "Why this layer"
+[ "$(corpus_hash)" = "$BEFORE" ] || fail "R11: refusal wrote to the corpus"
+
+# Fill the placeholders; the promotion threshold must still refuse, because one
+# assay is one incident and a single incident cannot reach the loop layer.
+"$PY" - "$L" <<'PYEOF'
+import re, sys
+p = sys.argv[1]
+t = open(p).read()
+for h in ("Why this layer", "Enforcement", "Validation", "Rejected alternatives"):
+    t = re.sub(r"(?m)^(## " + re.escape(h) + r")\n\n_[^\n]*_\n",
+               r"\1\n\nA real, human-written answer for this section.\n", t)
+open(p, "w").write(t)
+PYEOF
+BEFORE="$(corpus_hash)"
+reg accept --hdr "harness/decisions/$(basename "$L")" --cost-file cost.txt --approver russ@russmiles.com --now 2026-08-21T16:41Z
+expect_fail "R11 (harness-loop citing one assay)" "two distinct assays"
+[ "$(corpus_hash)" = "$BEFORE" ] || fail "R11: refusal wrote to the corpus"
+
+# A corroborated finding cites a prior assay in its own evidence, reaches two
+# with the appended anchor, and passes.
+reg propose --assay "$A1" --finding finding-9 --today 2026-08-21
+expect_ok "R11 (propose corroborated loop finding)"
+C="$DEC/HDR-2026-08-21-corroborated-across-two-assays.md"
+"$PY" - "$C" <<'PYEOF'
+import re, sys
+p = sys.argv[1]
+t = open(p).read()
+for h in ("Why this layer", "Enforcement", "Validation", "Rejected alternatives"):
+    t = re.sub(r"(?m)^(## " + re.escape(h) + r")\n\n_[^\n]*_\n",
+               r"\1\n\nA real, human-written answer for this section.\n", t)
+open(p, "w").write(t)
+PYEOF
+printf 'A different cost, in different words, for the corroborated rule.\n' > "$TMP/cost2.txt"
+reg accept --hdr "harness/decisions/$(basename "$C")" --cost-file cost2.txt --approver russ@russmiles.com --now 2026-08-21T17:00Z
+expect_ok "R11 (two distinct assays passes)"
+
+# === R16: precheck reports refusals without any cost being supplied ==========
+reg propose --assay "$A1" --finding finding-3 --today 2026-08-21 --slug third-take
+expect_ok "R16 (propose for precheck)"
+reg precheck --hdr harness/decisions/HDR-2026-08-21-third-take.md
+expect_ok "R16 (precheck on a clean HDR)"
+reg precheck --hdr "harness/decisions/$(basename "$L")"
+expect_fail "R16 (precheck surfaces the loop-layer refusal)" "two distinct assays"
+
+# === R12: the cycle cap ======================================================
+# Two accepted from this assay already. Take it to three, then four.
+printf 'Cost number three, written in its own words by a person.\n' > "$TMP/cost3.txt"
+printf 'Cost number four, written in its own words by a person.\n' > "$TMP/cost4.txt"
+reg accept --hdr harness/decisions/HDR-2026-08-21-third-take.md --cost-file cost3.txt --approver russ@russmiles.com --now 2026-08-21T17:10Z
+expect_ok "R12 (third accepted HDR from one assay)"
+
+reg propose --assay "$A1" --finding finding-3 --today 2026-08-21 --slug fourth-take
+expect_ok "R12 (propose a fourth)"
+BEFORE="$(corpus_hash)"
+reg accept --hdr harness/decisions/HDR-2026-08-21-fourth-take.md --cost-file cost4.txt --approver russ@russmiles.com --now 2026-08-21T17:20Z
+expect_fail "R12 (fourth accepted HDR from one assay)" "three"
+[ "$(corpus_hash)" = "$BEFORE" ] || fail "R12: refusal wrote to the corpus"
+
+# === R15: the index is a pure function of the corpus =========================
+reg index
+expect_ok "R15 (index)"
+IDX="$DEC/index.md"
+[ -f "$IDX" ] || fail "R15: expected $IDX"
+grep -q 'BEGIN GENERATED: harness-registrar' "$IDX" || fail "R15: missing generated marker"
+cp "$IDX" "$TMP/idx-1.md"
+reg index
+expect_ok "R15 (index re-run)"
+cmp -s "$TMP/idx-1.md" "$IDX" || fail "R15: index is not byte-identical on re-run"
+
+# Every HDR appears, and the rows are ordered by id.
+"$PY" - "$IDX" "$DEC" <<'PYEOF'
+import os, re, sys
+idx, dec = open(sys.argv[1]).read(), sys.argv[2]
+ids = sorted(n[:-3] for n in os.listdir(dec)
+             if n.startswith("HDR-") and n.endswith(".md"))
+for hid in ids:
+    assert hid in idx, f"R15: {hid} missing from the index"
+rows = [m.group(1) for m in re.finditer(r"^\| (HDR-[^ |]+)", idx, re.M)]
+assert rows == sorted(rows), f"R15: index rows are not sorted by id: {rows}"
+assert rows == ids, f"R15: index rows {rows} != corpus {ids}"
+PYEOF
+echo "R15 ok (index complete, sorted, idempotent)"
+
+# === R13: the corpus still validates after everything ========================
+set +e
+VOUT="$( cd "$TMP" && "$PY" "$ROOT/ai-literacy-superpowers/scripts/check-harness-decisions.py" 2>&1 )"
+VRC=$?
+set -e
+[ "$VRC" -eq 0 ] || fail "R13: corpus does not validate at the end. Out: $VOUT"
+
+echo "harness registrar: all checks passed (R1-R16)"

--- a/tdad_tests/scenarios/agents/harness-registrar/writes-but-never-authors.md
+++ b/tdad_tests/scenarios/agents/harness-registrar/writes-but-never-authors.md
@@ -1,0 +1,50 @@
+---
+component: harness-registrar
+component_type: agent
+tier: structural
+---
+
+# Scenario: the Registrar writes governance but never authors it
+
+## Given
+
+Every read-only advisory agent in this plugin carries `role: sentinel`, and
+`sentinel-integrity-check.sh` fails CI on a sentinel granted `Write` or `Edit`.
+
+The Registrar holds both. It is therefore not a sentinel, and the danger is not
+that someone tags it — CI would catch that — but that its instructions drift
+toward doing by hand what the mechanism does by construction. The rule text is
+copied verbatim by a script precisely because a model asked to copy usually
+copies and occasionally improves, and every improvement is a silent edit to a
+rule a human is about to approve as somebody else's words.
+
+An agent that both diagnoses failures and writes the rules can rationalise its
+own findings into rules that make its next diagnosis easier. The separation is
+the design.
+
+## When
+
+`ai-literacy-superpowers/agents/harness-registrar.agent.md` is read from the
+filesystem.
+
+## Then
+
+**Frontmatter:** `name: harness-registrar`, a non-empty description, `tools`
+including `Write` and `Edit`, and **no `role:` key at all**.
+
+**Body:**
+
+- States explicitly that it is not a sentinel and must never be tagged as one,
+  and gives the reason — it holds write authority and cannot claim a read-only
+  trust boundary.
+- Names the separation it exists to preserve: the Assayer diagnoses, the
+  Registrar legislates.
+- Carries the guarantee table: verbatim copy by script, refusals by validator,
+  all-or-nothing by staged transaction, cost authored by the approver.
+- Instructs the agent **not** to reimplement any of that in prose, and to stop
+  if it finds itself about to write rule text, evidence, or a cost by hand.
+- Forbids: authoring rule text, editing a `## Rule` block, writing the cost,
+  editing an accepted HDR, committing or pushing, and touching any control
+  surface.
+- States that a refusal is the mechanism working, not a task to be unblocked,
+  and that the failure mode to resist is helpfulness.

--- a/tdad_tests/scenarios/commands/harness-accept/refuses-before-it-asks.md
+++ b/tdad_tests/scenarios/commands/harness-accept/refuses-before-it-asks.md
@@ -1,0 +1,60 @@
+---
+component: harness-accept
+component_type: command
+tier: structural
+---
+
+# Scenario: /harness-accept refuses before it asks for a cost
+
+## Given
+
+The cost is the anti-theatre requirement of the whole design: the approver
+writes, in their own words, what the rule will demand of whoever works here next
+and how it might be gamed. A copy-pasted cost reads exactly like a considered
+one, so nothing downstream can tell them apart — which is why the validator
+refuses a cost identical to the Assayer's proposal.
+
+Asking someone to compose that for a rule which is about to be refused for
+citing a single assay spends precisely the human attention the mechanism exists
+to protect. The order is therefore load-bearing, not stylistic.
+
+Acceptance is also the only write transaction in the phase, and two of the
+refusals are corpus-level — the cycle cap and the promotion threshold compare
+HDRs against each other, so neither can be seen from the candidate alone.
+
+## When
+
+`ai-literacy-superpowers/commands/harness-accept.md` is read from the
+filesystem.
+
+## Then
+
+**Frontmatter:** `name: harness-accept`, a description stating that it is
+transactional and that a refusal leaves the record proposed.
+
+**Process, in this order:**
+
+1. Refuses an HDR whose status is not `proposed`, on the ground that an accepted
+   record is frozen and superseded rather than edited.
+2. Shows the human the **full** `## Rule` block, not a summary — that text is
+   what goes into force.
+3. Runs `harness-registrar.py precheck` and **stops without prompting** when it
+   exits non-zero, reporting each refusal with its real options in a table.
+4. Only then asks the cost question, verbatim.
+5. Passes the cost as `--cost-file`, never as an argument, and says why: shell
+   history, one copy-paste from the next HDR.
+6. Runs `accept`, then deletes the scratch cost file.
+
+**It must also:**
+
+- Instruct the agent to decline when asked to write the cost, explain that the
+  reason is not procedural, and offer discussion rather than words.
+- Forbid resolving a refusal by editing the HDR to satisfy it — reclassifying
+  after a threshold refusal is the human's decision, not the agent's repair.
+
+**Validation checkpoint:** checks A1–A6, including that the `## Rule` block is
+**unchanged** by acceptance (A4, escalated as a defect) and that the `## Cost`
+section no longer carries the Assayer's proposal label (A3).
+
+**Boundaries:** states that it writes to no control surface, and that it does
+not commit, push, or open a pull request — three gates, none implied by another.

--- a/tdad_tests/scenarios/commands/harness-propose/copies-verbatim-by-script.md
+++ b/tdad_tests/scenarios/commands/harness-propose/copies-verbatim-by-script.md
@@ -1,0 +1,52 @@
+---
+component: harness-propose
+component_type: command
+tier: structural
+---
+
+# Scenario: /harness-propose copies by script, never by hand
+
+## Given
+
+The build spec says `/harness-propose` copies the proposed rule text and
+evidence references verbatim. That sentence cannot be delivered by an agent
+writing the HDR itself: a model asked to copy text usually copies it and
+occasionally tidies it, and a tidied rule is a rule the approver did not
+actually read.
+
+The validation checkpoint is required by CLAUDE.md for every command writing
+structured markdown a downstream consumer parses. Here the downstream consumers
+are a deterministic validator and, later, a compiler that applies the rule block
+byte for byte — so a paraphrase is not a cosmetic problem.
+
+## When
+
+`ai-literacy-superpowers/commands/harness-propose.md` is read from the
+filesystem.
+
+## Then
+
+**Frontmatter:** `name: harness-propose`, a description stating that the copy is
+verbatim and the cost is left for the approver.
+
+**Process:**
+
+- Aborts with a specific message when the assay path does not exist.
+- Lists the assay's findings with id, priority, classification and enforcement
+  so the human confirms the choice.
+- Invokes `harness-registrar.py propose` rather than writing the HDR itself, and
+  states in the body that rule text and evidence must **never** be written by
+  hand.
+- Explains `--slug` as the collision remedy, and that the script never
+  overwrites.
+- Announces tier-2 placeholders explicitly when the classification is
+  `harness-loop`, `script-validator` or `new-agent`, and says that neither the
+  Assayer nor the Registrar may write that argument.
+
+**Validation checkpoint:** checks P1–P5, including that `cost` is empty (P2) and
+that the `## Rule` block matches the assay's proposed-rule block character for
+character (P3), with an instruction to **diff rather than eyeball**.
+
+Crucially, P3 and P4 deviations must be reported as defects and **not fixed in
+place** — fixing them in place would be the agent performing exactly the copy
+the script exists to prevent.

--- a/tdad_tests/tests/test_layer0_deterministic.py
+++ b/tdad_tests/tests/test_layer0_deterministic.py
@@ -108,6 +108,12 @@ BASH_TEST_SCRIPTS = [
     # a rule that existed only in its prompt would be a rule it could talk
     # itself past. Here it turns the build red instead.
     "test-harness-decisions",
+    # Harness Evolution S1 — the Registrar's write path. R2 asserts the copied
+    # rule text is byte-identical (the fixture's first line ends in two spaces:
+    # a markdown hard break that a well-meaning .rstrip() destroys). R13 hashes
+    # every file under harness/ before and after each refusal, because "nothing
+    # was written" deserves a measurement rather than a reading of the code.
+    "test-harness-registrar",
 ]
 
 


### PR DESCRIPTION
Part of the harness evolution epic #533. Second of six phases.

Closes #535. Depends on S0 (#540, v0.74.0).

## What this adds

S0 built the thing that says *no*. Nothing said *yes* — an HDR had no way to come
into existence, no way to travel `proposed → accepted`, and no index anyone could
read.

- `harness-registrar.agent.md` — the agent that applies decisions and never authors them
- `/harness-propose <assay> <finding>` — drafts an HDR at `status: proposed`
- `/harness-accept <hdr>` — the single write transaction
- `scripts/harness-registrar.py` — `propose`, `precheck`, `accept`, `index`
- The **assay-finding contract** (reference page), owned here and consumed by S3
- `harness/decisions/index.md` — generated, sorted, byte-identical on re-run
- How-to guide, reference entries, TDAD scenarios, Layer-0 suite R1–R16

It writes to **no control surface**. `HARNESS.md` is untouched — that is S2.

## The decision that shapes the phase: the copy is deterministic

The build spec says `/harness-propose` "copies evidence references and proposed
rule text verbatim". The epic made the Registrar a plugin agent, so the obvious
implementation is to let the agent read the assay and write the HDR.

That implementation cannot deliver what the sentence promises. A model asked to
copy text usually copies it, and occasionally *improves* it — fixes a typo,
tidies an inconsistent bullet, rewraps a line. Every one of those is a silent
edit to a rule a human is about to approve **on the understanding that it is the
Assayer's words**.

So the rule block and evidence list are extracted by a script, byte for byte, and
the agent never holds them in its output at all.

> Verbatim by construction, not verbatim by instruction.

The agent's job is to locate the assay, present the findings, run the script, and
read refusals back in plain language. It is the interface, not the mechanism —
and the boundary needs to exist *before* S2 gives it real judgement about where
in `HARNESS.md` a rule belongs.

## Acceptance stages the whole corpus

Two S0 refusals are **corpus-level**: the three-per-cycle cap and the two-assay
promotion threshold compare HDRs against each other, so neither can be evaluated
from the candidate alone.

`accept` therefore copies the entire `harness/` tree to a temporary root with the
candidate substituted, runs the S0 validator there, and writes the real file only
on exit 0. "Nothing is written and the HDR stays `proposed`" is now a property of
the mechanism rather than a promise in a document — and R13 hashes every file
under `harness/` before and after each refusal to prove it.

## Refusals run before the cost prompt

Making someone compose a considered cost for a rule that is about to be refused
for citing a single assay spends exactly the human attention this mechanism
exists to protect. `precheck` exists so that order is enforceable, not merely
documented.

## The agent is deliberately not a sentinel

Every read-only advisory agent here carries `role: sentinel`, and
`sentinel-integrity-check.sh` fails CI on a sentinel granted `Write`.

The Registrar holds `Write` and `Edit`, so it carries **no `role:` tag at all**.
Tagging it would be a lie CI would catch — and, worse, the exact category error
the two-role separation exists to prevent. The Assayer diagnoses; the Registrar
legislates. An agent doing both could rationalise its own findings into rules
that make its next diagnosis easier.

## S1 owns the assay contract

`/harness-propose` consumes an assay, but assays are S3. The precedent is the
Cadence Sentinels S1 slice, which owned the record contracts S2–S5 consumed.

The contract is narrow by design — only what `propose` must read. Everything else
in an assay report is prose for a human that the Registrar never parses.

One addition the build spec did not have: a finding must carry **observation
prose**. Without it the HDR's `## Finding` section has nothing to say, and a
finding with no observation is not a finding but a rule with a citation attached.

## The evidence rule

The HDR's evidence is the finding's evidence **plus the source assay anchor**.
This is what makes the two-assay threshold behave as the worked cycle describes:
a first-time `harness-loop` finding cites one assay and is refused; a corroborated
one names the prior assay in its own evidence, reaches two, and passes.

Without the appended anchor, a finding citing only build-log entries would produce
an HDR with zero assays — refused for a reason that reads like a bug rather than
like the threshold working.

## Testing

R1–R16 in `test-harness-registrar.sh`, then **mutation-tested against 22
deliberately broken implementations**. All 22 killed.

Three of them found bugs in the *tests*, not the code:

- The rule-text fixture was too clean to catch a copier that strips trailing
  whitespace. Its first line now ends in **two spaces** — a markdown hard line
  break, meaningful syntax that a well-meaning `rstrip()` destroys silently.
- The `## Cost` section replacement was untested: R9 grepped the whole file, and
  the frontmatter `cost` satisfied that grep on its own.
- An assertion that "a finding with no observation is refused" **passed against a
  validator with that check removed**, because the refused filename —
  `HDR-…-no-observation-at-all.md` — contained the word being grepped for. An
  assertion that can be satisfied by the fixture's own name is not an assertion.

Implementation also surfaced one design fix: findings are now parsed **lazily**,
so one malformed finding costs one finding rather than the whole report. An assay
is written by an agent under a materiality test, not by a compiler.

## Version

`0.74.0` → `0.75.0` (new agent, two new commands). All five CI-checked locations
plus the README table row and component counts updated.