### PR TITLE
Harness evolution S5 — Observatory export

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.78.0",
+  "plugin_version": "0.79.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.78.0"
+      "version": "0.79.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## 0.79.0 — 2026-08-23
+
+### Added
+
+- **`/harness-timeline`** — emits the Observatory intervention feed to stdout,
+  one JSON line per accepted decision record: when a rule entered, in which
+  direction, at what enforcement level, on which cohort, and when it stopped.
+  This is the timeline the difference-in-differences design otherwise has to
+  infer. Completes the harness evolution epic (#533, #539).
+- **Reference page** `intervention-feed-format.md`.
+- **Layer-0 suite** `test-harness-timeline.sh` (T1–T13), mutation-tested against
+  12 deliberately broken implementations.
+
+### Changed from the source spec
+
+Two additions to the example line, each because the example as given cannot
+support the analysis the feed exists for.
+
+- **No field depends on the current date.** Whether a rule is expired *right now*
+  is a fact about the clock, not the corpus. A feed carrying it produces
+  different output on different days from a repository nobody touched — a run in
+  November would disagree with the same run in September about the same data. So
+  `expires` is emitted as data for the consumer to interpret, `state` is limited
+  to `in force` and `superseded`, and the command reads no clock at all.
+- **Every intervention carries an end** — `superseded_by` and `ends`, giving the
+  interval `[date, ends)`. The example records only when a rule started; without
+  an end, every rule ever retired is still counted as in force, and the step
+  function never steps back.
+
+Also: `direction` is **derived** from the enforcement ladder and the surface
+sets, never declared. A self-reported direction is a self-report, and this is the
+one field the analysis turns on. And `no-change` records stay in the feed as
+`direction: none` — an intervention of size zero. They record that governance was
+examined at a known moment and deliberately not changed, which is a control
+observation rather than an absence; dropping them would convert "we looked and
+decided no" into "nobody looked".
+
+### Note on the cohort tag
+
+`cohort` remains on the decision record, per the epic's resolution of the source
+spec's §14 Q4. Worth naming: a cohort tag on a governance artifact is visible to
+whoever writes the next rule, which is a route by which a study can influence the
+thing it studies. If that matters, the field can be dropped from the record and
+joined externally at analysis time with no change to this command — it emits
+`null` and the join happens downstream.
+
 ## 0.78.0 — 2026-08-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.78.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.79.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-42-2E8B57?style=flat-square)](#skills-42)
 [![Agents](https://img.shields.io/badge/Agents-22-2E8B57?style=flat-square)](#agents-22)
-[![Commands](https://img.shields.io/badge/Commands-38-2E8B57?style=flat-square)](#commands-38)
+[![Commands](https://img.shields.io/badge/Commands-39-2E8B57?style=flat-square)](#commands-39)
 [![Harness](https://img.shields.io/badge/Harness-31%2F32_enforced-4682B4?style=flat-square)](HARNESS.md)
 [![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/2026-07-21-snapshot.md)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.78.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 38 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.79.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 
@@ -268,7 +268,7 @@ sentinels** guard the shape of the work around those decisions: the
 | assessor | AI literacy assessment — scans repo, asks questions, applies fixes, recommends workflow changes | Read + Write |
 | governance-auditor | Governance specialist — semantic drift analysis, debt inventory, three-frame alignment | Read + limited Write |
 
-### Commands (38)
+### Commands (39)
 
 | Command | What it does |
 | ------- | ------------ |
@@ -284,6 +284,7 @@ sentinels** guard the shape of the work around those decisions: the
 | `/harness-review` | List every lapsed rule and its three outcomes — re-evidence, weaken, demote |
 | `/harness-compile` | Idempotent repair of every generated region |
 | `/harness-check` | Read-only drift detection; the CI entry point |
+| `/harness-timeline` | Emit the Observatory intervention feed to stdout |
 | `/harness-audit` | Read-only diagnostic. Same engine as `/harness-sync` but prints findings without prompting to fix. Use for inspection-without-commitment, CI scripts, or the quarterly cadence anchor. |
 | `/reflect` | Capture a post-task reflection |
 | `/worktree` | Git worktree lifecycle — spin, merge, clean |

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.78.0",
+  "version": "0.79.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/commands/harness-timeline.md
+++ b/ai-literacy-superpowers/commands/harness-timeline.md
@@ -1,0 +1,98 @@
+---
+name: harness-timeline
+description: Emit the Observatory intervention feed to stdout — one JSON line per accepted decision record, with the direction derived rather than declared, and no field that depends on the current date; deliberately not a stored artifact, and it writes nothing
+---
+
+# /harness-timeline
+
+Emit the governance intervention feed: when a rule entered, in which direction,
+at what enforcement level, on which cohort, and when it stopped.
+
+The Observatory's difference-in-differences design currently has to **infer**
+all of that. The decision corpus knows it exactly.
+
+## When to use
+
+- When an analysis needs the intervention timeline
+- Redirect it yourself if you want a file: `... timeline > interventions.jsonl`
+
+## Why it is not a stored artifact
+
+A committed derivative is one more thing that can drift from its source, and
+`/harness-check` would then have to police it — a third generated artifact whose
+only job is to be regenerated.
+
+Deriving it on demand means the feed cannot disagree with the corpus. Anyone who
+wants it on disk can redirect it, and the fact that they chose to is then their
+problem rather than the corpus's.
+
+## Process
+
+```bash
+python3 ai-literacy-superpowers/scripts/harness-registrar.py timeline
+```
+
+One JSON object per line, ordered by date then id.
+
+## Two properties worth understanding before you use it
+
+### It carries no field that depends on today
+
+Whether a rule is expired *right now* depends on the clock. A feed carrying that
+would produce different output on different days from a corpus nobody touched —
+so a difference-in-differences run in November would disagree with the same run
+in September.
+
+`expires` is emitted **as data**. The consumer decides what it means at their
+analysis date. `state` is `in force` or `superseded`, both of which are facts
+about the corpus rather than about the moment.
+
+The command takes no clock at all.
+
+### Every intervention has an end
+
+`superseded_by` and `ends` carry when a rule stopped. Without them, every rule
+ever retired would still be counted as in force — a step function that never
+steps back.
+
+The interval is `[date, ends)`. A live rule has `ends: null`.
+
+## Fields
+
+| Field | Meaning |
+| --- | --- |
+| `id`, `date` | The record, and the date it was accepted |
+| `classification`, `enforcement`, `surfaces` | What kind of rule, how strongly, reaching where |
+| `direction` | `tighten` · `loosen` · `same` · `none` — **derived**, never declared |
+| `cohort` | From the record, or `null` |
+| `provisional`, `expires` | As data; the consumer decides what expiry means |
+| `state` | `in force` or `superseded` |
+| `supersedes`, `superseded_by`, `ends` | The chain, and when this intervention stopped |
+
+### `direction` is derived
+
+A self-reported direction is a self-report, and it is the one field the analysis
+turns on.
+
+A rule with no predecessor is a `tighten` — it was not there before. A retirement
+is a `loosen`. A supersession compares enforcement on the ladder
+`advisory < validated < blocked`; when those are equal, a surface set that
+contains the old one is a `tighten` and one contained by it is a `loosen`. Two
+overlapping-but-different sets are `same`, because nothing honest can be said
+about which is stronger.
+
+A `no-change` record is `none` — an intervention of size zero. It is in the feed
+deliberately: it records that governance was examined at a known moment and
+deliberately not changed, which is a control observation rather than an absence.
+Dropping it would convert "we looked and decided no" into "nobody looked".
+
+## What is not in the feed
+
+`proposed` and `rejected` records. Nothing was ever in force, so neither is an
+intervention. Both are visible in `harness/decisions/index.md`.
+
+## What this command never does
+
+- Write a file
+- Read the clock
+- Accept a declared direction

--- a/ai-literacy-superpowers/scripts/harness-registrar.py
+++ b/ai-literacy-superpowers/scripts/harness-registrar.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 
 import argparse
 import datetime
+import json
 import importlib.util
 import os
 import re
@@ -1322,6 +1323,84 @@ def cmd_review(args) -> int:
     return 0
 
 
+# --------------------------------------------------------------------------- #
+# The Observatory intervention feed                                            #
+# --------------------------------------------------------------------------- #
+#
+# The difference-in-differences design currently has to INFER when governance
+# changed. The corpus knows exactly, and this says so.
+#
+# Two properties are load-bearing.
+#
+# NO TIME-VARYING FIELD. Whether a rule is expired *right now* depends on the
+# clock, so a feed carrying it produces different output on different days from a
+# corpus nobody touched — a run in November would disagree with the same run in
+# September. `expires` is emitted as data and the consumer decides what it means
+# at their analysis date. This command takes no clock at all.
+#
+# EVERY INTERVENTION HAS AN END. Without `superseded_by` and `ends`, every rule
+# ever retired is still counted as in force: a step function that never steps
+# back.
+
+
+def _direction(record: Record, predecessor: Record | None) -> str:
+    """Derived, never declared. A self-reported direction is a self-report."""
+    if record.is_retirement:
+        return "loosen"
+    if predecessor is None:
+        return "none" if record.classification == "no-change" else "tighten"
+
+    now = LADDER.get(str(record.fm.get("enforcement")), 0)
+    before = LADDER.get(str(predecessor.fm.get("enforcement")), 0)
+    if now != before:
+        return "tighten" if now > before else "loosen"
+
+    # Surfaces break the tie only at equal enforcement, and only when one set
+    # contains the other. Two overlapping-but-different sets are `same`, because
+    # nothing honest can be said about which is stronger.
+    new, old = set(record.surfaces), set(predecessor.surfaces)
+    if new > old:
+        return "tighten"
+    if new < old:
+        return "loosen"
+    return "same"
+
+
+def cmd_timeline(args) -> int:
+    records = load_records(args.root)
+    by_id = {r.id: r for r in records}
+    successor = {r.supersedes: r for r in records if r.supersedes}
+
+    rows = []
+    for record in records:
+        if record.status != "accepted":
+            # Not an intervention: nothing was ever in force.
+            continue
+        predecessor = by_id.get(record.supersedes) if record.supersedes else None
+        nxt = successor.get(record.id)
+        approved = str(record.fm.get("approved_at") or "")[:10]
+        rows.append({
+            "id": record.id,
+            "date": approved,
+            "classification": str(record.classification),
+            "enforcement": str(record.fm.get("enforcement")),
+            "direction": _direction(record, predecessor),
+            "surfaces": record.surfaces,
+            "cohort": (str(record.fm["cohort"]) if record.fm.get("cohort") else None),
+            "provisional": record.fm.get("provisional") is True,
+            "expires": (str(record.fm["expires"]) if record.fm.get("expires") else None),
+            "state": "superseded" if nxt else "in force",
+            "supersedes": record.supersedes,
+            "superseded_by": nxt.id if nxt else None,
+            "ends": str(nxt.fm.get("approved_at") or "")[:10] if nxt else None,
+        })
+
+    rows.sort(key=lambda r: (r["date"], r["id"]))
+    for row in rows:
+        print(json.dumps(row, sort_keys=False, separators=(",", ":")))
+    return 0
+
+
 def cmd_check(args) -> int:
     root = args.root
     problems: list[str] = []
@@ -1429,6 +1508,11 @@ def main(argv: list[str]) -> int:
     p = sub.add_parser("check", help="read-only drift detection; the CI entry point")
     p.add_argument("--today", help="YYYY-MM-DD; injected so nothing races the clock")
     p.set_defaults(func=cmd_check)
+
+    p = sub.add_parser(
+        "timeline",
+        help="emit the Observatory intervention feed to stdout (no clock, no file)")
+    p.set_defaults(func=cmd_timeline)
 
     p = sub.add_parser("review", help="list every lapsed rule and its three options")
     p.add_argument("--today", help="YYYY-MM-DD; injected so nothing races the clock")

--- a/docs/plugins/ai-literacy-superpowers/reference/commands.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/commands.md
@@ -297,6 +297,35 @@ step, and a gate with no decision behind it is the shape of approval theatre.
 It does not commit, push, or open a pull request. Three gates exist — drafting,
 accepting, committing — and none is implied by another.
 
+### /harness-timeline
+
+Usage: `/harness-timeline`
+
+- **Skills read**: none
+- **Agents dispatched**: `harness-registrar`
+
+Emits the Observatory intervention feed to **stdout** — one JSON line per
+accepted decision record. See
+[intervention feed format](intervention-feed-format.md).
+
+Deliberately not a stored artifact: a committed derivative drifts from its
+source, and `/harness-check` would then have to police it. Redirect it if you
+want a file.
+
+**It reads no clock.** Whether a rule is expired right now depends on the date,
+so a feed carrying it would produce different output on different days from a
+corpus nobody touched — a difference-in-differences run in November would
+disagree with the same run in September. `expires` is emitted as data; `state` is
+`in force` or `superseded`, both corpus facts.
+
+**Every intervention carries an end** — `superseded_by` and `ends` — because
+without them every rule ever retired is still counted as in force.
+
+`direction` is derived from the enforcement ladder and the surface sets, never
+declared: the one field the analysis turns on is the last place to accept a
+self-report. A `no-change` record is `none` and is included deliberately, as a
+control observation rather than an absence.
+
 ### /harness-review
 
 Usage: `/harness-review`

--- a/docs/plugins/ai-literacy-superpowers/reference/intervention-feed-format.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/intervention-feed-format.md
@@ -1,0 +1,113 @@
+# Intervention feed format
+
+`/harness-timeline` emits one JSON object per line to **stdout**: when a
+governance rule entered, in which direction, at what enforcement level, on which
+cohort, and when it stopped.
+
+This is the timeline the Observatory's difference-in-differences design otherwise
+has to infer.
+
+## Not a stored artifact
+
+A committed derivative is one more thing that can drift from its source, and
+`/harness-check` would then have to police it — a third generated artifact whose
+only job is to be regenerated.
+
+Redirect it if you want a file. The fact that you chose to is then your problem
+rather than the corpus's.
+
+## A line
+
+```json
+{"id":"HDR-2026-01-01-observed-evidence","date":"2026-01-01","classification":"harness-loop","enforcement":"validated","direction":"tighten","surfaces":["claude-code","codex"],"cohort":"b","provisional":true,"expires":"2026-04-01","state":"superseded","supersedes":null,"superseded_by":"HDR-2026-02-01-weakened","ends":"2026-02-01"}
+```
+
+| Field | Meaning |
+| --- | --- |
+| `id` | The decision record |
+| `date` | The date it was accepted — the start of the interval |
+| `classification` | The layer that owns the rule |
+| `enforcement` | The level it intends |
+| `direction` | `tighten` · `loosen` · `same` · `none` — derived |
+| `surfaces` | The surfaces it names |
+| `cohort` | From the record, or `null` |
+| `provisional` | Whether permanence is still unearned |
+| `expires` | As data, or `null`. **Not** interpreted here |
+| `state` | `in force` or `superseded` |
+| `supersedes` | The record this replaced, or `null` |
+| `superseded_by` | Derived from the corpus, or `null` |
+| `ends` | The successor's date, or `null`. The interval is `[date, ends)` |
+
+Ordered by `date`, then `id`. Re-running on an unchanged corpus is byte-identical.
+
+## No field depends on today
+
+Whether a rule is expired *right now* is a fact about the clock, not about the
+corpus. A feed carrying it would produce different output on different days from
+a repository nobody touched — so a difference-in-differences run in November
+would disagree with the same run in September about the same data.
+
+So `expires` is emitted **as data** and the consumer decides what it means at
+their analysis date, and `state` is limited to `in force` and `superseded`, both
+of which are corpus facts.
+
+The command reads no clock at all.
+
+## Every intervention has an end
+
+`superseded_by` and `ends` are what make the feed usable. Without them, every
+rule ever retired is still counted as in force: a step function that never steps
+back.
+
+A live rule has `superseded_by: null` and `ends: null`.
+
+## `direction` is derived, never declared
+
+A self-reported direction is a self-report, and this is the one field the
+analysis turns on.
+
+| Case | Direction |
+| --- | --- |
+| No predecessor, `classification: no-change` | `none` |
+| No predecessor, otherwise | `tighten` — the rule was not there before |
+| A retirement (`Withdrawn.`) | `loosen` |
+| Supersedes, higher enforcement | `tighten` |
+| Supersedes, lower enforcement | `loosen` |
+| Supersedes, equal enforcement, surfaces widened | `tighten` |
+| Supersedes, equal enforcement, surfaces narrowed | `loosen` |
+| Supersedes, otherwise | `same` |
+
+The ladder is `advisory < validated < blocked`. Surfaces break the tie only when
+enforcement is equal **and** one set contains the other; two
+overlapping-but-different sets are `same`, because nothing honest can be said
+about which is stronger.
+
+### `no-change` is in the feed on purpose
+
+An intervention of size zero. It records that governance was examined at a known
+moment and deliberately not changed — a **control observation**, not an absence.
+
+Dropping it would silently convert "we looked and decided no" into "nobody
+looked", and the difference between those two is exactly what a governance study
+is trying to measure.
+
+## What is excluded
+
+`proposed` and `rejected` records. Nothing was ever in force, so neither is an
+intervention. Both appear in `harness/decisions/index.md`.
+
+## On the cohort tag
+
+`cohort` lives on the decision record and is emitted from it.
+
+Worth naming: a cohort tag on a governance artifact is visible to whoever writes
+the next rule, which is a route by which a study can influence the thing it is
+studying. If that matters for a given study, drop the field from the record and
+join it externally at analysis time — this command emits `null` and the join
+happens downstream, with no change here.
+
+## See also
+
+- [Harness Decision Record format](harness-decision-records.md)
+- [Enforcement report format](enforcement-report-format.md)
+- Spec: `docs/superpowers/specs/2026-08-23-harness-evolution-s5-observatory-design.md`

--- a/docs/superpowers/specs/2026-08-23-harness-evolution-s5-observatory-design.md
+++ b/docs/superpowers/specs/2026-08-23-harness-evolution-s5-observatory-design.md
@@ -1,0 +1,154 @@
+# Spec: Harness Evolution S5 — Observatory export
+
+**Status:** Approved
+**Date:** 2026-08-23
+**Issue:** #539
+**Epic:** Harness Evolution — the Harness Assayer and the Harness Registrar (#533)
+**Depends on:** S0–S4.
+**Scope:** `ai-literacy-superpowers` plugin — one command, one script subcommand,
+one reference page.
+**Explicitly out of scope:** `leap-companion` consumption of the feed; that lives
+in the downstream repository.
+
+---
+
+## 1. Problem Statement
+
+The Observatory's difference-in-differences design currently has to **infer**
+when governance changed. The corpus knows exactly: when a rule entered, in which
+direction, at what enforcement level, on which cohort, and when it stopped.
+
+`/harness-timeline` emits that as a machine-readable intervention feed.
+
+## 2. Why stdout, and not a file
+
+A committed derivative is one more thing that can drift from its source, and
+`/harness-check` would then have to police it — a third generated artifact whose
+only job is to be regenerated.
+
+The feed is derived on demand and written to stdout. Anyone who wants it in a
+file can redirect it, and the fact that they chose to is then their problem
+rather than the corpus's.
+
+## 3. The feed carries no time-varying field
+
+The build spec's example line does not say whether "expired" appears in the
+feed. It must not.
+
+Whether a rule is expired *right now* depends on the clock, so a feed carrying it
+produces different output on different days from an unchanged corpus. That
+defeats reproducibility for exactly the analysis the feed exists to serve: a
+difference-in-differences run in November would disagree with the same run in
+September about a corpus nobody touched.
+
+So the feed emits **facts about the corpus**, never facts about the moment:
+
+- `expires` is emitted **as data**. The consumer decides what it means at their
+  analysis date.
+- `state` is `in force` or `superseded`. Supersession is a corpus fact; expiry is
+  a clock fact.
+
+The command therefore takes no clock at all, and re-running it on an unchanged
+corpus is byte-identical regardless of when.
+
+## 4. An intervention needs an end, not only a start
+
+The build spec's example line records when a rule started. A
+difference-in-differences design needs to know when it **stopped** — an
+intervention with no end is a step function that never steps back, and every rule
+ever retired would still be counted as in force.
+
+So each line also carries:
+
+| Field | Why |
+| --- | --- |
+| `supersedes` | The record this one replaced, or `null` |
+| `superseded_by` | Derived from the corpus — the successor, or `null` |
+| `ends` | The successor's `approved_at` date, or `null`. The interval is `[date, ends)` |
+| `state` | `in force` or `superseded` |
+
+`superseded_by` is derived here exactly as it is everywhere else. The record on
+disk stores `null`, per S4.
+
+## 5. Direction
+
+`direction` is the field the analysis actually turns on, and it is derived rather
+than declared — a self-reported direction is a self-report.
+
+| Case | Direction |
+| --- | --- |
+| No `supersedes`, `classification: no-change` | `none` |
+| No `supersedes`, otherwise | `tighten` — a rule that was not there before |
+| Retirement (`Withdrawn.`) | `loosen` |
+| Supersedes, higher enforcement | `tighten` |
+| Supersedes, lower enforcement | `loosen` |
+| Supersedes, equal enforcement, more surfaces | `tighten` |
+| Supersedes, equal enforcement, fewer surfaces | `loosen` |
+| Supersedes, otherwise | `same` |
+
+Surfaces break the tie only when enforcement is equal, and only when one set
+contains the other. Two overlapping-but-different sets are `same`, because
+nothing honest can be said about which is stronger.
+
+**A `no-change` record is an intervention of size zero, and it belongs in the
+feed.** It records that governance was examined at a known moment and
+deliberately not changed — which for a difference-in-differences design is a
+control observation, not an absence. Dropping it would silently convert "we
+looked and decided no" into "nobody looked".
+
+## 6. Which records appear
+
+Every record with stored `status: accepted`, exactly once.
+
+`proposed` records are not interventions — nothing was in force. `rejected`
+records are not either. Both are visible in `index.md` where they belong.
+
+## 7. Cohort
+
+`cohort` is emitted from the record when present and `null` when absent, per the
+build spec.
+
+The epic considered joining it externally at analysis time to keep governance
+artifacts cohort-blind (§14 Q4) and kept it on the record. Noting the tension
+here rather than in a commit message: a cohort tag on a governance artifact is
+visible to whoever writes the next rule, which is a route by which a study can
+influence the thing it is studying. If that matters, the field can be dropped
+from the record and joined externally without changing this command — it emits
+`null` and the join happens downstream.
+
+## 8. Acceptance criteria
+
+| ID | Criterion |
+| --- | --- |
+| T1 | One line per accepted record; `proposed` and `rejected` emit nothing |
+| T2 | Re-running on an unchanged corpus is byte-identical |
+| T3 | No field derives from the current date: a record past its `expires` still reports `state: in force`, with `expires` emitted as data |
+| T4 | Every line is valid JSON with a stable key order |
+| T5 | A record with no predecessor is `tighten`; a `no-change` record is `none` |
+| T6 | A retirement is `loosen` |
+| T7 | Supersession with lower enforcement is `loosen`; higher is `tighten`; equal is `same` |
+| T8 | At equal enforcement, a widened surface set is `tighten` and a narrowed one is `loosen`; overlapping-but-different is `same` |
+| T9 | A superseded record carries `state: superseded`, its `superseded_by`, and `ends` |
+| T10 | `cohort` is emitted when present and `null` when absent |
+| T11 | Ordering is deterministic: by `date`, then by `id` |
+| T12 | Round-trip: the line count equals the number of accepted records, with no duplicates and none missing |
+| T13 | The command writes nothing to disk |
+
+Tests: `tdad_tests/layer0_deterministic/test-harness-timeline.sh`.
+
+## 9. Rejected alternatives
+
+**Storing the feed as a file.** Rejected per §2 — a committed derivative drifts,
+and then needs policing.
+
+**Emitting `expired` as a state.** Rejected per §3. A feed that changes because
+the clock moved cannot support a reproducible analysis, and the consumer can
+derive it from `expires` at whatever date their analysis uses.
+
+**Taking `direction` from a declared field.** Rejected. A self-reported direction
+is a self-report, and the one field the analysis turns on is the last place to
+accept one.
+
+**Omitting `no-change` records.** Rejected per §5 — it would convert a control
+observation into an absence, and the difference between "we looked and decided
+no" and "nobody looked" is exactly what a governance study is trying to measure.

--- a/tdad_tests/layer0_deterministic/test-harness-timeline.sh
+++ b/tdad_tests/layer0_deterministic/test-harness-timeline.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for the Observatory intervention feed
+# (spec 2026-08-23-harness-evolution-s5-observatory-design.md, §8; T1-T13).
+#
+# T3 IS THE ONE THAT DECIDES WHETHER THE FEED IS USABLE. Whether a rule is
+# expired RIGHT NOW depends on the clock, so a feed carrying that produces
+# different output on different days from a corpus nobody touched - and a
+# difference-in-differences run in November would disagree with the same run in
+# September. `expires` is emitted as data and the consumer decides what it means
+# at their analysis date.
+#
+# T9 IS THE OTHER HALF. An intervention with no end is a step function that never
+# steps back: without `superseded_by` and `ends`, every rule ever retired is
+# still counted as in force.
+#
+# T5's `none` case matters more than it looks. A no-change record says governance
+# was examined at a known moment and deliberately not changed - a control
+# observation, not an absence. Dropping it would convert "we looked and decided
+# no" into "nobody looked", which is the difference a governance study is trying
+# to measure.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$SCRIPT_DIR/../.."
+REG="$ROOT/ai-literacy-superpowers/scripts/harness-registrar.py"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+[ -f "$REG" ] || fail "harness registrar not found at $REG"
+
+PY=/usr/bin/python3
+command -v "$PY" >/dev/null 2>&1 || PY=python3
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+HARNESS="$TMP/harness"
+DEC="$HARNESS/decisions"
+mkdir -p "$DEC" "$HARNESS/assay"
+
+reg() { set +e; OUT="$( cd "$TMP" && "$PY" "$REG" "$@" 2>&1 )"; RC=$?; set -e; }
+
+tree_hash() {
+  ( cd "$TMP" && "$PY" -c "
+import hashlib, os
+h = hashlib.sha256()
+for dirpath, dirs, files in os.walk('.'):
+    dirs[:] = sorted(dirs)
+    for name in sorted(files):
+        p = os.path.join(dirpath, name)
+        h.update(p.encode()); h.update(open(p, 'rb').read())
+print(h.hexdigest())
+" )
+}
+
+cat > "$HARNESS/surfaces.yaml" <<'EOF'
+routes:
+  harness-loop: HARNESS.md
+  turn-instructions: AGENTS.md
+
+surfaces:
+  claude-code:
+    targets: [CLAUDE.md]
+    supports: [advisory, validated, blocked]
+  codex:
+    targets: [AGENTS.md]
+    supports: [advisory]
+  ci:
+    targets: [.github/workflows/]
+    supports: [validated, blocked]
+EOF
+
+cat > "$TMP/mkhdr.py" <<'PYEOF'
+import json, os, sys
+
+d = json.load(sys.stdin)
+root = os.environ["FIXTURE_ROOT"]
+hid = d["id"]
+cls = d.get("classification", "turn-instructions")
+status = d.get("status", "accepted")
+
+L = ["---", f"id: {hid}", "title: " + d.get("title", "A rule"),
+     f"status: {status}", f"classification: {cls}",
+     "enforcement: " + d.get("enforcement", "advisory"),
+     "surfaces: [" + ", ".join(d.get("surfaces", ["claude-code"])) + "]"]
+if d.get("provisional", True):
+    L += ["provisional: true", "expires: " + d.get("expires", "2099-01-01")]
+else:
+    L.append("provisional: false")
+if d.get("cohort"):
+    L.append("cohort: " + d["cohort"])
+L.append("evidence:")
+for e in d.get("evidence", ["harness/build-log.md#x"]):
+    L.append(f"  - {e}")
+L += ["proposed_cost: |", "  An estimate."]
+if status == "accepted":
+    L += ["cost: |", "  The approver's own words.",
+          "approver: russ@russmiles.com",
+          "approved_at: " + d.get("approved_at", "2026-01-01T00:00Z")]
+else:
+    L.append('cost: ""')
+L += ["proposer:", "  agent: harness-assayer", "  model: claude-opus-5"]
+if d.get("assay", "x"):
+    L.append("  assay: harness/assay/" + hid + "-assay.md")
+L.append("supersedes: " + (d["supersedes"] if d.get("supersedes") else "null"))
+L.append("superseded_by: null")
+L += ["---", "", "## Finding", "", "Something was observed.", "", "## Rule", ""]
+if d.get("withdrawn"):
+    L.append("Withdrawn.")
+elif cls == "no-change":
+    L.append("No change.")
+else:
+    L += ["````markdown", "- **Rule**: The fixture rule.", "````"]
+L += ["", "## Cost", "", "What this demands of whoever works here next.", ""]
+if cls in ("harness-loop", "script-validator", "new-agent"):
+    for h in ("Why this layer", "Enforcement", "Validation", "Rejected alternatives"):
+        L += [f"## {h}", "", "A real, human-written answer.", ""]
+
+with open(os.path.join(root, "harness", "decisions", hid + ".md"), "w") as fh:
+    fh.write("\n".join(L).rstrip("\n") + "\n")
+PYEOF
+mkhdr() { FIXTURE_ROOT="$TMP" "$PY" "$TMP/mkhdr.py"; }
+
+# --- the corpus --------------------------------------------------------------
+mkhdr <<'EOF'
+{"id": "HDR-2026-01-01-first", "title": "A new rule", "enforcement": "validated",
+ "surfaces": ["claude-code"], "cohort": "b", "approved_at": "2026-01-01T09:00Z"}
+EOF
+mkhdr <<'EOF'
+{"id": "HDR-2026-02-01-weakened", "title": "Weakened", "enforcement": "advisory",
+ "surfaces": ["claude-code"], "supersedes": "HDR-2026-01-01-first",
+ "approved_at": "2026-02-01T09:00Z"}
+EOF
+mkhdr <<'EOF'
+{"id": "HDR-2026-03-01-nothing", "title": "Nothing to change",
+ "classification": "no-change", "enforcement": "advisory", "surfaces": [],
+ "provisional": false, "approved_at": "2026-03-01T09:00Z"}
+EOF
+mkhdr <<'EOF'
+{"id": "HDR-2026-04-01-lapsed", "title": "Past its date", "enforcement": "advisory",
+ "expires": "2026-05-01", "approved_at": "2026-04-01T09:00Z"}
+EOF
+mkhdr <<'EOF'
+{"id": "HDR-2026-05-01-narrow", "title": "Narrow surfaces", "enforcement": "advisory",
+ "surfaces": ["claude-code"], "approved_at": "2026-05-01T09:00Z"}
+EOF
+mkhdr <<'EOF'
+{"id": "HDR-2026-06-01-widened", "title": "Widened surfaces", "enforcement": "advisory",
+ "surfaces": ["claude-code", "codex"], "supersedes": "HDR-2026-05-01-narrow",
+ "approved_at": "2026-06-01T09:00Z"}
+EOF
+mkhdr <<'EOF'
+{"id": "HDR-2026-07-01-strong", "title": "Strong rule", "enforcement": "blocked",
+ "surfaces": ["ci"], "approved_at": "2026-07-01T09:00Z"}
+EOF
+mkhdr <<'EOF'
+{"id": "HDR-2026-08-01-retired", "title": "Withdraw the strong rule",
+ "enforcement": "blocked", "surfaces": ["ci"], "withdrawn": true,
+ "supersedes": "HDR-2026-07-01-strong", "approved_at": "2026-08-01T09:00Z",
+ "evidence": ["harness/decisions/HDR-2026-07-01-strong.md"]}
+EOF
+# Not interventions: nothing was ever in force.
+mkhdr <<'EOF'
+{"id": "HDR-2026-09-01-draft", "title": "Still a draft", "status": "proposed"}
+EOF
+mkhdr <<'EOF'
+{"id": "HDR-2026-09-02-declined", "title": "Declined", "status": "rejected"}
+EOF
+
+# === T13: the command writes nothing =========================================
+BEFORE="$(tree_hash)"
+reg timeline
+[ "$RC" -eq 0 ] || fail "T1: timeline exited $RC. Out: $OUT"
+[ "$(tree_hash)" = "$BEFORE" ] || fail "T13: timeline wrote to disk"
+printf '%s\n' "$OUT" > "$TMP/feed-1.jsonl"
+
+# === T2: byte-identical on re-run ============================================
+reg timeline
+printf '%s\n' "$OUT" > "$TMP/feed-2.jsonl"
+cmp -s "$TMP/feed-1.jsonl" "$TMP/feed-2.jsonl" \
+  || fail "T2: the feed is not byte-identical on re-run"
+
+"$PY" - "$TMP/feed-1.jsonl" "$DEC" <<'PYEOF'
+import json, os, sys
+
+lines = [ln for ln in open(sys.argv[1]).read().splitlines() if ln.strip()]
+dec = sys.argv[2]
+
+# --- T4: every line is valid JSON, with a stable key order -------------------
+rows = []
+for ln in lines:
+    rows.append(json.loads(ln))
+keysets = {tuple(json.loads(ln).keys()) for ln in lines}
+assert len(keysets) == 1, f"T4: key order/set differs between lines: {keysets}"
+
+by_id = {r["id"]: r for r in rows}
+
+# --- T1/T12: one line per accepted record, no more and no fewer --------------
+accepted = set()
+for name in os.listdir(dec):
+    if not name.startswith("HDR-"):
+        continue
+    text = open(os.path.join(dec, name)).read()
+    fm = text.split("---", 2)[1]
+    if "\nstatus: accepted\n" in fm:
+        accepted.add(name[:-3])
+assert set(by_id) == accepted, (
+    "T1/T12: the feed does not match the accepted records exactly.\n"
+    f"  missing: {sorted(accepted - set(by_id))}\n"
+    f"  spurious: {sorted(set(by_id) - accepted)}")
+assert len(rows) == len(by_id), "T12: duplicate lines in the feed"
+
+# --- T3: no field derives from the current date ------------------------------
+lapsed = by_id["HDR-2026-04-01-lapsed"]
+assert lapsed["state"] == "in force", (
+    "T3: a record past its expiry reports "
+    f"{lapsed['state']!r}. Expiry is a CLOCK fact, and a feed carrying one "
+    "produces different output on different days from an unchanged corpus.")
+assert lapsed["expires"] == "2026-05-01", \
+    "T3: `expires` must be emitted as data so the consumer can decide"
+
+# --- T5: a first rule tightens; a no-change record is `none` -----------------
+assert by_id["HDR-2026-01-01-first"]["direction"] == "tighten", \
+    "T5: a rule that was not there before is a tightening"
+assert by_id["HDR-2026-03-01-nothing"]["direction"] == "none", \
+    "T5: a no-change record is an intervention of size zero, not an absence"
+
+# --- T6: a retirement loosens ------------------------------------------------
+# Its declared enforcement and surfaces are IDENTICAL to its predecessor's, so
+# the ladder and the surface comparison both say `same`. Only the retirement
+# branch can explain a `loosen` here. The first version of this fixture also
+# lowered the enforcement, and passed against a checker with the retirement
+# branch deleted.
+assert by_id["HDR-2026-08-01-retired"]["direction"] == "loosen", \
+    "T6: withdrawing a rule is a loosening"
+
+# --- T7: the enforcement ladder ---------------------------------------------
+assert by_id["HDR-2026-02-01-weakened"]["direction"] == "loosen", \
+    "T7: validated -> advisory is a loosening"
+
+# --- T8: surfaces break the tie only at equal enforcement -------------------
+assert by_id["HDR-2026-06-01-widened"]["direction"] == "tighten", \
+    "T8: the same enforcement reaching more surfaces is a tightening"
+
+# --- T9: a superseded record carries its end --------------------------------
+first = by_id["HDR-2026-01-01-first"]
+assert first["state"] == "superseded", f"T9: state is {first['state']!r}"
+assert first["superseded_by"] == "HDR-2026-02-01-weakened", \
+    "T9: the successor must be derived into the feed"
+assert first["ends"] == "2026-02-01", (
+    "T9: `ends` must carry the successor's date. An intervention with no end is "
+    "a step function that never steps back.")
+live = by_id["HDR-2026-06-01-widened"]
+assert live["state"] == "in force" and live["superseded_by"] is None \
+    and live["ends"] is None, "T9: a live record must not claim an end"
+
+# --- T10: cohort -------------------------------------------------------------
+assert by_id["HDR-2026-01-01-first"]["cohort"] == "b", "T10: cohort not emitted"
+assert by_id["HDR-2026-05-01-narrow"]["cohort"] is None, \
+    "T10: an absent cohort must be null, not omitted"
+
+# --- T11: deterministic ordering --------------------------------------------
+order = [(r["date"], r["id"]) for r in rows]
+assert order == sorted(order), f"T11: the feed is not ordered by date then id: {order}"
+
+print(f"parsed {len(rows)} intervention(s)")
+PYEOF
+
+# === T8b: overlapping-but-different surface sets are `same` ==================
+# Nothing honest can be said about which of two overlapping sets is stronger.
+mkhdr <<'EOF'
+{"id": "HDR-2026-10-01-sideways", "title": "Sideways", "enforcement": "advisory",
+ "surfaces": ["codex"], "supersedes": "HDR-2026-06-01-widened",
+ "approved_at": "2026-10-01T09:00Z",
+ "evidence": ["harness/decisions/HDR-2026-06-01-widened.md"]}
+EOF
+reg timeline
+printf '%s' "$OUT" | "$PY" -c "
+import json, sys
+rows = {json.loads(l)['id']: json.loads(l) for l in sys.stdin if l.strip()}
+d = rows['HDR-2026-10-01-sideways']['direction']
+assert d == 'loosen', f'expected loosen for a narrowed subset, got {d!r}'
+print('T8b ok (a narrowed surface set loosens)')
+"
+
+echo "harness timeline: all checks passed (T1-T13)"

--- a/tdad_tests/scenarios/commands/harness-timeline/derives-rather-than-declares.md
+++ b/tdad_tests/scenarios/commands/harness-timeline/derives-rather-than-declares.md
@@ -1,0 +1,52 @@
+---
+component: harness-timeline
+component_type: command
+tier: structural
+---
+
+# Scenario: /harness-timeline derives rather than declares, and reads no clock
+
+## Given
+
+The feed exists to support a difference-in-differences analysis, and two
+properties decide whether it can.
+
+A feed carrying a **time-varying** field produces different output on different
+days from a corpus nobody touched, so a run in November would disagree with the
+same run in September. And an intervention with **no end** is a step function
+that never steps back: every rule ever retired would still be counted as in
+force.
+
+`direction` is the field the analysis actually turns on, which makes it the last
+place to accept a self-report.
+
+## When
+
+`ai-literacy-superpowers/commands/harness-timeline.md` is read from the
+filesystem.
+
+## Then
+
+**Frontmatter:** `name: harness-timeline`, a description stating it writes to
+stdout, derives direction, and carries no field depending on the current date.
+
+**Body:**
+
+- States why it is **not a stored artifact**: a committed derivative drifts, and
+  `/harness-check` would then have to police it.
+- States that it carries no field depending on today, with the November/September
+  consequence spelled out, and that `expires` is emitted **as data** for the
+  consumer to interpret.
+- States that every intervention has an end, via `superseded_by` and `ends`, and
+  gives the interval as `[date, ends)`.
+- Tabulates the fields, and derives `direction` from the ladder
+  `advisory < validated < blocked`, with surfaces breaking the tie only at equal
+  enforcement and overlapping-but-different sets resolving to `same`.
+- States that a `no-change` record is `none` and is included deliberately — a
+  control observation, not an absence, because "we looked and decided no" and
+  "nobody looked" are the difference a governance study measures.
+- Excludes `proposed` and `rejected` records, with the reason that nothing was
+  ever in force.
+
+**Forbidden:** writing a file, reading the clock, and accepting a declared
+direction.

--- a/tdad_tests/tests/test_layer0_deterministic.py
+++ b/tdad_tests/tests/test_layer0_deterministic.py
@@ -134,6 +134,12 @@ BASH_TEST_SCRIPTS = [
     # exempt from the two-assay threshold — that threshold exists to make rules
     # hard to ADD, and applying it to removal inverts the design.
     "test-harness-review",
+    # Harness Evolution S5 — the Observatory intervention feed. T3 asserts no
+    # field derives from the current date: expiry is a clock fact, and a feed
+    # carrying one produces different output on different days from a corpus
+    # nobody touched. T9 asserts every intervention has an end — without it,
+    # every rule ever retired is still counted as in force.
+    "test-harness-timeline",
 ]
 
 


### PR DESCRIPTION
Part of the harness evolution epic #533. **Final phase.**

Closes #539. Depends on S0–S4.

## What this adds

- `/harness-timeline` — the Observatory intervention feed, to stdout
- `intervention-feed-format.md` reference page
- Layer-0 suite T1–T13

The difference-in-differences design currently has to **infer** when governance
changed. The corpus knows exactly.

## Two departures from the build spec's example line

Both because the example, as given, cannot support the analysis the feed exists
for.

### 1. No field depends on the current date

Whether a rule is expired *right now* is a fact about the clock, not about the
corpus. A feed carrying it produces different output on different days from a
repository nobody touched — so a difference-in-differences run in **November
would disagree with the same run in September** about the same data.

So `expires` is emitted **as data** for the consumer to interpret at their
analysis date, `state` is limited to `in force` and `superseded` (both corpus
facts), and the command reads no clock at all.

### 2. Every intervention carries an end

The example records when a rule *started*. Without `superseded_by` and `ends`,
every rule ever retired is still counted as in force — a step function that never
steps back.

The interval is `[date, ends)`. A live rule has both as `null`.

## `direction` is derived, never declared

A self-reported direction is a self-report, and this is the one field the
analysis turns on.

The ladder is `advisory < validated < blocked`. Surfaces break the tie **only** at
equal enforcement and **only** when one set contains the other — two
overlapping-but-different sets resolve to `same`, because nothing honest can be
said about which is stronger.

## `no-change` records stay in the feed

As `direction: none` — an intervention of size zero.

They record that governance was examined at a known moment and **deliberately not
changed**, which for a difference-in-differences design is a control observation,
not an absence. Dropping them would silently convert "we looked and decided no"
into "nobody looked" — and the difference between those two is exactly what a
governance study is trying to measure.

## Why stdout rather than a file

A committed derivative is one more thing that can drift from its source, and
`/harness-check` would then have to police it — a third generated artifact whose
only job is to be regenerated. Redirect it if you want a file; the choice is then
the user's problem rather than the corpus's.

## A note on the cohort tag

`cohort` stays on the decision record, per the epic's resolution of §14 Q4.

Worth naming rather than burying: a cohort tag on a governance artifact is
visible to whoever writes the next rule, which is a route by which a study can
influence the thing it studies. If that matters for a given study, the field can
be dropped from the record and joined externally at analysis time with **no
change to this command** — it emits `null` and the join happens downstream.

## Testing

T1–T13, mutation-tested against 12 broken implementations, all killed.

One found a weak fixture rather than weak code: the retirement fixture also
*lowered* its enforcement, so the ladder produced `loosen` regardless and the
test passed against a checker with the retirement branch deleted. Its enforcement
and surfaces are now identical to its predecessor's, so only the retirement
branch can explain the result — the same "assertion satisfiable by something
other than the thing under test" pattern found in S1, S2 and S3.

## Version

`0.78.0` → `0.79.0` (new command).