### PR TITLE
Require a validator to resolve, be runnable, and name the rule it enforces

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.81.0",
+  "plugin_version": "0.82.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.81.0"
+      "version": "0.82.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+## 0.82.0 — 2026-08-25
+
+### Fixed — a validator must be shown to enforce the rule that claims it
+
+`has_validator` tested that a named file exists, and nothing else. Existence is
+the entire link between a written rule and the code enforcing it — `render_region`
+only ever emits prose, so governance never edits code — and `achieved_for` gates
+the top of the enforcement ladder on that one boolean. See #553.
+
+Observed against this repository before the change: `validator: README.md`,
+`CHANGELOG.md` and `.gitignore` all reported a rule as `validated`, and
+`["docs/index.md", "nope/missing.py"]` passed because `any` accepted the doc while
+the real checker was missing.
+
+- **Every listed path must resolve.** `all`, not `any`.
+- **Each must look runnable** — the executable bit, or a `.py`, `.sh`, `.bash`,
+  `.js` or `.rb` suffix. A shape test to exclude documents, not a guarantee of
+  executability.
+- **At least one must name the record it enforces** — the HDR `id` in the file's
+  text. A comment is enough. This is the condition that makes the claim
+  falsifiable: a runnable, invoked script that checks something else is still not
+  enforcement of *this* rule.
+- **The report names the specific failure** instead of one collapsed string:
+  `no validator declared`, `validator not found: <path>`,
+  `validator is not runnable: <path>`, or `validator does not name <hdr-id>`.
+  "Nobody declared one" and "one was declared and it is missing" are different
+  failures with different remedies, and collapsing them was the same class of
+  defect being fixed.
+- **Existence is checked across every path before runnability**, so a missing
+  validator is reported ahead of a present-but-unrunnable one.
+
+**Invocation is deliberately not checked.** The obvious test — a reference from a
+workflow — passes `README.md`, which two of this repository's workflows grep,
+while wrongly downgrading a validator invoked from inside another script. A test
+that passes the worst case and fails good ones is not worth having.
+
+### Adopter impact
+
+A record declaring a validator that does not name it drops from `validated` to
+`advisory` on the next compile. That is a downgrade toward honesty — the report
+stops claiming enforcement it cannot demonstrate — and the reason string says
+exactly which condition failed. This repository's corpus declares no validators,
+so its enforcement report is byte-identical.
+
+- **Layer 0 suite** `test-validator-binding.sh` (V1–V7), fixtured directly on the
+  #553 evidence table. V4 asserts a bound validator still reaches `validated`,
+  because a check strict enough to reject everything would replace an
+  over-claiming report with a useless one.
+- `test-harness-compile.sh` C12b now asserts the absent path is *named* rather
+  than matching the old collapsed message, and C13's fixture gained the one-line
+  binding comment — which is what the new convention costs an adopter.
+
 ## 0.81.0 — 2026-08-25
 
 ### Fixed — the Assayer's reasoning reaches the record

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.81.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.82.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-42-2E8B57?style=flat-square)](#skills-42)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.81.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.82.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.81.0",
+  "version": "0.82.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/scripts/harness-registrar.py
+++ b/ai-literacy-superpowers/scripts/harness-registrar.py
@@ -988,22 +988,80 @@ def target_of(record: Record, routes: dict[str, str]) -> str | None:
     return str(target) if target else None
 
 
-def has_validator(record: Record, root: str) -> bool:
-    """A validator counts only if the file it names actually exists.
+# Suffixes we treat as plausibly runnable. A SHAPE test, not a guarantee: it
+# exists to exclude documents, which is the observed failure, not to prove that
+# anything executes.
+RUNNABLE_SUFFIXES = (".py", ".sh", ".bash", ".js", ".rb")
 
-    A declared-but-absent validator is the failure the report is built to catch,
-    so believing the declaration would defeat the mechanism at the one point it
-    is supposed to bite.
+
+def validator_state(record: Record, root: str) -> tuple[bool, str]:
+    """(counts, reason). Existence alone is not evidence of enforcement.
+
+    `validator` is the ENTIRE link between a written rule and the code that
+    enforces it — `render_region` only ever emits prose, so governance never
+    edits code — and `achieved_for` gates the top of the ladder on this one
+    result. Before #553 the test was `any(os.path.exists(...))`, so
+    `validator: README.md` reported a rule as `validated`, and a list passed when
+    one entry resolved while the real checker was missing.
+
+    Three conditions, each closing an observed row of that table:
+
+    1. EVERY listed path resolves. `all`, not `any`.
+    2. Each looks runnable — executable bit, or a known script suffix.
+    3. At least one names this record's id.
+
+    (3) is the one that makes the claim falsifiable. A runnable, invoked script
+    that checks something else is still not enforcement of THIS rule, and nothing
+    short of a binding can tell the difference. The binding is one-directional
+    and cheap — a comment naming the record is enough — and it makes the
+    validator self-describing, which is worth having on its own.
+
+    Deliberately NOT checked: whether anything invokes the validator. The obvious
+    test is a reference from a workflow, and `README.md` is referenced by two of
+    this repository's workflows because they grep its contents — so the test
+    passes the archetypal bad validator while wrongly downgrading any validator
+    invoked from inside another script.
     """
     value = record.fm.get("validator")
     if not value:
-        return False
-    items = value if isinstance(value, list) else [value]
-    return any(os.path.exists(os.path.join(root, str(item))) for item in items)
+        return False, "no validator declared"
+    items = [str(i) for i in (value if isinstance(value, list) else [value])]
+
+    # Existence across every path first, THEN runnability. A missing validator is
+    # a harder failure than a present-but-unrunnable one, and reporting the
+    # second while the first is also true sends someone to fix the wrong thing.
+    for item in items:
+        if not os.path.exists(os.path.join(root, item)):
+            return False, f"validator not found: {item}"
+    for item in items:
+        path = os.path.join(root, item)
+        if not (item.endswith(RUNNABLE_SUFFIXES) or os.access(path, os.X_OK)):
+            return False, f"validator is not runnable: {item}"
+
+    for item in items:
+        try:
+            with open(os.path.join(root, item), encoding="utf-8", errors="replace") as fh:
+                if record.id in fh.read():
+                    return True, ""
+        except OSError:
+            continue
+    return False, (f"validator does not name {record.id}, so it cannot be shown "
+                   "to enforce this rule")
 
 
-def achieved_for(intended: str, supports: list[str], validated: bool) -> tuple[str, str]:
-    """(achieved, reason). See the spec's §5.1 ladder."""
+def has_validator(record: Record, root: str) -> bool:
+    return validator_state(record, root)[0]
+
+
+def achieved_for(intended: str, supports: list[str], validated: bool,
+                 why: str = "no validator declared or resolvable") -> tuple[str, str]:
+    """(achieved, reason). See the spec's §5.1 ladder.
+
+    `why` is passed through rather than synthesised, because "nobody declared a
+    validator" and "one was declared and it is missing" are different failures
+    with different remedies, and collapsing them is the same class of defect the
+    enforcement report exists to prevent (#553).
+    """
     supports = [s for s in supports if s in LADDER]
     if intended in supports:
         candidate, reason = intended, ""
@@ -1015,19 +1073,19 @@ def achieved_for(intended: str, supports: list[str], validated: bool) -> tuple[s
         reason = f"surface supports at most {candidate}"
     if LADDER[candidate] >= LADDER["validated"] and not validated:
         if "advisory" in supports:
-            return "advisory", "no validator declared or resolvable"
-        return "none", "no validator declared or resolvable"
+            return "advisory", why
+        return "none", why
     return candidate, reason
 
 
 def enforcement_rows(record: Record, surfaces: dict, root: str) -> list[dict]:
     intended = str(record.fm.get("enforcement") or "advisory")
-    validated = has_validator(record, root)
+    validated, why = validator_state(record, root)
     rows = []
     for name in record.surfaces:
         entry = surfaces.get(name) or {}
         supports = [str(s) for s in (entry.get("supports") or [])]
-        achieved, reason = achieved_for(intended, supports, validated)
+        achieved, reason = achieved_for(intended, supports, validated, why)
         if not supports:
             achieved, reason = "none", f"surface '{name}' is not declared"
         rows.append({

--- a/docs/plugins/ai-literacy-superpowers/reference/harness-decision-records.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/harness-decision-records.md
@@ -164,6 +164,26 @@ It binds at acceptance rather than at proposal because the Assayer frequently
 identifies a behaviour without knowing which of four agent files should own it.
 That is the human's decision, made at the gate beside the cost.
 
+**A `validator` must resolve, be runnable, and name the record it enforces.**
+Every listed path must exist; each must carry the executable bit or a `.py`,
+`.sh`, `.bash`, `.js` or `.rb` suffix; and at least one must contain the record's
+`id`. A comment is enough.
+
+The binding is what makes the enforcement claim falsifiable. Existence alone is
+not evidence: before #553 the test was `any(os.path.exists(...))`, so
+`validator: README.md` reported a rule as `validated`, and a list passed when one
+entry resolved while the real checker was missing. A runnable, invoked script
+that checks something else is still not enforcement of *this* rule.
+
+Whether anything *invokes* the validator is deliberately not checked. The obvious
+test — a reference from a workflow — passes `README.md`, which two of this
+repository's workflows grep, while wrongly downgrading validators invoked from
+inside another script.
+
+The enforcement report names the specific failure: `no validator declared`,
+`validator not found: <path>`, `validator is not runnable: <path>`, or
+`validator does not name <hdr-id>`.
+
 **`validator`** is a path, or list of paths, to whatever actually enforces the
 rule. Its absence is never an error — an unenforced rule is not a malformed one —
 but it is what the [enforcement report](enforcement-report-format.md) uses to

--- a/docs/superpowers/specs/2026-08-25-validator-binding-design.md
+++ b/docs/superpowers/specs/2026-08-25-validator-binding-design.md
@@ -1,0 +1,142 @@
+# Validator binding — design
+
+**Status:** proposed
+**Date:** 2026-08-25
+**Issue:** #553
+**Provenance:** found while checking whether the #551 fix removed the ability to
+enforce rules on scripts. It did not — `render_region` only ever emitted prose,
+so governance has never edited code, which makes the `validator` field the
+*entire* link between a written rule and the code enforcing it. Evidence table
+reproduced against this repository at commit 91cd510 and recorded in #553.
+**Scope:** `has_validator`, the enforcement-report reason strings, and the
+`validator` field's contract.
+**Out of scope:** #555, #556, #557, #558, #559.
+
+## 1. Problem statement
+
+```python
+def has_validator(record: Record, root: str) -> bool:
+    """A validator counts only if the file it names actually exists."""
+    value = record.fm.get("validator")
+    if not value:
+        return False
+    items = value if isinstance(value, list) else [value]
+    return any(os.path.exists(os.path.join(root, str(item))) for item in items)
+```
+
+Existence is the whole test, and `any` means a list passes when one entry
+resolves. Observed against this repository:
+
+| `validator:` | `has_validator` |
+| --- | --- |
+| `README.md` | **True** |
+| `CHANGELOG.md` | **True** |
+| `.gitignore` | **True** |
+| `["docs/index.md", "nope/missing.py"]` | **True** |
+| an unrelated real script | **True** |
+| `scripts/does-not-exist.py` | False |
+
+`achieved_for` gates the top of the enforcement ladder on this single boolean, so
+`validator: README.md` is the difference between a rule reporting `advisory`
+(honest: written down, nothing enforces it) and `validated` or `blocked` (a claim
+that something refuses violations).
+
+The failure is silent and it flatters. Nothing corrupts and no check goes red —
+the report simply asserts enforcement that does not exist, which is the one thing
+`harness/enforcement-report.md` was built to prevent.
+
+## 2. What must be true for `validated` to mean what it says
+
+1. The named path exists.
+2. It is plausibly runnable.
+3. Something invokes it.
+4. It checks **this** rule.
+
+Only (1) is checked today, and weakly.
+
+### Why (3) is not in this change
+
+"Referenced by a workflow or hook" looks like the natural test for invocation and
+is close to worthless here. `README.md` is referenced by
+`.github/workflows/version-check.yml` and `tdad-scenario-check.yml`, which grep
+its contents — so the archetypal bad validator satisfies the invocation test.
+
+Worse, it carries a real false-negative cost: a validator invoked from inside
+another script reads as uninvoked, and a genuinely enforced rule would silently
+drop to `advisory`. A test that passes the worst case and fails good ones is not
+worth having.
+
+## 3. Decision — resolve, runnable, and bound to the rule
+
+`has_validator` requires all three:
+
+- **Every** listed path resolves. `all`, not `any`. A list whose real checker is
+  missing must not pass because a doc beside it exists.
+- **Each path looks runnable**: the executable bit is set, or the suffix is one of
+  `.py`, `.sh`, `.bash`, `.js`, `.rb`. This is a shape test, not a guarantee — it
+  exists to exclude documents, which is the observed failure, not to prove
+  executability.
+- **At least one listed path names the record it enforces** — the HDR `id`
+  appears in the file's text.
+
+The third is the one that makes the claim falsifiable. A runnable, invoked script
+that checks something else is still not enforcement of *this* rule, and nothing
+short of a binding can tell the difference.
+
+The binding is deliberately one-directional and cheap: the validator mentions the
+record. A comment is enough. That also makes the validator self-describing, which
+is worth having on its own — a checker that says which governance rule it exists
+for is easier to keep honest than one that does not.
+
+### The adopter cost, stated plainly
+
+Any existing record declaring a validator that does not name it will drop from
+`validated` to `advisory` on the next compile. That is a **downgrade toward
+honesty**: the report stops claiming enforcement it cannot demonstrate. It is
+still a change adopters will see, and the reason string has to say exactly why so
+nobody has to read this spec to understand their report.
+
+This repository's corpus declares no validators, so nothing here changes.
+
+## 4. Decision — the report distinguishes the states
+
+`achieved_for` currently collapses everything into one reason:
+
+```text
+no validator declared or resolvable
+```
+
+That sentence covers four different situations and tells an adopter nothing about
+which one they are in. Replace it with a specific reason per state:
+
+| State | Reason |
+| --- | --- |
+| No `validator` field | `no validator declared` |
+| A listed path does not exist | `validator not found: <path>` |
+| A listed path is not runnable | `validator is not runnable: <path>` |
+| No listed path names the record | `validator does not name <hdr-id>, so it cannot be shown to enforce this rule` |
+
+The distinction is the point of the report. "Nobody declared one" and "one was
+declared and it is missing" are different failures with different remedies, and
+collapsing them is the same class of defect as the one being fixed.
+
+## 5. Acceptance criteria
+
+- **A1** — a `validator` naming a document (`README.md`, `CHANGELOG.md`,
+  `.gitignore`) does not reach `validated`.
+- **A2** — a list passes only when **every** entry resolves.
+- **A3** — a runnable script that does not name the record does not reach
+  `validated`.
+- **A4** — a runnable script that names the record **does** reach `validated`.
+- **A5** — the executable bit qualifies a path with no recognised suffix.
+- **A6** — each state produces its own reason string in the enforcement report.
+- **A7** — a record with no `validator` still reports `advisory`, unchanged.
+- **A8** — the existing corpus is unaffected: `/harness-check` passes and the
+  enforcement report is byte-identical before and after.
+- **A9** — Layer 0 coverage using the #553 evidence table as fixtures, so the
+  loophole cannot return.
+
+## 6. Version
+
+Behaviour change to plugin files: minor bump, `0.81.0` → `0.82.0`, across the
+five CI-checked locations named in `CLAUDE.md`.

--- a/docs/superpowers/specs/2026-08-25-validator-binding-design.md
+++ b/docs/superpowers/specs/2026-08-25-validator-binding-design.md
@@ -130,7 +130,11 @@ collapsing them is the same class of defect as the one being fixed.
 - **A4** — a runnable script that names the record **does** reach `validated`.
 - **A5** — the executable bit qualifies a path with no recognised suffix.
 - **A6** — each state produces its own reason string in the enforcement report.
-- **A7** — a record with no `validator` still reports `advisory`, unchanged.
+- **A7** — a record with no `validator` behaves exactly as before: the ladder
+  decides the downgrade, so it reports `advisory` on a surface that supports
+  advisory and `none` on one that does not. (Corrected during implementation —
+  the original wording said "still reports `advisory`", which is only true on
+  surfaces supporting it; `ci` supports `validated` and `blocked` only.)
 - **A8** — the existing corpus is unaffected: `/harness-check` passes and the
   enforcement report is byte-identical before and after.
 - **A9** — Layer 0 coverage using the #553 evidence table as fixtures, so the

--- a/tdad_tests/layer0_deterministic/test-harness-compile.sh
+++ b/tdad_tests/layer0_deterministic/test-harness-compile.sh
@@ -412,12 +412,23 @@ achieved, why = rows.get("claude-code", ("?", "?"))
 assert achieved == "advisory", (
     "C12b: a declared-but-ABSENT validator lifted the degradation; "
     f"claude-code achieved {achieved!r}")
-assert "no validator" in why, f"C12b: the reason should name the validator, got {why!r}"
+# Since #553 the reason is specific per state rather than one collapsed string,
+# so this asserts the stronger contract: the ABSENT PATH ITSELF is named. The
+# previous message ("no validator declared or resolvable") covered four distinct
+# situations and named none of them.
+assert "ghost-that-does-not-exist.sh" in why, (
+    f"C12b: the reason must name the absent validator path, got {why!r}")
+assert "not found" in why, (
+    f"C12b: an absent validator must be distinguishable from an undeclared one, "
+    f"got {why!r}")
 PYEOF
 echo "C12b ok (an absent validator does not lift the degradation)"
 
 # === C13: a resolvable validator lifts the degradation ======================
-printf '#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n' \
+# Since #553 a validator must NAME the record it enforces: existing, runnable and
+# unrelated is not evidence of enforcement. The binding is one comment, and this
+# fixture is what that convention costs an adopter.
+printf '#!/usr/bin/env bash\nset -euo pipefail\n# Enforces HDR-2026-08-21-blocked-everywhere\nexit 0\n' \
   > "$TMP/.github/workflows/enforce.sh"
 rm -f "$DEC/HDR-2026-08-21-blocked-everywhere.md"
 mkhdr <<'EOF'

--- a/tdad_tests/layer0_deterministic/test-validator-binding.sh
+++ b/tdad_tests/layer0_deterministic/test-validator-binding.sh
@@ -168,8 +168,9 @@ R3="$(probe HDR-2026-08-25-none)";        rm -f harness/decisions/HDR-2026-08-25
 printf '%s' "$R1" | grep -qi 'runnable'   || fail "V6: non-runnable needs its own reason: $R1"
 printf '%s' "$R2" | grep -qi 'not found'  || fail "V6: missing needs its own reason: $R2"
 printf '%s' "$R3" | grep -qi 'no validator declared' || fail "V6: absent field needs its own reason: $R3"
-[ "$R1" != "$R2" ] && [ "$R2" != "$R3" ] \
-  || fail "V6: states must not collapse to one reason"
+if [ "$R1" = "$R2" ] || [ "$R2" = "$R3" ] || [ "$R1" = "$R3" ]; then
+  fail "V6: states must not collapse to one reason: $R1 / $R2 / $R3"
+fi
 echo "V6 ok (four states, four reasons)"
 
 # === V7: an undeclared validator behaves exactly as before ===================

--- a/tdad_tests/layer0_deterministic/test-validator-binding.sh
+++ b/tdad_tests/layer0_deterministic/test-validator-binding.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for validator binding
+# (spec 2026-08-25-validator-binding-design.md; V1-V9 -> A1-A9).
+#
+# THE FIXTURES ARE THE #553 EVIDENCE TABLE. Each row was observed returning True
+# from has_validator against the real repository before this change, so the suite
+# is a direct transcription of the loophole rather than a guess at its shape.
+#
+# V4 IS THE ONE THAT MUST STAY TRUE. It is easy to write a check so strict that
+# nothing reaches `validated` and call the problem solved; that would replace an
+# over-claiming report with a useless one.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$SCRIPT_DIR/../.."
+REG="$ROOT/ai-literacy-superpowers/scripts/harness-registrar.py"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+[ -f "$REG" ] || fail "harness registrar not found at $REG"
+
+PY=/usr/bin/python3
+command -v "$PY" >/dev/null 2>&1 || PY=python3
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+cd "$TMP"
+mkdir -p harness/decisions scripts docs
+
+# Artifacts a validator might plausibly (and implausibly) name.
+printf '# Readme\n' > README.md
+printf '# Changelog\n' > CHANGELOG.md
+printf 'node_modules\n' > .gitignore
+printf '# doc\n' > docs/index.md
+printf '#!/usr/bin/env python3\nprint("unrelated")\n' > scripts/unrelated.py
+printf '#!/usr/bin/env python3\n# Enforces HDR-2026-08-25-bound\nprint("ok")\n' > scripts/bound.py
+printf '#!/usr/bin/env bash\n# Enforces HDR-2026-08-25-bound\n' > scripts/bound.sh
+# No recognised suffix, but executable — V5.
+printf '#!/usr/bin/env bash\n# Enforces HDR-2026-08-25-bound\n' > scripts/bound-noext
+chmod +x scripts/bound-noext
+
+hdr() {  # hdr <slug> <validator-yaml>
+  local slug="$1" validator="$2"
+  cat > "harness/decisions/HDR-2026-08-25-$slug.md" <<EOF
+---
+id: HDR-2026-08-25-$slug
+title: A rule about $slug
+status: accepted
+classification: agent-instruction
+enforcement: validated
+surfaces: [ci]
+provisional: false
+target: HARNESS.md
+$validator
+evidence:
+  - harness/assay/2026-08-25T08-08Z-assay.md#finding-1
+cost: |
+  Written by a human.
+proposer:
+  agent: harness-assayer
+  model: claude-opus-5
+  assay: harness/assay/2026-08-25T08-08Z-assay.md
+approver: tester
+approved_at: 2026-08-25T10:00Z
+supersedes: null
+superseded_by: null
+---
+
+## Finding
+
+Observed.
+
+## Rule
+
+\`\`\`\`markdown
+- **Rule**: Something.
+\`\`\`\`
+
+## Cost
+
+Written by a human.
+EOF
+}
+
+# achieved + reason for one record, straight from the library.
+probe() {
+  "$PY" - "$1" "${2:-}" <<'PYEOF'
+import importlib.util, sys, os
+spec = importlib.util.spec_from_file_location("reg", os.environ["REG"])
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+records = m.load_records(".")
+rec = next(r for r in records if r.id == sys.argv[1])
+supports = (sys.argv[2].split(",") if len(sys.argv) > 2 and sys.argv[2]
+            else ["validated", "blocked"])
+surfaces = {"ci": {"targets": [".github/workflows/"], "supports": supports}}
+rows = m.enforcement_rows(rec, surfaces, ".")
+print(f"{rows[0]['achieved']}|{rows[0]['reason']}")
+PYEOF
+}
+export REG
+
+expect() {  # expect <slug> <achieved> <reason-substring> <label>
+  hdr "$1" "$2" >/dev/null 2>&1 || true
+  local got; got="$(probe "HDR-2026-08-25-$1")"
+  local achieved="${got%%|*}" reason="${got#*|}"
+  [ "$achieved" = "$3" ] \
+    || fail "$5: expected achieved='$3', got '$achieved' (reason: $reason)"
+  if [ -n "$4" ]; then
+    printf '%s' "$reason" | grep -qi -- "$4" \
+      || fail "$5: reason must mention '$4', got '$reason'"
+  fi
+  echo "$5"
+}
+
+# === V1: documents must not reach validated ==================================
+for doc in README.md CHANGELOG.md .gitignore; do
+  slug="doc-$(printf '%s' "$doc" | tr -d '.' | tr '[:upper:]' '[:lower:]')"
+  hdr "$slug" "validator: $doc"
+  got="$(probe "HDR-2026-08-25-$slug")"
+  [ "${got%%|*}" != "validated" ] \
+    || fail "V1: '$doc' reached validated ($got)"
+  rm -f "harness/decisions/HDR-2026-08-25-$slug.md"
+done
+echo "V1 ok (README.md, CHANGELOG.md, .gitignore rejected)"
+
+# === V2: a list passes only when every entry resolves ========================
+hdr listpartial "validator: [docs/index.md, nope/missing.py]"
+got="$(probe HDR-2026-08-25-listpartial)"
+[ "${got%%|*}" != "validated" ] || fail "V2: partial list reached validated ($got)"
+printf '%s' "$got" | grep -qi 'not found' \
+  || fail "V2: reason should name the missing path, got '$got'"
+rm -f harness/decisions/HDR-2026-08-25-listpartial.md
+echo "V2 ok (partial list rejected, missing path named)"
+
+# === V3: a runnable script that does not name the record =====================
+hdr unbound "validator: scripts/unrelated.py"
+got="$(probe HDR-2026-08-25-unbound)"
+[ "${got%%|*}" != "validated" ] || fail "V3: unrelated script reached validated ($got)"
+printf '%s' "$got" | grep -qi 'name' \
+  || fail "V3: reason should say the validator does not name the record, got '$got'"
+rm -f harness/decisions/HDR-2026-08-25-unbound.md
+echo "V3 ok (unrelated runnable script rejected)"
+
+# === V4: a runnable script that names the record DOES reach validated ========
+# The suite must prove the check is not merely strict.
+expect bound "validator: scripts/bound.py" validated "" \
+  "V4 ok (bound .py reaches validated)"
+rm -f harness/decisions/HDR-2026-08-25-bound.md
+hdr bound "validator: [scripts/bound.py, scripts/bound.sh]"
+got="$(probe HDR-2026-08-25-bound)"
+[ "${got%%|*}" = "validated" ] || fail "V4b: fully-resolving bound list rejected ($got)"
+rm -f harness/decisions/HDR-2026-08-25-bound.md
+echo "V4b ok (list of bound validators reaches validated)"
+
+# === V5: the executable bit qualifies a path with no recognised suffix =======
+hdr bound "validator: scripts/bound-noext"
+got="$(probe HDR-2026-08-25-bound)"
+[ "${got%%|*}" = "validated" ] || fail "V5: executable with no suffix rejected ($got)"
+rm -f harness/decisions/HDR-2026-08-25-bound.md
+echo "V5 ok (executable bit qualifies)"
+
+# === V6: each state has its own reason =======================================
+hdr nonrunnable "validator: docs/index.md"
+R1="$(probe HDR-2026-08-25-nonrunnable)"; rm -f harness/decisions/HDR-2026-08-25-nonrunnable.md
+hdr missing "validator: scripts/absent.py"
+R2="$(probe HDR-2026-08-25-missing)";     rm -f harness/decisions/HDR-2026-08-25-missing.md
+hdr none ""
+R3="$(probe HDR-2026-08-25-none)";        rm -f harness/decisions/HDR-2026-08-25-none.md
+printf '%s' "$R1" | grep -qi 'runnable'   || fail "V6: non-runnable needs its own reason: $R1"
+printf '%s' "$R2" | grep -qi 'not found'  || fail "V6: missing needs its own reason: $R2"
+printf '%s' "$R3" | grep -qi 'no validator declared' || fail "V6: absent field needs its own reason: $R3"
+[ "$R1" != "$R2" ] && [ "$R2" != "$R3" ] \
+  || fail "V6: states must not collapse to one reason"
+echo "V6 ok (four states, four reasons)"
+
+# === V7: an undeclared validator behaves exactly as before ===================
+# The ladder decides which downgrade applies, and this change must not move it.
+# On a surface supporting `advisory` an unvalidated rule lands there; on one that
+# does not (ci supports only validated/blocked) it lands on `none`.
+hdr none ""
+got="$(probe HDR-2026-08-25-none advisory,validated,blocked)"
+[ "${got%%|*}" = "advisory" ] \
+  || fail "V7: surface supporting advisory should downgrade to advisory, got '$got'"
+got="$(probe HDR-2026-08-25-none validated,blocked)"
+[ "${got%%|*}" = "none" ] \
+  || fail "V7: surface without advisory should give none, got '$got'"
+rm -f harness/decisions/HDR-2026-08-25-none.md
+echo "V7 ok (ladder unchanged: advisory where supported, none where not)"
+
+echo "validator binding: all checks passed (V1-V7)"


### PR DESCRIPTION
Closes #553

Spec committed first: `docs/superpowers/specs/2026-08-25-validator-binding-design.md`.

## The defect

`has_validator` tested that a file exists. That boolean gates the top of the
enforcement ladder in `achieved_for`, and — since `render_region` only ever emits
prose and governance never edits code — the `validator` field is the **entire**
link between a written rule and the code enforcing it.

Observed before the change:

| `validator:` | result |
| --- | --- |
| `README.md` | **validated** |
| `CHANGELOG.md` | **validated** |
| `.gitignore` | **validated** |
| `["docs/index.md", "nope/missing.py"]` | **validated** (`any` accepted the doc) |
| an unrelated real script | **validated** |

Silent, and it flatters: nothing corrupts, no check goes red, the report just
asserts enforcement that does not exist.

## The fix

Every listed path resolves (`all`, not `any`); each looks runnable (executable bit
or `.py`/`.sh`/`.bash`/`.js`/`.rb`); and **at least one names the record's `id`**.

The binding is the condition that makes the claim falsifiable. A runnable, invoked
script that checks something else is still not enforcement of *this* rule, and
nothing short of a binding distinguishes them. It costs one comment, and it makes
the validator self-describing.

The report now names which condition failed — `no validator declared`,
`validator not found: <path>`, `validator is not runnable: <path>`,
`validator does not name <hdr-id>` — instead of one string covering four states.
Collapsing them was the same class of defect being fixed.

## Rejected: invocation detection

The ticket's option 2 was "require a reference from something that runs". A
control check killed it: **`README.md` is referenced by `version-check.yml` and
`tdad-scenario-check.yml`**, which grep its contents. So the test passes the
archetypal bad validator — while risking a silent downgrade for any validator
invoked from inside another script. A test that passes the worst case and fails
good ones is not worth having.

## Verification

- `test-validator-binding.sh` (V1–V7), fixtured directly on the #553 table.
  Observed red on `V1: 'README.md' reached validated` before the fix.
- **V4 is deliberate**: it asserts a *bound* validator still reaches `validated`.
  A check strict enough to reject everything would replace an over-claiming report
  with a useless one.
- V7 asserts the ladder is unmoved — `advisory` where the surface supports it,
  `none` where it does not.
- A8 verified: this corpus declares no validators, and `harness/enforcement-report.md`
  is byte-identical after compile.

## Two existing tests changed, deliberately

- **C12b** asserted `"no validator" in why`, encoding the old collapsed string. Its
  own comment said "the reason should name the validator" — which the old message
  never did. Now asserts the **absent path itself** is named, and that it is
  distinguishable from an undeclared one. Stronger, not weaker.
- **C13**'s fixture created a runnable `enforce.sh` that never named the record —
  exactly the case this change must reject. It gained the one-line binding comment,
  which is what the convention costs an adopter, demonstrated in our own suite.

## Adopter impact

A record whose validator does not name it drops from `validated` to `advisory` on
the next compile. That is a downgrade toward honesty, and the reason says which
condition failed.

## Spec correction

A7 originally read "still reports `advisory`". That is only true on surfaces
supporting advisory; `ci` supports `validated`/`blocked` only, so an unvalidated
rule lands on `none`. Corrected in the spec rather than left disagreeing with the
tests.

Version: 0.81.0 → 0.82.0 across the five CI-checked locations.