### PR TITLE
Adopt the optional Stakeholders block and bump the harness template marker to 0.79.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,24 @@ decided no" into "nobody looked".
   The roster-parity check derives membership from `role: sentinel` frontmatter
   but does not read prose counts.
 
+### Harness upgrade to the 0.79.0 template
+
+- **Adopted the optional `## Stakeholders` block** into `HARNESS.md`, commented
+  out as the template ships it. The Convener treats an absent section as
+  not-an-error and flags every derived voice `inferred`; the block is now
+  present as a prompt to fill in, and filling it in is what makes those voices
+  `observed`.
+- **Template-version marker bumped `0.73.2` → `0.79.0`**, clearing the
+  `Template currency` GC rule.
+- Worth recording for whoever runs the next upgrade: the shipped
+  `templates/HARNESS.md` still carries its own `0.57.0` marker, so a version gap
+  against the plugin does not imply new template content. Everything the harness
+  evolution epic added arrived as commands, agents and skills. This repo's own
+  harness leads the template by roughly forty items — including the three
+  harness-evolution constraints (`Sentinel integrity`, `Harness decision records
+  are well-formed`, `Harness governance is applied and undrifted`), which a
+  project adopting 0.79.0 does not get from the template.
+
 ### Note on the cohort tag
 
 `cohort` remains on the decision record, per the epic's resolution of the source

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -10,7 +10,7 @@
 
      Inspired by Birgitta Boeckeler's "Harness Engineering":
      https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html -->
-<!-- template-version: 0.73.2 -->
+<!-- template-version: 0.79.0 -->
 
 ## Context
 
@@ -51,6 +51,23 @@
   include an Overview section. README.md documents the full plugin.
   Bash scripts must have a header comment block explaining purpose
   and behaviour.
+
+<!-- ## Stakeholders
+
+     OPTIONAL. Who this project affects, as roles or groups — never named
+     individuals, and never agents. The Convener reads this section to map the
+     voices a spec touches, flagging a voice it names `observed` rather than
+     `inferred`.
+
+     Who a project affects is a property of the PROJECT, which is why it lives
+     here rather than in a personal file. Leaving this out is not an error: the
+     Convener derives candidates from the change itself and flags every one
+     `inferred`, producing a shorter, less certain list, honestly labelled.
+
+- Support — fields questions about the CLI
+- Docs — owns the published reference
+- PO — disposes behaviour changes
+-->
 
 ---
 


### PR DESCRIPTION
Closes #547

Runs `/harness-upgrade` against the 0.79.0 plugin cache.

## What the comparison found

The version gap was misleading. The harness marker read `0.73.2` against a `0.79.0`
plugin, but the shipped `templates/HARNESS.md` carries its own `0.57.0` marker — it
has not been revised in six minor versions. Everything the harness evolution epic
added shipped as commands, agents and skills, not as template constraints.

| Bucket | Result |
| --- | --- |
| New | 1 — the optional `## Stakeholders` block, adopted commented as the template ships it |
| Updated | 0 actionable — `Consistent formatting` differs, but this harness's version is customised and stronger |
| Removed | ~40 advisory — this repo is the plugin's source, so its harness leads the template |

## Changes

- `HARNESS.md` — the commented `## Stakeholders` block, byte-identical to the template's,
  inserted after `### Conventions`. No behaviour change; `/convene` continues to flag every
  voice `inferred` until the roles are filled in.
- `HARNESS.md` — template-version marker `0.73.2` → `0.79.0`, clearing `Template currency`.
- `CHANGELOG.md` — entry under 0.79.0.

No plugin version bump: the change is outside `ai-literacy-superpowers/`.

## Worth flagging

Three constraints exist in this harness and **not** in the shipped template —
`Sentinel integrity`, `Harness decision records are well-formed`, and `Harness governance
is applied and undrifted`. A project adopting 0.79.0 gets `/harness-assay` and
`/harness-accept` with no template constraint keeping the records well-formed.

`Template currency` compares the harness marker against the *plugin* version rather than
the template's own, so it will fire on every release regardless of whether the template
changed. Evidence for a future assay rather than something to fix here.