### PR TITLE
Carry the Assayer's reasoning into the decision record, attributed and distinct

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.80.0",
+  "plugin_version": "0.81.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.80.0"
+      "version": "0.81.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 0.81.0 — 2026-08-25
+
+### Fixed — the Assayer's reasoning reaches the record
+
+`/harness-propose` took the observation as everything before the first fence
+(`_parse_finding`), so the Assayer's "why this layer", overfitting assessment and
+validation plan — which conventionally sit *after* the YAML metadata block — were
+discarded. The record then arrived with four `_TODO` placeholders while a better
+argument sat one directory away. Reconstructing those sections by hand is how an
+error ("no enforcement gap", where the generated report said `gap`) got into a
+record that is now accepted and frozen. See #554.
+
+- **New optional `## Assayer's reasoning` section**, carrying that prose verbatim
+  and labelled as the Assayer's. Extraction is positional — the text between the
+  metadata block and the first `####` subsection — so it takes whatever was
+  written there and makes no judgement about which paragraph matters.
+- **It does not satisfy the tier-2 sections.** `## Why this layer`,
+  `## Enforcement`, `## Validation` and `## Rejected alternatives` stay `_TODO`
+  placeholders, and acceptance is still refused until a human writes them. The
+  split mirrors `proposed_cost` and `cost` and exists for the same reason:
+  pre-filled reasoning reads exactly like considered reasoning, and nothing
+  downstream could tell them apart. Pre-filling those sections was considered and
+  rejected as the cost-rule failure one section over.
+- **Omitted entirely when a finding carries no such prose**, rather than emitted
+  empty. An empty heading invites someone to fill it, and this one is not theirs.
+- **`overfitting_risk` now reaches the HDR frontmatter** when the finding declares
+  it. Not added to `FINDING_REQUIRED_KEYS` — making it mandatory changes the assay
+  contract and deserves its own evidence.
+- **`## Finding` and `## Rule` are unchanged.** The rule block is still
+  byte-identical to the assay's four-backtick block, nested fences intact; that
+  guarantee is asserted directly rather than assumed, because this change touches
+  the same parser.
+- **Layer 0 suite** `test-assayer-reasoning.sh` (R1–R9), fixtured on finding-2 of
+  `2026-08-25T08-08Z-assay.md` — the finding the defect was found on.
+
 ## 0.80.0 — 2026-08-25
 
 ### Fixed — the harness evolution write path

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.80.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.81.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-42-2E8B57?style=flat-square)](#skills-42)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.80.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.81.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.80.0",
+  "version": "0.81.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/scripts/harness-registrar.py
+++ b/ai-literacy-superpowers/scripts/harness-registrar.py
@@ -202,10 +202,17 @@ class FindingError(Exception):
 
 
 class Finding:
-    def __init__(self, fid, title, observation, meta, rule_block, cost_estimate):
+    def __init__(self, fid, title, observation, meta, rule_block, cost_estimate,
+                 reasoning=""):
         self.id = fid
         self.title = title
         self.observation = observation
+        # The Assayer's argument for its own finding. Carried verbatim and kept
+        # STRUCTURALLY SEPARATE from the human's tier-2 sections, exactly as
+        # `proposed_cost` is kept separate from `cost`: pre-filled reasoning
+        # reads precisely like considered reasoning, and nothing downstream
+        # could tell them apart.
+        self.reasoning = reasoning
         self.meta = meta
         self.rule_block = rule_block
         self.cost_estimate = cost_estimate
@@ -301,6 +308,23 @@ def _parse_finding(path: str, fid: str, title: str, block: str) -> Finding:
             "block. A finding must say what was observed."
         )
 
+    # The Assayer's reasoning: prose between the end of the metadata block and
+    # the first `#### ` subsection. A POSITIONAL rule, not a semantic one — it
+    # takes whatever was written there and makes no judgement about which
+    # paragraph is load-bearing.
+    #
+    # Before this existed, `observation` stopped at the first fence and the rest
+    # of the preamble was discarded, so the "why this layer", overfitting and
+    # validation-plan paragraphs never reached the record. A human then wrote
+    # those sections from scratch beside a file that already held a better
+    # version (#554).
+    reasoning = ""
+    fence_end = preamble.find("```", preamble.find("```") + 3)
+    if fence_end != -1:
+        nl = preamble.find("\n", fence_end)
+        if nl != -1:
+            reasoning = preamble[nl + 1:].strip()
+
     if "Proposed rule" not in subsections:
         raise FindingError(f"{where}: no '#### Proposed rule' section.")
     if "Cost estimate" not in subsections:
@@ -324,7 +348,8 @@ def _parse_finding(path: str, fid: str, title: str, block: str) -> Finding:
             )
         rule_block = blocks[0]
 
-    return Finding(fid, title.strip(), observation, meta, rule_block, cost_estimate)
+    return Finding(fid, title.strip(), observation, meta, rule_block,
+                   cost_estimate, reasoning)
 
 
 # --------------------------------------------------------------------------- #
@@ -379,6 +404,12 @@ def render_hdr(hdr_id: str, finding: Finding, assay_path: str, assay_fm: dict,
     # and left for the human at the acceptance gate when it is not.
     if meta.get("target"):
         lines.append(f"target: {meta['target']}")
+    # A claim the Assayer made about its own finding, and exactly what a reviewer
+    # at the acceptance gate should weigh. Carried when present, omitted when
+    # not; deliberately NOT added to FINDING_REQUIRED_KEYS, because making it
+    # mandatory changes the assay contract and deserves its own evidence.
+    if meta.get("overfitting_risk"):
+        lines.append(f"overfitting_risk: {meta['overfitting_risk']}")
     lines.append("evidence:")
     for item in evidence:
         lines.append(f"  - {item}")
@@ -398,6 +429,20 @@ def render_hdr(hdr_id: str, finding: Finding, assay_path: str, assay_fm: dict,
     lines.append("")
     lines.append(finding.observation)
     lines.append("")
+
+    # Omitted entirely when the finding carries none, rather than emitted empty.
+    # An empty section invites someone to fill it, and this one is not theirs to
+    # fill — the whole point is that these words are the Assayer's and the four
+    # tier-2 sections below are the approver's.
+    if finding.reasoning:
+        lines.append("## Assayer's reasoning")
+        lines.append("")
+        lines.append("_Written by the Assayer, carried verbatim. Not the "
+                     "approver's words, and not a substitute for the sections "
+                     "below._")
+        lines.append("")
+        lines.append(finding.reasoning)
+        lines.append("")
 
     lines.append("## Rule")
     lines.append("")

--- a/docs/plugins/ai-literacy-superpowers/reference/harness-decision-records.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/harness-decision-records.md
@@ -143,6 +143,7 @@ cohort: b                  # optional
 | `target` | when the classification has no route | `status: accepted` |
 | `validator` | optional | — |
 | `cohort`, `proposed_cost`, `imported` | optional | — |
+| `overfitting_risk` | optional | — |
 
 **`target`** names the artifact the rule text is written into, and is required at
 **acceptance** for `agent-instruction`, `agent-reference`, `regression-test` and
@@ -196,6 +197,27 @@ classifications whose reach extends beyond a single agent — `## Why this layer
 
 Every required section must be non-empty. A heading with nothing under it is a
 missing section that looks present, which is worse than an absent one.
+
+### `## Assayer's reasoning` — optional, and never the approver's
+
+Emitted by `/harness-propose` when the finding carries prose between its metadata
+block and its first `####` subsection — conventionally the Assayer's "why this
+layer", overfitting assessment and validation plan. Carried **verbatim** and
+labelled, so a reader cannot mistake it for the approver's words.
+
+It is **not** a substitute for the tier-2 sections and does not satisfy them.
+Those stay `_TODO` placeholders and acceptance is still refused until a human
+writes them.
+
+The split mirrors `proposed_cost` and `cost`, and exists for the same reason:
+pre-filled reasoning reads exactly like considered reasoning, and nothing
+downstream could tell them apart. Before it existed, extraction stopped at the
+first fence and this prose was discarded, so a human wrote the four sections from
+scratch beside a file that already held a better version (#554).
+
+The section is **omitted entirely** when a finding carries no such prose, rather
+than emitted empty — an empty heading invites someone to fill it, and this one is
+not theirs to fill.
 
 ### The Rule block
 

--- a/docs/superpowers/specs/2026-08-25-carry-assayer-reasoning-design.md
+++ b/docs/superpowers/specs/2026-08-25-carry-assayer-reasoning-design.md
@@ -1,0 +1,129 @@
+# Carry the Assayer's reasoning into the decision record — design
+
+**Status:** proposed
+**Date:** 2026-08-25
+**Issue:** #554
+**Provenance:** raised as O9 in
+`docs/superpowers/objections/harness-provenance-citation.md` during the first
+end-to-end loop run (#548, PR #550), and confirmed in use while accepting
+`HDR-2026-08-25-the-periodic-check-suite-stops-at-its-first-failure-and-reports-the-rest-as-nothing`.
+**Scope:** what `/harness-propose` extracts from a finding, and what
+`render_hdr` writes.
+**Out of scope:** the four remaining defects from the same run — #553, #555,
+#556, #557, #558 — and the routes trap #559.
+
+## 1. Problem statement
+
+`_parse_finding` takes the observation as everything before the first fence:
+
+```python
+observation = preamble.split("```", 1)[0].strip()
+```
+
+The Assayer's `**Why this layer**`, `**Overfitting risk**` and
+`**Validation plan**` paragraphs conventionally sit *after* the YAML metadata
+block, so none reaches the record. They are not `####` subsections either, so
+`subsections` does not hold them. `overfitting_risk` is dropped from the
+metadata as well: it is not in `FINDING_REQUIRED_KEYS` and `render_hdr` never
+reads it.
+
+`render_hdr` then emits four `_TODO —` placeholders, and a human writes the
+argument from scratch beside a file that already contains a better one.
+
+### Observed cost
+
+In `harness/assay/2026-08-25T08-08Z-assay.md`, finding-2's metadata fence opens
+at line 31 of the finding; the three paragraphs are at 44, 56 and 60. All were
+discarded, including the sharpest sentence in the finding:
+
+> a fix that makes the job green by tolerating failures is worse than the defect
+
+Reconstructing the four sections by hand introduced an error: the `Enforcement`
+section asserted "no enforcement gap" while the generated report said
+`ci | validated | none | gap`. That record is accepted and frozen with the error
+in it.
+
+## 2. Decision — mirror `proposed_cost`
+
+The corpus has already solved this problem once. The Assayer's cost estimate is
+preserved verbatim in `proposed_cost`; the human writes `cost`; the two are
+structurally distinct, so nothing downstream can mistake one for the other.
+
+**Apply the same split to the reasoning.**
+
+A new `## Assayer's reasoning` section carries the finding's post-metadata prose
+verbatim, explicitly attributed. The four tier-2 sections stay `_TODO`
+placeholders that a human writes.
+
+```text
+## Finding               observation, verbatim
+## Assayer's reasoning   post-metadata prose, verbatim, attributed   <- new
+## Rule                  verbatim
+## Cost                  human
+## Why this layer        human, _TODO
+## Enforcement           human, _TODO
+## Validation            human, _TODO
+## Rejected alternatives human, _TODO
+```
+
+### Why not pre-fill the tier-2 sections
+
+Because that is the cost-rule failure one section over. The build spec is
+deliberate that the assay carries a validation plan and an overfitting
+assessment while the HDR's tier-2 sections are human-authored; the gap between
+them is the point. Pre-filled reasoning reads exactly like considered reasoning,
+and nothing downstream could tell them apart — the same sentence the build spec
+uses about cost.
+
+### Why not move the convention instead
+
+Requiring the Assayer to place its reasoning *above* the metadata block would
+let existing extraction reach it with no format change. Rejected: it lands the
+argument inside `## Finding`, whose contract is "what was observed, with evidence
+references". Conflating an observation with an argument about it makes the
+Finding section a worse record of what was seen, and the assay format reference
+would have to be rewritten against a convention that exists only to work around
+a parser.
+
+### What counts as the reasoning
+
+The prose between the end of the metadata block and the first `####` subsection.
+That is a positional rule, not a semantic one: it captures whatever the Assayer
+wrote there and makes no judgement about which paragraphs are load-bearing.
+
+A finding with nothing there is normal — most `no-change` findings will have
+none — so the section is **omitted entirely** rather than emitted empty. An
+empty section invites someone to fill it, and this one is not theirs to fill.
+
+## 3. Decision — `overfitting_risk` reaches the frontmatter
+
+It is a claim the Assayer made about its own finding, and it is exactly what a
+reviewer at the acceptance gate should weigh. It is carried when present and
+omitted when absent. It is **not** added to `FINDING_REQUIRED_KEYS`: making it
+mandatory would change the assay contract, which is a separate decision with its
+own evidence.
+
+## 4. Acceptance criteria
+
+- **A1** — a finding with post-metadata prose produces an HDR with an
+  `## Assayer's reasoning` section whose content is byte-identical to that prose.
+- **A2** — the section is attributed, so a reader cannot mistake it for the
+  approver's words.
+- **A3** — a finding with no post-metadata prose produces an HDR with no such
+  section, and no empty heading.
+- **A4** — the four tier-2 sections are still `_TODO` placeholders, and
+  acceptance is still refused while they are unfilled.
+- **A5** — `overfitting_risk` reaches the HDR frontmatter when present, and is
+  absent when not.
+- **A6** — `## Finding` is unchanged: still the observation only, still ending at
+  the first fence.
+- **A7** — `## Rule` is unchanged and still byte-identical to the assay's
+  four-backtick block. This is the guarantee that must survive the change.
+- **A8** — Layer 0 coverage using finding-2 of `2026-08-25T08-08Z-assay.md` as
+  the fixture, since that is the finding this defect was found on.
+- **A9** — the existing corpus still validates, and `/harness-check` passes.
+
+## 5. Version
+
+Behaviour change to plugin files: minor bump, `0.80.0` → `0.81.0`, across the
+five CI-checked locations named in `CLAUDE.md`.

--- a/tdad_tests/layer0_deterministic/test-assayer-reasoning.sh
+++ b/tdad_tests/layer0_deterministic/test-assayer-reasoning.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for carrying the Assayer's reasoning into the record
+# (spec 2026-08-25-carry-assayer-reasoning-design.md; R1-R9 -> A1-A9).
+#
+# R7 IS THE ONE THAT MUST NOT BREAK. The rule block is the byte-identical source
+# the compiler applies, and this change touches the same parser. A regression
+# there is worse than the defect being fixed.
+#
+# R2 IS WHY THE SECTION EXISTS AT ALL. The Assayer's words and the approver's
+# must be distinguishable in the record, for the same reason proposed_cost and
+# cost are separate fields: pre-filled reasoning reads exactly like considered
+# reasoning, and nothing downstream can tell them apart.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$SCRIPT_DIR/../.."
+REG="$ROOT/ai-literacy-superpowers/scripts/harness-registrar.py"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+[ -f "$REG" ] || fail "harness registrar not found at $REG"
+
+PY=/usr/bin/python3
+command -v "$PY" >/dev/null 2>&1 || PY=python3
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/harness/decisions" "$TMP/harness/assay"
+printf '# Harness\n\nHand-written.\n' > "$TMP/HARNESS.md"
+
+A="harness/assay/2026-08-25T08-08Z-assay.md"
+
+reg() {
+  set +e
+  OUT="$( cd "$TMP" && "$PY" "$REG" "$@" 2>&1 )"
+  RC=$?
+  set -e
+}
+
+cat > "$TMP/harness/surfaces.yaml" <<'EOF'
+routes:
+  harness-loop: HARNESS.md
+  turn-instructions: AGENTS.md
+  script-validator: HARNESS.md
+
+surfaces:
+  ci:
+    targets: [.github/workflows/]
+    supports: [validated, blocked]
+EOF
+
+# finding-2 reproduces the real one: reasoning AFTER the metadata block, which
+# is where the Assayer conventionally puts it and where extraction never looked.
+# finding-5 has none, which is normal for no-change.
+cat > "$TMP/$A" <<'EOF'
+---
+assay: harness/assay/2026-08-25T08-08Z-assay.md
+date: 2026-08-25
+agent: harness-assayer
+model: claude-opus-5
+---
+
+# Assay 2026-08-25T08-08Z
+
+## Findings
+
+### finding-2 — The periodic check suite stops at its first failure
+
+Only the Summary step carries `if: always()`, so a failing step silences every
+later step. Six consecutive scheduled runs failed.
+
+```yaml
+classification: script-validator
+enforcement: validated
+surfaces: [ci]
+priority: P1
+evidence:
+  - .github/workflows/gc.yml
+overfitting_risk: low
+```
+
+**Why this layer, and why no existing owner absorbs it.** `/harness-gc` runs the
+rules on demand. What it cannot own is the scheduled runner when nobody invokes
+it: the whole value of a weekly job is the weeks nobody looks.
+
+**Overfitting risk: low.** The rule states a property of any periodic check
+suite and encodes neither of the two rules that happened to fail.
+
+**Validation plan.** Re-run with a deliberately failing early step and assert
+every later step still produces a conclusion. A fix that makes the job green by
+tolerating failures is worse than the defect.
+
+#### Proposed rule
+
+````markdown
+- **Rule**: A periodic check suite must produce a result for every rule it
+  declares, in every run.
+
+  Note the indentation and the fence below; both are part of the text.
+
+  ```bash
+  gh run view --json jobs
+  ```
+- **Enforcement**: deterministic
+- **Scope**: pr
+````
+
+#### Cost estimate
+
+Thirty minutes once; the weekly run looks worse before it looks better.
+
+### finding-5 — Nothing needed to change
+
+The decision corpus is empty because nothing has been proposed yet.
+
+```yaml
+classification: no-change
+enforcement: advisory
+surfaces: []
+priority: P3
+evidence:
+  - harness/decisions/index.md
+```
+
+#### Proposed rule
+
+No change.
+
+#### Cost estimate
+
+None.
+EOF
+
+# === R1/R2/R6/R7: reasoning carried, attributed, and nothing else disturbed ==
+reg propose --assay "$A" --finding finding-2 --today 2026-08-25 --slug reasoned
+[ "$RC" -eq 0 ] || fail "R1: propose failed. Out: $OUT"
+H="$TMP/harness/decisions/HDR-2026-08-25-reasoned.md"
+[ -f "$H" ] || fail "R1: HDR not written"
+
+grep -q "^## Assayer's reasoning" "$H" \
+  || fail "R1: no '## Assayer's reasoning' section. Out: $(sed -n '/^## /p' "$H")"
+
+"$PY" - "$H" "$TMP/$A" <<'PYEOF'
+import re, sys
+hdr, assay = open(sys.argv[1]).read(), open(sys.argv[2]).read()
+
+def section(text, name):
+    m = re.search(rf"^## {re.escape(name)}\n(.*?)(?=^## |\Z)", text, re.M | re.S)
+    return m.group(1) if m else None
+
+# R1: byte-identical to the assay's post-metadata prose.
+body = assay.split("### finding-2", 1)[1].split("### finding-5", 1)[0]
+# Past the CLOSING fence of the yaml block specifically. Splitting on bare
+# fences walks into the rule block's nested ```bash and lands in the wrong place.
+ystart = body.index("```yaml")
+yend = body.index("```", ystart + len("```yaml"))
+after = body[body.index("\n", yend) + 1:]
+expected = after.split("#### ", 1)[0].strip()
+got = section(hdr, "Assayer's reasoning")
+assert got is not None, "R1: section missing"
+# strip the attribution line, whatever form it takes, then compare the prose
+prose = "\n".join(l for l in got.strip().split("\n")
+                  if not l.strip().startswith("_")).strip()
+assert prose == expected, (
+    "R1: reasoning is not byte-identical.\n--- expected ---\n"
+    f"{expected!r}\n--- got ---\n{prose!r}")
+
+# R2: attributed - the section must name the Assayer, not leave it ambiguous.
+assert re.search(r"assayer", got, re.I), f"R2: section is not attributed: {got[:200]!r}"
+
+# R6: ## Finding is still the observation only, ending at the first fence.
+finding = section(hdr, "Finding").strip()
+assert finding.startswith("Only the Summary step"), f"R6: {finding[:80]!r}"
+assert "Why this layer" not in finding, "R6: reasoning leaked into ## Finding"
+assert "```" not in finding, "R6: a fence leaked into ## Finding"
+
+# R7: the rule block is byte-identical, fences and indentation intact.
+hb = re.findall(r"^````markdown\n(.*?)^````$", hdr, re.M | re.S)
+ab = re.findall(r"^````markdown\n(.*?)^````$", body, re.M | re.S)
+assert len(hb) == 1 and hb[0] == ab[0], "R7: rule block changed"
+assert "```bash" in hb[0], "R7: the inner fence was eaten"
+print("R1 ok (reasoning carried verbatim)")
+print("R2 ok (attributed to the Assayer)")
+print("R6 ok (## Finding unchanged)")
+print("R7 ok (rule block still byte-identical)")
+PYEOF
+
+# === R5: overfitting_risk reaches the frontmatter ============================
+grep -q '^overfitting_risk: low$' "$H" \
+  || fail "R5: overfitting_risk missing from frontmatter"
+echo "R5 ok (overfitting_risk carried)"
+
+# === R4: the tier-2 placeholders are untouched, and acceptance still refuses ==
+for s in "Why this layer" "Enforcement" "Validation" "Rejected alternatives"; do
+  "$PY" - "$H" "$s" <<'PYEOF'
+import re, sys
+t, name = open(sys.argv[1]).read(), sys.argv[2]
+m = re.search(rf"^## {re.escape(name)}\n\n(.*?)$", t, re.M)
+assert m and m.group(1).startswith("_TODO"), f"R4: '{name}' is not a placeholder"
+PYEOF
+done
+printf 'A cost in the approver own words.\n' > "$TMP/cost.txt"
+reg accept --hdr harness/decisions/HDR-2026-08-25-reasoned.md \
+  --cost-file cost.txt --approver tester --now 2026-08-25T10:00Z
+[ "$RC" -ne 0 ] || fail "R4: acceptance must still refuse while placeholders stand"
+printf '%s' "$OUT" | grep -qi 'placeholder' \
+  || fail "R4: refusal should name the placeholders. Out: $OUT"
+echo "R4 ok (placeholders intact; acceptance still refused)"
+
+# === R3: a finding with no post-metadata prose emits no section ==============
+reg propose --assay "$A" --finding finding-5 --today 2026-08-25 --slug quiet
+[ "$RC" -eq 0 ] || fail "R3: propose failed for no-change finding. Out: $OUT"
+Q="$TMP/harness/decisions/HDR-2026-08-25-quiet.md"
+grep -q "Assayer's reasoning" "$Q" \
+  && fail "R3: emitted a reasoning section for a finding that has none"
+grep -q '^overfitting_risk:' "$Q" \
+  && fail "R5: emitted overfitting_risk when the finding declares none"
+echo "R3 ok (section omitted, not emitted empty)"
+echo "R5b ok (overfitting_risk omitted when absent)"
+
+# === R9: the corpus still validates =========================================
+set +e
+VOUT="$( cd "$TMP" && "$PY" "$ROOT/ai-literacy-superpowers/scripts/check-harness-decisions.py" 2>&1 )"
+VRC=$?
+set -e
+[ "$VRC" -eq 0 ] || fail "R9: corpus does not validate. Out: $VOUT"
+echo "R9 ok (corpus validates)"
+
+echo "assayer reasoning: all checks passed (R1-R9)"


### PR DESCRIPTION
Closes #554

Spec committed first: `docs/superpowers/specs/2026-08-25-carry-assayer-reasoning-design.md`.

## The defect

`_parse_finding` took the observation as everything before the first fence:

```python
observation = preamble.split("```", 1)[0].strip()
```

The Assayer's `**Why this layer**`, `**Overfitting risk**` and
`**Validation plan**` paragraphs conventionally sit *after* the YAML metadata
block, so none reached the record. `overfitting_risk` was dropped from the
metadata too.

In `harness/assay/2026-08-25T08-08Z-assay.md`, finding-2's fence opens at line 31
of the finding; the three paragraphs are at 44, 56 and 60. All discarded —
including the sharpest sentence in the finding:

> a fix that makes the job green by tolerating failures is worse than the defect

Reconstructing the four sections by hand introduced an error: `Enforcement`
asserted "no enforcement gap" while the generated report said
`ci | validated | none | gap`. That record is accepted and frozen with it.

## The fix — mirror `proposed_cost`

The corpus already solved this once. The Assayer's estimate lives verbatim in
`proposed_cost`, the human writes `cost`, and the two are structurally distinct.

A new optional **`## Assayer's reasoning`** section carries the post-metadata
prose verbatim and labelled. Extraction is **positional** — text between the
metadata block and the first `####` subsection — so it takes whatever was written
there and makes no judgement about which paragraph is load-bearing.

**It does not satisfy the tier-2 sections.** They stay `_TODO` and acceptance is
still refused until a human writes them (R4 asserts both).

## Rejected alternatives

**Pre-fill the tier-2 sections from the Assayer's prose.** This is the cost-rule
failure one section over. The build spec is deliberate that the assay carries a
validation plan while the HDR's tier-2 sections are human-authored; the gap is the
point. Pre-filled reasoning reads exactly like considered reasoning.

**Move the convention** — require the Assayer to write above the metadata block so
existing extraction reaches it. Rejected: it lands the argument inside
`## Finding`, whose contract is "what was observed", conflating an observation
with an argument about it.

## Verification

- `test-assayer-reasoning.sh` (R1–R9), fixtured on finding-2 of the real assay.
  Observed red before the fix, green after.
- **R7 is the one that matters**: the rule block must stay byte-identical, nested
  ` ```bash ` fence intact, because this change touches the same parser that
  produces it. Asserted directly rather than assumed.
- R3 asserts the section is *omitted* for a finding with no such prose, not
  emitted empty — an empty heading invites someone to fill it, and this one is not
  theirs to fill.
- All Layer 0 suites pass; `harness check: OK`.
- Re-proposing finding-2 from the real assay now carries the full ownership
  argument into the record.

## One thing found while testing

The first test run failed on a *fixture* bug, not the implementation: computing
the expected prose with `split("```", 2)` walked into the rule block's nested
` ```bash ` fence. The implementation was right and the test was wrong. Fixed by
locating the yaml block's closing fence specifically — worth noting because it is
the same nested-fence hazard R7 guards the real parser against.

Version: 0.80.0 → 0.81.0 across the five CI-checked locations.