### PR TITLE
Refuse a target that cannot hold a rule, and route script-validator to HARNESS.md

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.79.0",
+  "plugin_version": "0.80.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.79.0"
+      "version": "0.80.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 0.80.0 — 2026-08-25
+
+### Fixed — the harness evolution write path
+
+Found by running the loop end to end for the first time (#548, PR #550), where
+accepting a record whose `target` was `.github/workflows/gc.yml` appended a
+markdown region to a YAML file and left the workflow unparseable. `/harness-check`
+then reported `OK`. See #551 and
+`docs/superpowers/specs/2026-08-25-harness-write-path-integrity-design.md`.
+
+- **A target must be a markdown artifact.** Rule text is markdown and is applied
+  verbatim, so the artifact that *hosts* a rule must be able to hold markdown. The
+  artifact a rule is *about* goes in its `**Tool**` field. `/harness-accept`,
+  `/harness-compile` and `/harness-check` all refuse a target that cannot hold the
+  text, and the refusal names the target and directs the author to `**Tool**`.
+- **Checked before routing.** A routed classification would otherwise silently
+  ignore a target its author named, and quietly discarding what someone wrote is
+  the failure shape this mechanism exists to refuse.
+- **An allowlist, not a denylist.** A denylist answers "is this one of the types we
+  thought of?", which is the question nobody had asked about `.yml`.
+- **`script-validator` gains a fixed route to `HARNESS.md`.** A rule about a
+  validator is still a rule about how work proceeds here, and its text is prose.
+  The classification was previously unusable: its targets are code files by
+  definition, and the compiler emits only markdown.
+- **Superseded and retirement records stay exempt**, so an existing corpus that
+  already resolved this by supersession — as this one did — still passes.
+- **Layer 0 suite** `test-harness-write-path.sh` (W1–W8), covering the refusal at
+  accept, compile and check, the routed case, the superseded exemption, and four
+  file types beyond the one that failed. This is the coverage the original Phase 2
+  acceptance criteria never had: both fixed routes were markdown, so no test ever
+  pointed a record at another file type.
+
+### Known limitation
+
+A `routes:` block in `surfaces.yaml` **replaces** the defaults rather than merging
+with them, despite `effective_routes`' docstring claiming otherwise. A project that
+declares any custom route silently loses every default, including
+`harness-loop: HARNESS.md`. Documented in the reference and left for its own
+change rather than widened into this one.
+
 ## 0.79.0 — 2026-08-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.79.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.80.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-42-2E8B57?style=flat-square)](#skills-42)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.79.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.80.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.79.0",
+  "version": "0.80.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/scripts/check-harness-decisions.py
+++ b/ai-literacy-superpowers/scripts/check-harness-decisions.py
@@ -86,6 +86,10 @@ VALID_CLASSIFICATION = {
 DEFAULT_ROUTES = {
     "harness-loop": "HARNESS.md",
     "turn-instructions": "AGENTS.md",
+    # A rule about a validator is still a rule about how work proceeds here, and
+    # its text is prose. Before this route existed the classification named a
+    # script as its target, and the compiler appended markdown to it (#551).
+    "script-validator": "HARNESS.md",
 }
 
 # The classifications whose reach extends beyond a single agent. Process burden

--- a/ai-literacy-superpowers/scripts/harness-registrar.py
+++ b/ai-literacy-superpowers/scripts/harness-registrar.py
@@ -905,6 +905,34 @@ def load_matrix(root: str) -> tuple[dict[str, str], dict[str, dict]]:
     return S0.effective_routes(root), surfaces
 
 
+# A rule's text is markdown, applied verbatim. The artifact that HOSTS it must
+# therefore be one that can hold markdown; the artifact a rule is ABOUT is named
+# in its `**Tool**` field, and those are different things.
+#
+# On 2026-08-25 a record targeting `.github/workflows/gc.yml` was accepted, the
+# region was appended to a YAML file, the workflow stopped parsing, and
+# `/harness-check` reported OK against it. The two fixed routes were both
+# markdown, so no test had ever pointed a record at another file type.
+#
+# An ALLOWLIST, deliberately. A denylist answers "is this one of the types we
+# thought of?", which is exactly the question nobody asked about `.yml`.
+PROSE_SUFFIXES = (".md",)
+
+
+def hosts_prose(path: str) -> bool:
+    return str(path).endswith(PROSE_SUFFIXES)
+
+
+def target_refusal(where: str, target: str) -> str:
+    return (
+        f"FAIL: {where}: target '{target}' cannot hold this rule. Rule text is "
+        "markdown and is applied verbatim, so the target must be a markdown "
+        f"artifact ({', '.join(PROSE_SUFFIXES)}). Name a markdown artifact as the "
+        f"target and put '{target}' in the rule's **Tool** field, which is where "
+        "the artifact a rule is ABOUT belongs."
+    )
+
+
 def target_of(record: Record, routes: dict[str, str]) -> str | None:
     if record.classification == "no-change":
         return None
@@ -1058,12 +1086,23 @@ def compile_plan(root: str, records: list[Record]) -> tuple[dict[str, str], list
         # mechanism, not its residue - but neither reaches an artifact.
         if record.id in retired or record.is_retirement:
             continue
+        # Checked BEFORE routing. A routed classification would otherwise
+        # silently ignore a declared target, and quietly discarding what an
+        # author wrote is the shape of failure this whole mechanism exists to
+        # refuse.
+        declared = record.fm.get("target")
+        if declared and not hosts_prose(str(declared)):
+            errors.append(target_refusal(record.rel, str(declared)))
+            continue
         target = target_of(record, routes)
         if not target:
             errors.append(
                 f"FAIL: {record.rel}: classification '{record.classification}' "
                 "has no route and the HDR names no 'target'."
             )
+            continue
+        if not hosts_prose(target):
+            errors.append(target_refusal(record.rel, target))
             continue
         by_target.setdefault(target, []).append(record)
 

--- a/docs/plugins/ai-literacy-superpowers/reference/harness-decision-records.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/harness-decision-records.md
@@ -145,9 +145,19 @@ cohort: b                  # optional
 | `cohort`, `proposed_cost`, `imported` | optional | — |
 
 **`target`** names the artifact the rule text is written into, and is required at
-**acceptance** for `agent-instruction`, `agent-reference`, `script-validator`,
-`regression-test` and `new-agent`. `harness-loop` and `turn-instructions` have
+**acceptance** for `agent-instruction`, `agent-reference`, `regression-test` and
+`new-agent`. `harness-loop`, `turn-instructions` and `script-validator` have
 fixed routes in `surfaces.yaml` and need no target of their own.
+
+**A target must be a markdown artifact (`.md`).** Rule text is markdown and is
+applied verbatim, so the artifact that *hosts* a rule has to be one that can hold
+markdown. The artifact a rule is *about* belongs in the rule's `**Tool**` field —
+those are different things, and conflating them is what put a generated markdown
+region into a YAML workflow and left it unparseable (#551).
+
+This is an allowlist rather than a list of known-bad types, because a denylist
+answers "is this one of the types we thought of?" — which is exactly the question
+nobody had asked about `.yml`.
 
 It binds at acceptance rather than at proposal because the Assayer frequently
 identifies a behaviour without knowing which of four agent files should own it.
@@ -228,6 +238,7 @@ itself past.
 | **Attribution** | An accepted HDR without `approver` and `approved_at`. |
 | **Surfaces** | An HDR naming a surface not declared in `surfaces.yaml`. |
 | **Target** | An accepted HDR whose classification has no route and which names no `target`. |
+| **Target type** | A `target` that is not a markdown artifact. Checked before routing, so a routed classification cannot silently discard a target its author named. |
 | **Derived state** | A record storing `status: superseded` or `expired`, or a non-null `superseded_by`. |
 | **Broken chain** | `supersedes` naming a record that does not exist, itself, or one already superseded by a different record. |
 | **Contradiction** | `provisional: false` alongside an `expires` date — a rule not on trial has no trial date. |
@@ -250,6 +261,16 @@ People then learn to ignore a red check, which costs far more than the
 un-evidenced legacy rules ever did.
 
 ## `surfaces.yaml`
+
+A `routes:` block **replaces** the defaults rather than merging with them, so
+every route a project relies on must be listed in its own file:
+
+```yaml
+routes:
+  harness-loop: HARNESS.md
+  turn-instructions: AGENTS.md
+  script-validator: HARNESS.md
+```
 
 ```yaml
 surfaces:

--- a/docs/superpowers/specs/2026-08-25-harness-write-path-integrity-design.md
+++ b/docs/superpowers/specs/2026-08-25-harness-write-path-integrity-design.md
@@ -1,0 +1,163 @@
+# Harness write-path integrity — design
+
+**Status:** proposed
+**Date:** 2026-08-25
+**Issue:** #551
+**Provenance:** found by running the harness evolution loop end to end for the
+first time (#548, PR #550). Every claim below cites an artifact in this
+repository: the assay at `harness/assay/2026-08-25T08-08Z-assay.md`, the
+superseded record `HDR-2026-08-25-the-periodic-check-suite-stops-at-its-first-failure-and-reports-the-rest-as-nothing`,
+and its retirement `HDR-2026-08-25-retire-periodic-check-suite-runner`.
+**Scope:** the write path — `/harness-accept`'s target refusal, the compiler's
+routing table, and what `/harness-check` verifies.
+**Explicitly out of scope:** the cost rule's blind spot, assay supersession, the
+missing record of a declined finding, and the metadata-fence truncation in
+`/harness-propose`. Each is real, each is recorded in `CHANGELOG.md` under
+0.79.0, and each needs its own evidence.
+
+## 1. Problem statement
+
+Accepting a `script-validator` record whose `target` was
+`.github/workflows/gc.yml` applied its rule text to that file and left it
+invalid YAML. The compiler appends a markdown region — an HTML comment marker, a
+heading and a bullet list — to whatever artifact a record names. GitHub Actions
+could no longer load the workflow, so the weekly garbage-collection job would not
+have run.
+
+`/harness-check` then reported `OK`.
+
+Four defects, in the order they failed:
+
+- **D1** — `/harness-check` validates the corpus, not the artifacts it writes.
+  `cmd_check` runs the record validator, computes the compile plan, and compares
+  each generated region byte-for-byte against what it would produce. All of that
+  passed against an unparseable file.
+- **D2** — `script-validator` corrupts its target by construction. Its targets
+  are scripts and workflows; the compiler emits only markdown.
+- **D3** — the `/harness-accept` refusal for rule text that "does not apply
+  cleanly to the target artifact" is a marker check. `compile_plan` verifies the
+  target exists and that its `BEGIN`/`END` markers are unambiguous, and has no
+  notion of what syntax the file accepts.
+- **D4** — a mis-targeted record cannot be corrected. `target` is copied verbatim
+  from an append-only assay and `/harness-accept` has no override, so the only
+  remedy is supersession.
+
+### Why the tests did not catch it
+
+The two fixed routes — `harness-loop → HARNESS.md` and
+`turn-instructions → AGENTS.md` — are both markdown. Only the free-`target`
+classifications can name another file type, and nothing in the Phase 2 acceptance
+criteria exercises one. The happy path is markdown all the way down.
+
+### The confusion underneath
+
+The retired record's rule text is `HARNESS.md` constraint syntax — `- **Rule**:`,
+`- **Enforcement**:`, `- **Tool**:`, `- **Scope**:`. It was always prose meant for
+a prose artifact, and it already carried `gc.yml` in its `**Tool**` field.
+
+The assay's finding metadata conflated **the artifact that hosts a rule** with
+**the artifact a rule is about**. Those are different things and the schema
+already has a place for each.
+
+## 2. Decision — targets host prose; the Tool names the code
+
+**A governance rule is prose about work, so the artifact that hosts it must be one
+that can hold prose.** The artifact the rule *concerns* is named in the rule's
+`**Tool**` field, which is where the retired record already named `gc.yml`.
+
+Three consequences:
+
+1. **`script-validator` gains a fixed route to `HARNESS.md`.** It joins
+   `harness-loop` and `turn-instructions` in the routes table. A rule about a
+   validator is still a rule about how work proceeds here, and `HARNESS.md` is
+   where those live.
+2. **A target that cannot host a markdown region is refused at
+   `/harness-accept`**, before anything is written, and by `/harness-compile`
+   before it writes.
+3. **The refusal names the remedy.** Not "invalid target" but: this rule's text is
+   markdown and `<path>` cannot hold it; name a markdown artifact as the target
+   and put `<path>` in the rule's `**Tool**` field.
+
+### What "can host prose" means
+
+A target must have a `.md` extension. That covers every artifact governance
+actually reaches: `HARNESS.md`, `AGENTS.md`, `CLAUDE.md`, agent files
+(`<name>.agent.md`), and skill files (`SKILL.md`).
+
+Deliberately an allowlist rather than a denylist of known-bad types. A denylist
+answers "is this one of the file types we thought of?", which is the question that
+was never asked about `.yml`.
+
+### The alternative considered and rejected
+
+**Teach the compiler comment syntax** — emit `# ` -prefixed regions into YAML,
+shell and Python, `// ` into JavaScript. This makes `script-validator` work as its
+name suggests and puts the rule beside the code it governs.
+
+Rejected on three grounds. It breaks the guarantee that applied text is
+byte-identical to the four-backtick block, because every line must be re-prefixed.
+`/harness-check`'s byte comparison would have to learn the inverse transform, so
+the check that failed here acquires more to get wrong. And it puts paragraphs of
+governance prose into executable files, which is noise at best.
+
+A middle option — refuse by default, allow a comment syntax declared per
+extension in `surfaces.yaml` — was also rejected: it builds both mechanisms, and
+the declared map becomes another thing that can drift from reality.
+
+## 3. Decision — `/harness-check` verifies its own targets
+
+With targets constrained to markdown, the corruption class is eliminated at
+source. The check is therefore **defence in depth, not the primary fix**, and is
+scoped accordingly:
+
+`/harness-check` fails when any record it would compile names a target that is
+not a permitted prose artifact.
+
+This catches a record that acquired a bad target another way — hand-edited, or
+carried in from a corpus written before this change. It does not attempt to parse
+arbitrary file types, because after this change it never governs one.
+
+**Superseded and retirement records are exempt**, because `compile_plan` already
+skips them. The corpus in this repository contains exactly one record with a
+non-markdown target and it is superseded, so this change must not fail the
+existing corpus. That is an acceptance criterion, not an assumption.
+
+## 4. D4 — the missing override
+
+With `script-validator` routed, the free-`target` classifications that remain are
+`agent-instruction`, `agent-reference`, `regression-test` and `new-agent`. Three
+of those four naturally name markdown; `regression-test` is the one that might
+reasonably want to name a test file, and under this design it may not.
+
+No `--target` override is added. The refusal now fires at `/harness-accept` before
+anything is written, and it names the remedy, so a mis-targeted record is caught
+at the gate rather than after the damage. Adding an override would let a human
+retarget a rule at the acceptance gate, which quietly moves authorship of the
+target from the assay to the approver — a larger change than this defect
+justifies, and one that deserves its own evidence.
+
+`regression-test` naming a markdown target is a known consequence and is recorded
+here rather than solved.
+
+## 5. Acceptance criteria
+
+- **A1** — accepting a record whose `target` is not `.md` is refused, nothing is
+  written, and the record stays `proposed`.
+- **A2** — the refusal message names the target, says the rule text is markdown,
+  and directs the author to the `**Tool**` field.
+- **A3** — `script-validator` routes to `HARNESS.md`; a `script-validator` record
+  with no `target` is accepted and applied there.
+- **A4** — `/harness-compile` refuses the same case rather than writing.
+- **A5** — `/harness-check` exits non-zero when a compilable record names a
+  non-markdown target.
+- **A6** — the existing corpus passes unchanged: the superseded record with
+  `target: .github/workflows/gc.yml` does not fail `/harness-check`, because
+  superseded records are not compiled.
+- **A7** — Layer-0 coverage for a non-markdown target, both at accept and at
+  check, so this cannot regress. This is the criterion Phase 2 never had.
+- **A8** — re-running the retired scenario end to end leaves `gc.yml` valid.
+
+## 6. Version
+
+Behaviour change to plugin files: minor bump, `0.79.0` → `0.80.0`, across the
+five CI-checked locations named in `CLAUDE.md`.

--- a/harness/surfaces.yaml
+++ b/harness/surfaces.yaml
@@ -15,9 +15,15 @@
 # Where a rule's TEXT goes, by classification. Two have a fixed home; the rest
 # name their own `target`, because nothing in the schema can infer which of four
 # agent files a given agent instruction belongs in.
+# NOTE: a `routes:` block REPLACES the defaults rather than merging with them
+# (`effective_routes`), so every route this project relies on must be listed here.
 routes:
   harness-loop: HARNESS.md
   turn-instructions: AGENTS.md
+  # A rule about a validator is still a rule about how work proceeds here, and
+  # its text is prose. Before this route existed the classification named a
+  # script as its target and the compiler appended markdown to it (#551).
+  script-validator: HARNESS.md
 
 # Who is TOLD about a rule, and how strongly it binds there. Compilation does not
 # write into these files: `.github/copilot-instructions.md`, `.cursor/rules/` and

--- a/tdad_tests/layer0_deterministic/test-harness-write-path.sh
+++ b/tdad_tests/layer0_deterministic/test-harness-write-path.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for harness write-path integrity
+# (spec 2026-08-25-harness-write-path-integrity-design.md; W1-W8 -> A1-A8).
+#
+# THIS SUITE EXISTS BECAUSE PHASE 2 NEVER HAD IT. The two fixed routes are both
+# markdown, so nothing in the original acceptance criteria ever pointed a record
+# at another file type. On 2026-08-25 a script-validator record targeting
+# .github/workflows/gc.yml was accepted, the compiler appended a markdown region
+# to a YAML file, the workflow stopped parsing, and /harness-check reported OK.
+#
+# W1 and W5 are the two that matter. W1 asserts the refusal fires BEFORE
+# anything is written; W5 asserts the check can see a bad target at all, which
+# is the thing that was silent.
+#
+# THE CLOCK IS INJECTED, NOT READ. --today and --now exist so this suite cannot
+# fail because it ran at the wrong hour.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$SCRIPT_DIR/../.."
+REG="$ROOT/ai-literacy-superpowers/scripts/harness-registrar.py"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+[ -f "$REG" ] || fail "harness registrar not found at $REG"
+
+PY=/usr/bin/python3
+command -v "$PY" >/dev/null 2>&1 || PY=python3
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+HARNESS="$TMP/harness"
+DEC="$HARNESS/decisions"
+ASSAY="$HARNESS/assay"
+mkdir -p "$DEC" "$ASSAY" "$TMP/.github/workflows"
+
+A1F="harness/assay/2026-08-25T08-08Z-assay.md"
+
+reg() {
+  set +e
+  OUT="$( cd "$TMP" && "$PY" "$REG" "$@" 2>&1 )"
+  RC=$?
+  set -e
+}
+
+refuses() {
+  [ "$RC" -ne 0 ] || fail "$1: expected non-zero exit, got 0. Out: $OUT"
+  printf '%s' "$OUT" | grep -q 'Traceback' \
+    && fail "$1: crashed instead of refusing. Out: $OUT"
+  printf '%s' "$OUT" | grep -qi -- "$2" \
+    || fail "$1: message must mention '$2'. Out: $OUT"
+}
+
+corpus_hash() {
+  ( cd "$TMP" && "$PY" -c "
+import hashlib, os
+h = hashlib.sha256()
+for dirpath, dirs, files in os.walk('harness'):
+    dirs.sort()
+    for name in sorted(files):
+        p = os.path.join(dirpath, name)
+        h.update(p.encode())
+        h.update(open(p,'rb').read())
+print(h.hexdigest())
+" )
+}
+
+# --- artifacts ---------------------------------------------------------------
+printf '# Harness\n\nHand-written.\n' > "$TMP/HARNESS.md"
+printf '# Agents\n\nHand-written.\n' > "$TMP/AGENTS.md"
+
+# A real workflow, valid YAML. If the write path ever touches it, it stops
+# being valid, which is the whole point of W8.
+cat > "$TMP/.github/workflows/gc.yml" <<'EOF'
+name: Garbage Collection
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+jobs:
+  gc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summary
+        if: always()
+        run: echo "done"
+EOF
+WF_BEFORE="$( "$PY" -c "import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" "$TMP/.github/workflows/gc.yml" )"
+
+cat > "$HARNESS/surfaces.yaml" <<'EOF'
+routes:
+  harness-loop: HARNESS.md
+  turn-instructions: AGENTS.md
+  script-validator: HARNESS.md
+
+surfaces:
+  claude-code:
+    targets: [CLAUDE.md, .claude/agents/]
+    supports: [advisory, validated, blocked]
+  ci:
+    targets: [.github/workflows/]
+    supports: [validated, blocked]
+EOF
+
+# --- the assay ---------------------------------------------------------------
+# finding-2 reproduces the real one: a script-validator whose target is a
+# workflow file. finding-9 is the same finding with no target at all, which
+# under the new route must land in HARNESS.md.
+cat > "$TMP/$A1F" <<'EOF'
+---
+assay: harness/assay/2026-08-25T08-08Z-assay.md
+date: 2026-08-25
+agent: harness-assayer
+model: claude-opus-5
+---
+
+# Assay 2026-08-25T08-08Z
+
+## Findings
+
+### finding-2 — The periodic check suite stops at its first failure
+
+Only the Summary step carries `if: always()`, so a failing step silences every
+later step. Six consecutive scheduled runs failed.
+
+```yaml
+classification: script-validator
+enforcement: validated
+surfaces: [ci]
+target: .github/workflows/gc.yml
+priority: P1
+evidence:
+  - .github/workflows/gc.yml
+overfitting_risk: low
+```
+
+#### Proposed rule
+
+````markdown
+- **Rule**: A periodic check suite must produce a result for every rule it
+  declares, in every run.
+- **Enforcement**: deterministic
+- **Tool**: `.github/workflows/gc.yml` (weekly schedule)
+- **Scope**: pr
+````
+
+#### Cost estimate
+
+Thirty minutes once; the weekly run looks worse before it looks better.
+
+### finding-9 — The same rule, routed rather than targeted
+
+Identical observation, with no target named, so the classification route decides.
+
+```yaml
+classification: script-validator
+enforcement: validated
+surfaces: [ci]
+priority: P1
+evidence:
+  - .github/workflows/gc.yml
+overfitting_risk: low
+```
+
+#### Proposed rule
+
+````markdown
+- **Rule**: A periodic check suite must produce a result for every rule it
+  declares, in every run.
+- **Enforcement**: deterministic
+- **Tool**: `.github/workflows/gc.yml` (weekly schedule)
+- **Scope**: pr
+````
+
+#### Cost estimate
+
+Thirty minutes once; the weekly run looks worse before it looks better.
+EOF
+
+printf 'Written by a human, in their own words, and not the proposal.\n' > "$TMP/cost.txt"
+
+# === W1 (A1): a non-markdown target is refused, and nothing is written =======
+reg propose --assay "$A1F" --finding finding-2 --today 2026-08-25
+[ "$RC" -eq 0 ] || fail "W1 setup: propose failed. Out: $OUT"
+HDR2="$( cd "$TMP" && ls harness/decisions/HDR-*.md | head -1 )"
+
+# Fill the tier-2 sections, so the refusal under test is the target refusal and
+# not the placeholder one. A test that passes on the wrong refusal proves
+# nothing about the thing it names.
+fill_tier2() {
+  "$PY" - "$1" <<'PYEOF'
+import re, sys
+p = sys.argv[1]; t = open(p).read()
+for h in ("Why this layer", "Enforcement", "Validation", "Rejected alternatives"):
+    t = re.sub(rf"(## {h}\n\n)_TODO[^\n]*\n", rf"\1Written by a human.\n", t)
+open(p, "w").write(t)
+PYEOF
+}
+fill_tier2 "$TMP/$HDR2"
+
+BEFORE="$(corpus_hash)"
+reg accept --hdr "$HDR2" --cost-file cost.txt \
+  --approver "tester" --now 2026-08-25T10:00Z
+refuses "W1" "cannot hold"
+AFTER="$(corpus_hash)"
+[ "$BEFORE" = "$AFTER" ] || fail "W1: corpus changed during a refused acceptance"
+grep -q '^status: proposed' "$TMP/$HDR2" || fail "W1: record must stay proposed"
+echo "W1 ok (non-markdown target refused at accept; nothing written)"
+
+# === W2 (A2): the refusal names the target and points at the Tool field ======
+printf '%s' "$OUT" | grep -q '\.github/workflows/gc\.yml' \
+  || fail "W2: refusal must name the offending target. Out: $OUT"
+printf '%s' "$OUT" | grep -qi 'tool' \
+  || fail "W2: refusal must direct the author to the Tool field. Out: $OUT"
+echo "W2 ok (refusal names the target and the remedy)"
+
+# === W8 (A8): the workflow file is untouched =================================
+WF_AFTER="$( "$PY" -c "import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" "$TMP/.github/workflows/gc.yml" )"
+[ "$WF_BEFORE" = "$WF_AFTER" ] || fail "W8: the workflow file was modified"
+grep -q 'BEGIN GENERATED' "$TMP/.github/workflows/gc.yml" \
+  && fail "W8: a generated region was written into a YAML workflow"
+echo "W8 ok (gc.yml untouched and free of generated markers)"
+
+# === W3 (A3): script-validator with no target routes to HARNESS.md ===========
+reg propose --assay "$A1F" --finding finding-9 --today 2026-08-25 --slug routed
+[ "$RC" -eq 0 ] || fail "W3 setup: propose failed. Out: $OUT"
+HDR9="harness/decisions/HDR-2026-08-25-routed.md"
+fill_tier2 "$TMP/$HDR9"
+reg accept --hdr "$HDR9" --cost-file cost.txt \
+  --approver "tester" --now 2026-08-25T10:05Z
+[ "$RC" -eq 0 ] || fail "W3: routed script-validator must be accepted. Out: $OUT"
+grep -q 'BEGIN GENERATED' "$TMP/HARNESS.md" \
+  || fail "W3: the rule was not applied to HARNESS.md"
+grep -q 'periodic check suite must produce a result' "$TMP/HARNESS.md" \
+  || fail "W3: rule text missing from HARNESS.md"
+echo "W3 ok (script-validator routes to HARNESS.md and applies)"
+
+# === W4 (A4): compile refuses the same case rather than writing ==============
+# Hand-accept it, attribution included. A record flipped to accepted without
+# approver/cost fails the validator for an unrelated reason, and a test that
+# fails for the wrong reason proves nothing.
+"$PY" - "$TMP/$HDR2" <<'PYEOF'
+import re, sys
+p = sys.argv[1]; t = open(p).read()
+t = t.replace("status: proposed", "status: accepted", 1)
+t = t.replace('cost: ""',
+              'cost: |\n  Written by a human, in their own words.', 1)
+t = re.sub(r"^supersedes:", "approver: tester\napproved_at: 2026-08-25T10:00Z\nsupersedes:",
+           t, count=1, flags=re.M)
+t = re.sub(r"(## Cost\n\n)_TODO[^\n]*\n", r"\1Written by a human, in their own words.\n", t)
+open(p, "w").write(t)
+PYEOF
+BEFORE="$(corpus_hash)"
+reg compile
+refuses "W4" "cannot hold"
+WF_AFTER="$( "$PY" -c "import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" "$TMP/.github/workflows/gc.yml" )"
+[ "$WF_BEFORE" = "$WF_AFTER" ] || fail "W4: compile modified the workflow file"
+echo "W4 ok (compile refuses a non-markdown target)"
+
+# === W5 (A5): check exits non-zero on a compilable bad target ================
+reg check
+[ "$RC" -ne 0 ] || fail "W5: check must fail on a non-markdown target. Out: $OUT"
+printf '%s' "$OUT" | grep -q '\.github/workflows/gc\.yml' \
+  || fail "W5: check must name the offending target. Out: $OUT"
+echo "W5 ok (check sees the bad target)"
+
+# === W6 (A6): a superseded record with a bad target does NOT fail check ======
+# The existing corpus carries exactly this shape. Retiring is how the real one
+# was resolved, and the fix must not fail the corpus it was written for.
+cat > "$TMP/harness/decisions/HDR-2026-08-25-retire.md" <<EOF
+---
+id: HDR-2026-08-25-retire
+title: Retire the periodic check suite rule
+status: accepted
+classification: script-validator
+enforcement: validated
+surfaces: [ci]
+provisional: false
+evidence:
+  - $A1F#finding-2
+proposed_cost: |
+  None.
+cost: |
+  Withdrawing where the rule was pointed, not the rule itself.
+proposer:
+  agent: human
+  model: n/a
+  assay: $A1F
+approver: tester
+approved_at: 2026-08-25T10:10Z
+supersedes: $(basename "$HDR2" .md)
+superseded_by: null
+---
+
+## Finding
+
+The rule was applied to a YAML workflow and left it unparseable.
+
+## Rule
+
+Withdrawn.
+
+## Cost
+
+Withdrawing where the rule was pointed, not the rule itself.
+
+## Why this layer
+
+Same layer as the rule it withdraws.
+
+## Enforcement
+
+None. A retirement compiles nothing.
+
+## Validation
+
+The workflow parses and carries no generated region.
+
+## Rejected alternatives
+
+No change: the next compile would re-break the workflow.
+EOF
+# The retirement makes HDR2 superseded, so it drops out of the compile plan and
+# the index must be regenerated to match.
+reg compile
+[ "$RC" -eq 0 ] || fail "W6: compile must succeed once the bad target is superseded. Out: $OUT"
+reg check
+[ "$RC" -eq 0 ] || fail "W6: a superseded bad target must not fail check. Out: $OUT"
+echo "W6 ok (superseded records are exempt; existing corpus survives)"
+
+# === W7 (A7): the allowlist is an allowlist, not a denylist =================
+# A type nobody thought of must refuse too. `.yml` was the one nobody thought of.
+# Mutates HDR9, which is accepted and still IN FORCE - HDR2 is superseded by now
+# and correctly exempt, so it would prove nothing.
+for ext in json sh py toml; do
+  "$PY" - "$TMP/$HDR9" "$ext" <<'PYEOF'
+import re, sys
+p, ext = sys.argv[1], sys.argv[2]
+t = open(p).read()
+line = f"target: some/file.{ext}"
+if re.search(r"^target: .*$", t, flags=re.M):
+    t = re.sub(r"^target: .*$", line, t, count=1, flags=re.M)
+else:
+    t = re.sub(r"^supersedes:", line + "\nsupersedes:", t, count=1, flags=re.M)
+open(p, "w").write(t)
+PYEOF
+  reg check
+  [ "$RC" -ne 0 ] || fail "W7: check must refuse a .$ext target. Out: $OUT"
+  printf '%s' "$OUT" | grep -q "some/file.$ext" \
+    || fail "W7: check must name the .$ext target. Out: $OUT"
+done
+echo "W7 ok (allowlist refuses json, sh, py, toml)"
+
+echo "harness write path: all checks passed (W1-W8)"

--- a/tdad_tests/layer0_deterministic/test-harness-write-path.sh
+++ b/tdad_tests/layer0_deterministic/test-harness-write-path.sh
@@ -180,7 +180,7 @@ printf 'Written by a human, in their own words, and not the proposal.\n' > "$TMP
 # === W1 (A1): a non-markdown target is refused, and nothing is written =======
 reg propose --assay "$A1F" --finding finding-2 --today 2026-08-25
 [ "$RC" -eq 0 ] || fail "W1 setup: propose failed. Out: $OUT"
-HDR2="$( cd "$TMP" && ls harness/decisions/HDR-*.md | head -1 )"
+HDR2="$( cd "$TMP" && printf '%s\n' harness/decisions/HDR-*.md | head -1 )"
 
 # Fill the tier-2 sections, so the refusal under test is the target refusal and
 # not the placeholder one. A test that passes on the wrong refusal proves


### PR DESCRIPTION
Closes #551

Spec committed first: `docs/superpowers/specs/2026-08-25-harness-write-path-integrity-design.md`.

## The defect

Accepting `HDR-2026-08-25-the-periodic-check-suite-...` with `target:
.github/workflows/gc.yml` appended a markdown region — HTML comment marker,
heading, bullet list — to a YAML file:

```
Psych::SyntaxError: could not find expected ':' while scanning
a simple key at line 288 column 1
```

GitHub Actions could no longer load the workflow. `/harness-check` reported `OK`.

Both fixed routes (`harness-loop`, `turn-instructions`) are markdown, so nothing
in the Phase 2 acceptance criteria ever pointed a record at another file type.

## The fix

**A target must be a markdown artifact.** Rule text is markdown applied verbatim,
so the artifact that *hosts* a rule must hold markdown. The artifact a rule is
*about* goes in its `**Tool**` field — the retired record already named `gc.yml`
there. Conflating the two is the root error.

`/harness-accept`, `/harness-compile` and `/harness-check` all refuse, and the
refusal names the target and directs the author to `**Tool**`.

**Checked before routing.** A routed classification would otherwise silently
ignore a target its author named. Quietly discarding what someone wrote is the
failure shape this mechanism exists to refuse.

**An allowlist, not a denylist** — a denylist answers "is this one of the types we
thought of?", which is the question nobody asked about `.yml`.

**`script-validator` routes to `HARNESS.md`.** It was unusable: its targets are
code files by definition and the compiler emits only markdown.

## Rejected: teaching the compiler comment syntax

Emitting `# `-prefixed regions into YAML/shell/Python would make
`script-validator` work as named. Rejected — it breaks the byte-identical
guarantee (every line re-prefixed), gives the check that already failed here an
inverse transform to get wrong, and puts governance prose into executable files.

## Verification

- `test-harness-write-path.sh` (W1–W8): refusal at accept / compile / check, the
  routed case, the superseded exemption, and four file types beyond the one that
  failed. Observed red before the fix and green after.
- All Layer 0 suites pass; `harness check: OK` against the real corpus, which
  contains exactly the superseded `.yml`-target record this must not fail (A6).
- Reference page updated: target-type rule, the new refusal row, and the routes
  block.

## Known limitation, documented not fixed

A `routes:` block in `surfaces.yaml` **replaces** the defaults rather than merging,
despite `effective_routes`' docstring claiming otherwise — so a project declaring
any custom route silently loses every default, including `harness-loop`. Real, and
deliberately left for its own change rather than widened into this one.

## Still open from the same run

The cost rule's blind spot, assay supersession, the missing record of a declined
finding, and the metadata-fence truncation in `/harness-propose`. Recorded under
0.79.0 in `CHANGELOG.md`.

Version: 0.79.0 → 0.80.0 across the five CI-checked locations.