### PR TITLE
Make harness evolution the preferred, visible path in the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,32 @@ examined at a known moment and deliberately not changed, which is a control
 observation rather than an absence; dropping them would convert "we looked and
 decided no" into "nobody looked".
 
+### Documentation — harness evolution becomes the preferred path
+
+- **New tutorial** `your-first-governance-change.md` — the Diataxis entry point
+  for changing a harness rule the governed way.
+- **The plugin landing page leads with the loop.** Seven pages added across
+  S0–S5 were reachable through the filesystem-derived nav but linked from none
+  of the curated index lists — they are now, and `harness-evolution.md` is
+  promoted into the numbered first-principles sequence rather than buried in
+  Deep dives. A new **Evolving the harness** how-to section sits above the
+  lifecycle one.
+- **Pages describing the older path now say where it fits.**
+  `the-harness-tuning-loop.md` documented reflection → candidate →
+  `/harness-constrain`, which is the unevidenced path; it now says so, keeps its
+  capture and pattern-recognition stages, and points at the governed path for
+  promotion. `self-improving-harness.md`, `the-harness-lifecycle.md`,
+  `harness-engineering.md` and `how-to/add-a-constraint.md` carry the same
+  pointer.
+- **`/harness-constrain` is repositioned, not deprecated.** It authors the first
+  draft of a harness that does not exist yet; the governed loop changes one that
+  does, and grandfathering (`imported: true`) is the bridge between them.
+- **README and CLAUDE.md** carry the loop and the four properties that make it
+  hard to game.
+- Fixed a stale count: `your-first-sentinels.md` said there were nine sentinels.
+  The roster-parity check derives membership from `role: sentinel` frontmatter
+  but does not read prose counts.
+
 ### Note on the cohort tag
 
 `cohort` remains on the decision record, per the epic's resolution of the source

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,29 @@ When adding a new command that writes structured markdown, add a
 validation step following this pattern. Reference the format spec
 rather than inlining field definitions.
 
+## Changing a Harness Rule
+
+Once a harness exists, changing it goes through the governed loop rather than a
+hand edit to `HARNESS.md`:
+
+```text
+/harness-assay → /harness-propose → /harness-accept → /harness-check
+```
+
+with `/harness-review` when a rule lapses, `/harness-compile` as repair, and
+`/harness-timeline` for the Observatory feed.
+
+A rule enters on recorded evidence, carries a cost the approver wrote in their
+own words, and expires unless someone renews it. `/harness-check` runs in
+`.github/workflows/harness.yml` and fails the build when what is written down
+and what is in force disagree, or when a rule has outlived its expiry.
+
+`/harness-constrain` still authors the _first_ draft of a harness. After that,
+hand edits are how a governing document becomes the least governed thing in the
+repository.
+
+See `docs/plugins/ai-literacy-superpowers/explanation/harness-evolution.md`.
+
 ## Dynamic Workflows
 
 When a task looks **long-running**, massively parallel, highly structured,

--- a/README.md
+++ b/README.md
@@ -140,6 +140,34 @@ After installation, run these commands to set up your project:
 
 **`/harness-init`** sets up only the harness: HARNESS.md with starter constraints and GC rules. Use this if you want the constraint and enforcement machinery without the full agent pipeline.
 
+### Changing a harness rule
+
+Setting a harness up is the easy half. **Once it exists, this is how it changes:**
+
+```bash
+/harness-assay      # read what actually happened; propose, then stop
+/harness-propose    # draft a decision record, rule text copied verbatim
+/harness-accept     # you write the cost; the rule is applied and compiled
+/harness-check      # CI verifies what is written down is what is in force
+/harness-review     # when a rule lapses: re-evidence, weaken, or demote
+```
+
+Harness rules accrete. One enters because somebody was annoyed once, and it never leaves, because leaving requires somebody to remember it exists. A year later the document governing the work is the least governed thing in the repository — a dozen rules, none carrying the evidence that justified it, none saying what it costs, none with an expiry.
+
+This loop is the answer, and it is deliberately asymmetric: **rules are hard to add and easy to retire.**
+
+- A rule enters on **recorded evidence**, and a change to `HARNESS.md` needs evidence from two distinct assays — one bad afternoon is not a governance finding
+- The **cost is written by the approver**, in their own words. A cost copied from the proposal is refused, because a copy-pasted cost reads exactly like a considered one
+- Every rule is **provisional by default**. An expired rule still in force fails CI, so retiring one never depends on anyone remembering to reflect
+- `harness/enforcement-report.md` says which rules are **actually enforced** and which are merely written down — a rule intending `blocked` on a tool that can only advise is reported as a gap, never silently downgraded
+- **`no-change` is a first-class outcome.** An assay in which nothing needs changing is a successful assay
+
+The two roles are kept apart on purpose: the **Harness Assayer** diagnoses and is read-only by construction; the **Harness Registrar** writes but never authors. An agent that did both could rationalise its own findings into rules that make its next diagnosis easier.
+
+Start with [Your First Governance Change](docs/plugins/ai-literacy-superpowers/tutorials/your-first-governance-change.md).
+
+Editing `HARNESS.md` by hand still has one job — the first draft of a harness that does not exist yet.
+
 ### Tool Compatibility
 
 This plugin works with both Claude Code and GitHub Copilot CLI from the same repository. The formats have converged:

--- a/docs/plugins/ai-literacy-superpowers/explanation/harness-engineering.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/harness-engineering.md
@@ -7,6 +7,14 @@ Harness engineering is the practice of surrounding AI-assisted code generation w
 
 ---
 
+> **How a harness changes**
+>
+> Once a harness exists, changing it is itself a governed act:
+> [Harness Evolution](harness-evolution.md). A rule enters on recorded
+> evidence, carries a cost written by the person approving it, and expires
+> unless someone renews it — because the alternative is a governing document
+> that becomes the least governed thing in the repository.
+
 ## The Origin
 
 The term comes from Birgitta Boeckeler's article on martinfowler.com, written in the ThoughtWorks context of teams shipping real software with AI coding assistants. Boeckeler observed something that many teams had noticed independently: AI assistants produce plausible-looking code, but left unconstrained they drift. They forget conventions, repeat mistakes, and slowly erode the internal consistency of a codebase. The code continues to compile and pass tests. The degradation is quiet.

--- a/docs/plugins/ai-literacy-superpowers/explanation/self-improving-harness.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/self-improving-harness.md
@@ -9,6 +9,19 @@ title: The Self-Improving Harness
 > ceremony when the team is large. The harness has to keep up — and
 > the cheapest way to do that is to make every session a contribution.
 
+---
+
+> **The mechanism that does this**
+>
+> This page is the *why*. The **how**, for a harness that already exists, is
+> [Harness Evolution](harness-evolution.md) — the assay-to-decision-record
+> loop, where a rule enters on recorded evidence and leaves on an expiry
+> date rather than on somebody remembering it exists.
+>
+> The failure mode named below as **drift** is the one that loop was built
+> against, and the reason it makes rules *hard to add and easy to retire*
+> rather than the other way round.
+
 ## Why iteration matters
 
 The conventions captured in HARNESS.md were correct *when they were

--- a/docs/plugins/ai-literacy-superpowers/explanation/the-harness-lifecycle.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/the-harness-lifecycle.md
@@ -7,6 +7,21 @@ title: The Harness Lifecycle
 > upstream when needed**. Three commands cover it. Everything else is
 > a deeper or specialised version of one of those three.
 
+---
+
+> **Drift is not the only way a harness changes**
+>
+> This lifecycle keeps the harness *consistent with itself*. It does not
+> govern the moment a rule is added, changed, or retired — which is a
+> different question with a different answer.
+>
+> That is [Harness Evolution](harness-evolution.md): an assay produces
+> evidence, a decision record carries the rule and its cost, and
+> `/harness-check` fails the build when what is written down and what is in
+> force disagree — or when a rule has outlived its expiry.
+>
+> Detecting drift and governing change are complementary. Run both.
+
 ## Before the lifecycle: setting up the harness
 
 The lifecycle starts when a harness exists. To get there, run one of

--- a/docs/plugins/ai-literacy-superpowers/explanation/the-harness-tuning-loop.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/the-harness-tuning-loop.md
@@ -12,6 +12,26 @@ For the broader picture, see [The Harness Lifecycle](the-harness-lifecycle.md).
 This page goes deeper on the part of the lifecycle that turns
 *lessons* into *enforcement*.
 
+> **Where this fits now**
+>
+> This describes the **unevidenced** path: a reflection becomes a candidate,
+> a candidate becomes a constraint, and nothing records what justified it,
+> what it costs, or when it stops being true.
+>
+> For changing a harness that already exists, the governed path in
+> [Harness Evolution](harness-evolution.md) is the one to reach for. It takes
+> the same raw material — what surprised you, what recurred — and adds the
+> four things this loop leaves out: recorded evidence, a declared enforcement
+> level, a cost written by the approver, and an expiry that CI enforces.
+>
+> What follows is still worth reading, and still applies while a harness is
+> being drafted for the first time. The capture and pattern-recognition
+> stages are unchanged; it is the *promotion* stage that has been superseded.
+>
+> A rule promoted this way can be brought under governance later by importing
+> it as a grandfathered decision record — `imported: true`, no expiry, so
+> adoption does not manufacture a cliff of lapses on day ninety.
+
 ## The four stages
 
 ### 1. Capture — write the reflection

--- a/docs/plugins/ai-literacy-superpowers/how-to/add-a-constraint.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/add-a-constraint.md
@@ -6,6 +6,23 @@ title: Add a Constraint
 Add or promote a constraint in HARNESS.md using `/harness-constrain` to capture the rule,
 its enforcement state, and the verification command.
 
+> **Use this for the first draft, not for evolution**
+>
+> `/harness-constrain` writes a rule straight into `HARNESS.md`. That is the
+> right thing when you are **authoring a harness that does not exist yet**.
+>
+> For changing a harness that already exists, use the governed path —
+> [Record a Governance Change](record-a-governance-change.md). It records the
+> evidence that justified the rule, the cost the approver wrote, the
+> enforcement each surface actually achieves, and an expiry that CI enforces.
+>
+> The difference matters after about a year, when a harness written by hand
+> has a dozen rules and nobody can say why any of them are there or what it
+> would cost to remove one.
+>
+> A constraint added this way can be brought under governance later by
+> importing it as a grandfathered decision record.
+
 ---
 
 ## 1. Open a guided session

--- a/docs/plugins/ai-literacy-superpowers/index.md
+++ b/docs/plugins/ai-literacy-superpowers/index.md
@@ -7,10 +7,32 @@ The flagship plugin in this marketplace — harness engineering, agent
 orchestration, literate programming, CUPID code review, compound
 learning, and the three enforcement loops.
 
-The everyday lifecycle entry is `/harness-sync` — it detects drift
-across every surface and applies the fixes you select. See
-[The Harness Lifecycle](explanation/the-harness-lifecycle.md) for the
-broader frame.
+## Changing a harness rule
+
+**Once a harness exists, this is how it changes.** Rules enter on recorded
+evidence, carry a cost the approver wrote, and expire unless someone renews
+them:
+
+```text
+/harness-assay      read what actually happened; propose, then stop
+/harness-propose    draft a decision record, rule text copied verbatim
+/harness-accept     you write the cost; the rule is applied and compiled
+/harness-check      CI verifies what is written down is what is in force
+/harness-review     when a rule lapses: re-evidence, weaken, or demote
+```
+
+Start with **[Your First Governance Change](tutorials/your-first-governance-change.md)**,
+or read [Harness evolution](explanation/harness-evolution.md) for why the role
+that diagnoses failures is forbidden from writing the rules.
+
+Editing `HARNESS.md` by hand still has one job — the first draft of a harness
+that does not exist yet. After that, hand edits are how a governing document
+becomes the least governed thing in the repository.
+
+The everyday drift-and-heal entry is `/harness-sync` — it detects drift across
+every surface and applies the fixes you select. See
+[The Harness Lifecycle](explanation/the-harness-lifecycle.md) for the broader
+frame.
 
 The plugin's source lives at [`ai-literacy-superpowers/`](https://github.com/Habitat-Thinking/ai-literacy-superpowers/tree/main/ai-literacy-superpowers)
 in the repository.
@@ -53,7 +75,8 @@ matches the kind of reading you're doing right now.
 
 Start here if you're new to the plugin.
 
-- [Your First Sentinels](tutorials/your-first-sentinels.md) — meet three of the nine in one session; the category that guards your understanding rather than your code
+- [Your First Governance Change](tutorials/your-first-governance-change.md) — change a harness rule the governed way: from evidence, through a recorded decision, with a cost you wrote and an expiry CI enforces
+- [Your First Sentinels](tutorials/your-first-sentinels.md) — meet three of the ten in one session; the category that guards your understanding rather than your code
 - [Getting Started](tutorials/getting-started.md)
 - [First Time Tour](tutorials/first-time-tour.md)
 - [Harness From Scratch](tutorials/harness-from-scratch.md)
@@ -68,9 +91,17 @@ Start here if you're new to the plugin.
 
 Practical guides for specific tasks.
 
+#### Evolving the harness
+
+How a rule changes once the harness exists. This is the governed path, and the
+one to reach for by default.
+
+- [Assay a Phase](how-to/assay-a-phase.md) — the read-only postmortem a governance change is built from
+- [Record a Governance Change](how-to/record-a-governance-change.md) — propose, accept, and read the enforcement report
+
 #### Harness lifecycle
 
-- [Add a Constraint](how-to/add-a-constraint.md)
+- [Add a Constraint](how-to/add-a-constraint.md) — authoring the *first* draft by hand; for changes to an existing harness, use the governed path above
 - [Add Fitness Functions](how-to/add-fitness-functions.md)
 - [Run a Harness Audit](how-to/run-a-harness-audit.md)
 - [Run a Calibration Review](how-to/run-a-calibration-review.md)
@@ -138,6 +169,10 @@ Practical guides for specific tasks.
 - [Hooks](reference/hooks.md)
 - [Templates](reference/templates.md)
 - [HARNESS.md format](reference/harness-md-format.md)
+- [Harness Decision Record format](reference/harness-decision-records.md) — the unit a governance change is recorded in
+- [Assay finding format](reference/assay-finding-format.md) — the contract between the Assayer and the Registrar
+- [Enforcement report format](reference/enforcement-report-format.md) — intended versus achieved, per rule, per surface
+- [Intervention feed format](reference/intervention-feed-format.md) — the Observatory timeline `/harness-timeline` emits
 - [Output validation](reference/output-validation.md)
 - [Governance summary format](reference/governance-summary-format.md)
 
@@ -153,11 +188,13 @@ from first principles to the complete system:
 5. [Agent Orchestration](explanation/agent-orchestration.md) — specialised agents with trust boundaries
 6. [Compound Learning](explanation/compound-learning.md) — how your AI gets smarter every session
 7. [The Loops That Learn](explanation/the-loops-that-learn.md) — four operational loops that make AI environments compound
+8. [Harness Evolution](explanation/harness-evolution.md) — **how the rules themselves change**: the two roles, the human gate between them, and why rules should be hard to add and easy to retire
 
 #### Deep dives
 
 - [HARNESS.md, the Document](explanation/harness-md.md) — what `HARNESS.md` is, how it is operated, and how it compares to `AGENTS.md`, CI config, and hooks
 - [The Self-Improving Harness](explanation/self-improving-harness.md) — the audit-and-amendment feedback loop that keeps the harness honest
+- [The Harness Tuning Loop](explanation/the-harness-tuning-loop.md) — the older reflection-to-constraint path, and where it still applies
 - [Habitat Engineering](explanation/habitat-engineering.md) — the broader environment around the harness
 - [Harness Engineering](explanation/harness-engineering.md) — what the harness is and isn't
 - [Cadence Governance](explanation/cadence-governance.md) — the carpaccio agent's role; slicing the task before any spec exists

--- a/docs/plugins/ai-literacy-superpowers/tutorials/your-first-governance-change.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/your-first-governance-change.md
@@ -1,0 +1,222 @@
+---
+title: Your First Governance Change
+---
+# Your First Governance Change
+
+In this tutorial you will change a harness rule the governed way: from
+evidence, through a recorded decision, with a cost you wrote yourself and an
+expiry date that CI will enforce.
+
+Plan for about thirty minutes. Most of it is reading.
+
+## Why not just edit HARNESS.md
+
+You can. Nothing stops you, and for the *first* draft of a harness that is the
+right thing to do — see [Add a Constraint](../how-to/add-a-constraint.md).
+
+The problem is what happens next. Harness rules accrete. One enters because
+somebody was annoyed once, and it never leaves, because leaving requires
+somebody to remember it exists. A year later the document that governs the work
+is the least governed thing in the repository: a dozen rules, none carrying the
+evidence that justified it, none saying who owns it, none saying what it costs,
+and none with an expiry.
+
+That is a failure with no incident behind it, which is why it is rarely fixed.
+Nothing ever goes wrong on a Tuesday because of it.
+
+This loop is the answer. **Once a harness exists, this is how it changes.**
+
+## What you will need
+
+A repository with a `HARNESS.md`, and a phase of work that has just finished.
+Not one still in flight — an assay of unfinished work is an assay of a guess.
+
+If you have never set up a harness, run `/harness-init` first and come back
+after your next phase.
+
+## 1. Set up the corpus, once
+
+```bash
+mkdir -p harness/decisions
+```
+
+Then write `harness/surfaces.yaml`, declaring what each of your tools can
+actually enforce:
+
+```yaml
+routes:
+  harness-loop: HARNESS.md
+  turn-instructions: AGENTS.md
+
+surfaces:
+  claude-code:
+    targets: [CLAUDE.md, .claude/agents/, .claude/hooks/]
+    supports: [advisory, validated, blocked]
+  copilot:
+    targets: [.github/copilot-instructions.md]
+    supports: [advisory]
+  ci:
+    targets: [.github/workflows/]
+    supports: [validated, blocked]
+```
+
+`routes` says where a rule's *text* goes. `surfaces` says who is *told* about
+it, and how strongly it can bind there.
+
+Be honest in `supports`. A surface that reads prose and refuses nothing
+supports `advisory`, however much you would like it to block. That honesty is
+what makes the enforcement report worth reading later.
+
+Finally, add the check to CI:
+
+```yaml
+- name: "Harness governance is applied and undrifted"
+  run: python3 ai-literacy-superpowers/scripts/harness-registrar.py check
+```
+
+## 2. Run the assay
+
+```bash
+/harness-assay
+```
+
+The Harness Assayer reads your `HARNESS.md`, `AGENTS.md`, agent files, build
+log, reflection log, decision records, and whatever the cadence sentinels
+recorded. It reconstructs what the workflow was *meant* to be, then what
+actually happened, and reports the gap.
+
+**Do not tell it what you think went wrong.** An assay steered toward a
+conclusion is a confirmation.
+
+The report lands at `harness/assay/<timestamp>-assay.md`.
+
+## 3. Read it — this is the step that matters
+
+Everything after this is mechanical. Six sections: executive summary, what
+worked, what created friction, findings, rejected candidates, unresolved
+questions.
+
+Three things to check, because no linter can:
+
+- **Every claim that a check passed cites observed output.** A planned command
+  quoted from a build file is not evidence that it ran. This is the Assayer's
+  honesty rule and the most likely place for it to have slipped.
+- **Rejected candidates is not empty** — or the report says why. An assay that
+  rejects nothing has stopped checking itself against `/harness-audit`,
+  `/governance-audit` and `/reflect`, which read the same artifacts.
+- **Absent sources are named as absent.** "No boundary events" from a machine
+  with no boundary-note store is a fabrication dressed as a measurement.
+
+### If every finding is `no-change`, you are finished
+
+That is a **successful** assay. Recording that nothing needed to change is
+itself evidence, and the next assay will read it. Stop here.
+
+## 4. Propose one finding
+
+```bash
+/harness-propose harness/assay/<timestamp>-assay.md finding-3
+```
+
+Not all of them. Three accepted records per cycle is the cap, and a proposal
+that cannot win a slot twice running probably was not worth a rule.
+
+This writes `harness/decisions/HDR-<date>-<slug>.md` at `status: proposed`. The
+rule text and evidence are copied **by a script**, byte for byte — a model asked
+to copy text usually copies it and occasionally improves it, and every
+improvement is a silent edit to a rule you are about to approve believing it to
+be the Assayer's words.
+
+`cost` is deliberately empty. That is yours.
+
+## 5. Accept it — and expect to be refused
+
+```bash
+/harness-accept harness/decisions/HDR-<date>-<slug>.md
+```
+
+Every refusal that does not need a cost runs **first**, so you are never asked
+to compose a considered cost for a rule that is about to be rejected.
+
+A first-timer usually meets one of these:
+
+| Refusal | What it means |
+| --- | --- |
+| `harness-loop` citing one assay | A single incident cannot reach the loop layer. Wait for a second assay, or reclassify to the layer that owns the behaviour |
+| Tier-2 sections are placeholders | A change reaching beyond one agent must argue why it belongs at that layer. Neither the Assayer nor the Registrar may write that argument |
+| No route and no `target` | `agent-instruction` says the behaviour belongs to an agent, not *which* agent. That is your call |
+
+**A refusal is the mechanism working.** Rules should be hard to add. A proposal
+that carries forward to the next cycle is not a blocked task.
+
+Once it passes, you get one question:
+
+```text
+Cost of this rule, in your own words. What will it demand of whoever
+works here next, and how might it be gamed?
+```
+
+Answer it yourself. The validator refuses a cost identical to the Assayer's
+proposal — not as procedure, but because a copy-pasted cost reads exactly like a
+considered one, so nothing downstream can tell them apart. If you ask the agent
+to write it, it will decline and offer to discuss the rule instead.
+
+Acceptance then does three things in one transaction: accepts the record, writes
+the rule into the artifact that owns it, and recompiles the index and the
+enforcement report.
+
+## 6. Read the enforcement report
+
+```bash
+cat harness/enforcement-report.md
+```
+
+```markdown
+| Surface | Intended | Achieved | Gap | Why |
+| --- | --- | --- | --- | --- |
+| claude-code | blocked | advisory | gap | no validator declared or resolvable |
+| copilot | blocked | advisory | gap | surface supports at most advisory |
+```
+
+**A gap is not a failure.** It is a true fact, and the report exists to state it.
+What you must not do is lower the rule's `enforcement` to make the gaps
+disappear — that discards the information you just gained.
+
+The second row is a ceiling: Copilot reads prose and refuses nothing. The first
+is more interesting. It says the rule *could* be enforced here and nothing
+enforces it. Point `validator:` at the script or workflow that does the
+refusing, and the gap closes. A validator that does not exist counts as no
+validator.
+
+## 7. Review the diff and commit
+
+Nothing has been committed for you. Three gates exist — drafting, accepting,
+committing — and none is implied by another.
+
+## 8. Ninety days later
+
+Your rule was accepted `provisional: true` with an expiry. Permanence is earned
+at review, not at creation.
+
+When it lapses, CI goes red and `/harness-review` gives you three options:
+**re-evidence** it, **weaken** it, or **demote** it. All three write a *new*
+record that supersedes the old one — nothing edits an accepted record, and
+nothing is ever deleted. The record that the rule existed, what it cost, and why
+it went is the output of this whole mechanism.
+
+That is the half of governance almost nobody does, and it is the half this loop
+exists for.
+
+## What you have now
+
+- A rule that entered on evidence, not irritation
+- A cost written by a person, in their own words
+- A truthful account of how strongly it binds on each tool
+- An expiry that CI enforces, so retiring it never depends on anyone remembering
+
+## Where to go next
+
+- [Assay a phase](../how-to/assay-a-phase.md)
+- [Record a governance change](../how-to/record-a-governance-change.md)
+- [Harness evolution](../explanation/harness-evolution.md) — why the two roles are separate
+- [Harness Decision Record format](../reference/harness-decision-records.md)

--- a/docs/plugins/ai-literacy-superpowers/tutorials/your-first-sentinels.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/your-first-sentinels.md
@@ -143,7 +143,7 @@ is an untested assertion, and the friction you just felt is the quality.
 
 ## Where to go next
 
-There are **nine** sentinels. You have met three.
+There are **ten** sentinels. You have met three.
 
 - **[Sentinels](../explanation/sentinels.md)** — the full roster and, in *Using
   them*, which to reach for when


### PR DESCRIPTION
Follows the harness evolution epic #533 (PRs #540–#545).

Docs-only. Nothing under `ai-literacy-superpowers/` changed, so no version bump;
CHANGELOG appended under the current `0.79.0` heading per the repo convention.

## Two problems found

### 1. Seven new pages were orphaned from the curated navigation

Everything the epic added — four reference pages, two how-to guides, one
explanation page — was reachable through the filesystem-derived `awesome-pages`
nav, and linked from **none** of the curated lists on the plugin landing page.

| Page | Was |
| --- | --- |
| `reference/harness-decision-records.md` | not linked |
| `reference/assay-finding-format.md` | not linked |
| `reference/enforcement-report-format.md` | not linked |
| `reference/intervention-feed-format.md` | not linked |
| `how-to/record-a-governance-change.md` | not linked |
| `how-to/assay-a-phase.md` | not linked |
| `explanation/harness-evolution.md` | not linked |

### 2. The docs said two different things about how a harness changes

`explanation/the-harness-tuning-loop.md` documents reflection → candidate →
`/harness-constrain`. That is exactly the unevidenced path the epic exists to
replace, and it was presented as *the* way a harness improves.

Leaving both in place would have been worse than either alone.

## What changed

**Visibility**

- New tutorial **[Your First Governance Change]** — Diataxis puts tutorials at
  the entry point, which is where "preferred" has to be visible
- The plugin landing page now **leads** with the loop, before the drift-and-heal
  entry
- `harness-evolution.md` promoted into the **numbered first-principles
  sequence** (item 8) rather than sitting in Deep dives
- A new **Evolving the harness** how-to section, placed above Harness lifecycle
- All seven orphaned pages linked
- README and `CLAUDE.md` carry the loop and the four properties that make it
  hard to game

**Reconciliation — reframed, not deleted**

`the-harness-tuning-loop.md` keeps its capture and pattern-recognition stages;
those are unchanged and still correct. It now says plainly that the *promotion*
stage is the unevidenced one, points at the governed path, and notes that a rule
promoted its way can be brought under governance later as a grandfathered
record.

`self-improving-harness.md`, `the-harness-lifecycle.md`, `harness-engineering.md`
and `how-to/add-a-constraint.md` carry the same pointer.

**`/harness-constrain` is repositioned, not deprecated.** It authors the *first*
draft of a harness that does not exist yet — the governed loop needs an assay,
and a project with no completed work has nothing to assay. Grandfathering
(`imported: true`, no expiry) is the bridge, which is also why importing legacy
rules deliberately does not start a 90-day clock.

## Two things worth flagging

**Blockquotes, not admonitions.** My first pass used `!!! note`. No page in these
docs uses MkDocs admonitions, and a four-space-indented admonition body reads to
markdownlint as an indented code block — which then makes every fenced block in
the file inconsistent (MD046). Four of the five files passed only because they
happen to contain no fenced blocks. Converted to the blockquote style the docs
already use.

**A stale count.** `your-first-sentinels.md` said there were nine sentinels; the
Assayer made ten. The roster-parity check derives membership from `role: sentinel`
frontmatter across three rosters, but does not read prose counts — so this class
of drift is invisible to it. Worth an HDR classified `regression-test` once the
loop is running on this repo.

## Verification

- markdownlint: 0 issues across 484 files
- Every relative link in all 9 changed pages resolves (checked)
- Full local suite: 444 passed
- `mkdocs` is not installed locally, so `docs-build-check` in CI is the
  authoritative build verification

[Your First Governance Change]: docs/plugins/ai-literacy-superpowers/tutorials/your-first-governance-change.md