### PR TITLE
Record a finding a human declines

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.82.0",
+  "plugin_version": "0.83.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.82.0"
+      "version": "0.83.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## 0.83.0 — 2026-08-25
+
+### Added — a finding a human declines is now recorded
+
+The corpus recorded what **entered** and had no way to record what a human
+weighed and refused. During the first loop run, finding-1 of
+`2026-08-25T08-08Z-assay.md` was read, adversarially reviewed and declined on
+evidence, and nothing in the corpus shows it. See #555.
+
+`rejected` was already a **storable** status that nothing produced — the schema
+anticipated this outcome and no command reached it.
+
+- **`/harness-propose --reject --reason-file <path>`** writes a record at
+  `status: rejected`, carrying `## Finding` and a non-empty `## Rejection`.
+- **Declining costs one section.** No `## Rule` (nothing enters force), no `cost`
+  key (nothing is demanded, and an empty cost would imply an obligation that will
+  never be met), no tier-2 sections (no layer is being argued for). Friction on
+  the path we want people to take means the path is not taken.
+- **The reason is supplied up front, never a placeholder.** A rejection has no
+  later gate — it is written at `rejected` and never accepted — so a placeholder
+  would either block the write, since `propose` validates before writing, or sit
+  in the corpus permanently recording that someone said no and nothing about why.
+  `--reason-file` is a file rather than an argument for the same reason
+  `--cost-file` is.
+- **It reaches no artifact, consumes no cycle slot, and stays out of
+  `/harness-timeline`.** The `no-change` precedent argues the other way, but a
+  `no-change` record is *accepted* and carries `approved_at`; a rejection was
+  never in force. It is not an intervention of size zero — it is not an
+  intervention. It appears in `harness/decisions/index.md` with state `rejected`.
+- **The relaxation is keyed on status and does not leak.** An accepted record
+  still requires `## Rule`, `## Cost` and its tier-2 sections; asserted directly,
+  because a leak would let a rule enter force with no rule text and no cost.
+- **Layer 0 suite** `test-declined-findings.sh` (D1–D9).
+
+### Why it matters beyond tidiness
+
+A later assay reads prior assays and will re-find the same class of problem.
+Nothing told it a human had already considered and declined one, so it could not
+distinguish a recurring problem from one already adjudicated — the distinction the
+two-assay promotion threshold turns on. Corroboration by a finding that was
+already refused is not corroboration.
+
 ## 0.82.0 — 2026-08-25
 
 ### Fixed — a validator must be shown to enforce the rule that claims it

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.82.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.83.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-42-2E8B57?style=flat-square)](#skills-42)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.82.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.83.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.82.0",
+  "version": "0.83.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/scripts/check-harness-decisions.py
+++ b/ai-literacy-superpowers/scripts/check-harness-decisions.py
@@ -519,7 +519,10 @@ def check_hdr(path: str, surfaces: dict, errors: list[str],
         if field not in fm:
             errors.append(f"FAIL: {where}: missing required field '{field}'.")
 
-    if "cost" not in fm:
+    # A rejection carries no cost key. The key exists so a PENDING obligation is
+    # visible while a record is proposed; a rejected record has no pending
+    # obligation, and an empty cost would imply one that will never be met.
+    if "cost" not in fm and fm.get("status") != "rejected":
         errors.append(
             f"FAIL: {where}: missing required field 'cost'. It may be empty "
             "while proposed - the human authors it at the acceptance gate - "
@@ -760,7 +763,44 @@ def _check_acceptance(fm, status, where, errors) -> None:
         )
 
 
+REJECTION_SECTION = "Rejection"
+
+
+def _check_rejection(body, where, errors) -> None:
+    """A rejection costs one section, and that section has to say something.
+
+    Declining must be cheaper than accepting. If a rejected harness-loop record
+    still needed four tier-2 sections and a cost, nobody would record a refusal
+    and the corpus would go on recording only what entered (#555).
+
+    But a rejection with no reason records that someone said no and nothing about
+    why, and the why is the half a later reader needs — particularly a later
+    assay deciding whether a re-found problem is recurring or already adjudicated.
+    """
+    found = sections(body)
+    for heading in ("Finding", REJECTION_SECTION):
+        if heading not in found:
+            errors.append(f"FAIL: {where}: a rejected record requires '## {heading}'.")
+        elif not found[heading].strip():
+            errors.append(
+                f"FAIL: {where}: section '## {heading}' is empty. A rejection with "
+                "no reason records that someone said no and nothing about why."
+            )
+        elif heading == REJECTION_SECTION and found[heading].strip().startswith("_TODO"):
+            errors.append(
+                f"FAIL: {where}: '## {REJECTION_SECTION}' is still a placeholder. "
+                "The approver writes why the finding was declined."
+            )
+
+
 def _check_body(fm, body, classification, is_no_change, is_retirement, where, errors) -> None:
+    # A rejection is not a decision that anything happens, so it is exempt from
+    # the sections that describe what happens. The exemption is keyed on status
+    # and must not leak: an ACCEPTED record still requires everything below.
+    if fm.get("status") == "rejected":
+        _check_rejection(body, where, errors)
+        return
+
     found = sections(body)
     required = list(TIER1_SECTIONS)
     if classification in TIER2_CLASSIFICATIONS:

--- a/ai-literacy-superpowers/scripts/harness-registrar.py
+++ b/ai-literacy-superpowers/scripts/harness-registrar.py
@@ -367,6 +367,64 @@ def block_scalar(value: str, indent: str = "  ") -> str:
     return "\n".join(indent + line if line.strip() else "" for line in lines)
 
 
+def render_rejection(hdr_id: str, finding: Finding, assay_path: str,
+                     assay_fm: dict, today: datetime.date, reason: str) -> str:
+    """A record of what a human weighed and refused.
+
+    The corpus records what ENTERED. Without this it has no way to record what
+    was considered and declined, so a later assay re-finding the same class
+    cannot tell a recurring problem from one already adjudicated — which is the
+    distinction the two-assay promotion threshold turns on (#555).
+
+    Deliberately cheap. No rule, because nothing enters force; no cost, because
+    nothing is demanded of anyone; no tier-2 sections, because no layer is being
+    argued for. Friction on the path we want people to take means the path is not
+    taken, and then the corpus goes on recording only what entered.
+
+    The reason is supplied up front rather than left as a placeholder. A
+    rejection has no later gate — it is written at `rejected` and never accepted
+    — so a placeholder would either block the write, or sit in the corpus
+    permanently recording that someone said no and nothing about why.
+    """
+    meta = finding.meta
+    evidence = [str(i) for i in (meta.get("evidence") or [])]
+    anchor = f"{assay_path}#{finding.id}"
+    if anchor not in evidence:
+        evidence.append(anchor)
+
+    lines = ["---",
+             f"id: {hdr_id}",
+             f"title: {finding.title}",
+             "status: rejected",
+             f"classification: {meta['classification']}",
+             f"enforcement: {meta['enforcement']}",
+             "surfaces: [" + ", ".join(str(s) for s in (meta.get("surfaces") or [])) + "]",
+             "provisional: false",
+             "evidence:"]
+    lines += [f"  - {item}" for item in evidence]
+    lines += ["proposer:",
+              f"  agent: {assay_fm['agent']}",
+              f"  model: {assay_fm['model']}",
+              f"  assay: {assay_path}",
+              "supersedes: null",
+              "superseded_by: null",
+              "---",
+              "",
+              "## Finding",
+              "",
+              finding.observation,
+              ""]
+    if finding.reasoning:
+        lines += ["## Assayer's reasoning",
+                  "",
+                  "_Written by the Assayer, carried verbatim._",
+                  "",
+                  finding.reasoning,
+                  ""]
+    lines += ["## Rejection", "", reason.strip(), ""]
+    return "\n".join(lines)
+
+
 def render_hdr(hdr_id: str, finding: Finding, assay_path: str, assay_fm: dict,
                today: datetime.date) -> str:
     meta = finding.meta
@@ -534,7 +592,22 @@ def cmd_propose(args) -> int:
     if os.path.exists(target):
         die(f"{rel} already exists — pass --slug to give this one a distinct name.")
 
-    text = render_hdr(hdr_id, match, args.assay, assay_fm, today)
+    if getattr(args, "reject", False):
+        reason_rel = getattr(args, "reason_file", None)
+        if not reason_rel:
+            die("--reject needs --reason-file: a rejection with no reason records "
+                "that someone said no and nothing about why.")
+        reason_abs = os.path.join(root, reason_rel)
+        if not os.path.isfile(reason_abs):
+            die(f"reason file not found at {reason_rel}")
+        with open(reason_abs, encoding="utf-8") as handle:
+            reason = handle.read().strip()
+        if not reason:
+            die("the reason is empty. The approver writes why the finding was "
+                "declined.")
+        text = render_rejection(hdr_id, match, args.assay, assay_fm, today, reason)
+    else:
+        text = render_hdr(hdr_id, match, args.assay, assay_fm, today)
 
     code, output = validate_staged(root, rel, text)
     if code != 0:
@@ -544,6 +617,9 @@ def cmd_propose(args) -> int:
     os.makedirs(os.path.dirname(target), exist_ok=True)
     with open(target, "w", encoding="utf-8") as handle:
         handle.write(text)
+    if getattr(args, "reject", False):
+        print(f"rejected {rel}")
+        return 0
     print(f"proposed {rel}")
     if match.meta["classification"] in S0.TIER2_CLASSIFICATIONS:
         print("  tier-2 classification: four sections are placeholders and must "
@@ -1621,6 +1697,14 @@ def main(argv: list[str]) -> int:
     p.add_argument("--finding", required=True)
     p.add_argument("--slug")
     p.add_argument("--today", help="YYYY-MM-DD; injected so nothing races the clock")
+    p.add_argument("--reject", action="store_true",
+                   help="record the finding as DECLINED rather than proposed: no "
+                        "rule, no cost, one section for the reason")
+    p.add_argument("--reason-file",
+                   help="with --reject: a FILE holding why the finding was "
+                        "declined. A file, never an argument, for the same reason "
+                        "--cost-file is: it is prose, and shell history is one "
+                        "copy-paste from the next rejection")
     p.set_defaults(func=cmd_propose)
 
     p = sub.add_parser("precheck", help="report every refusal that does not need a cost")

--- a/docs/plugins/ai-literacy-superpowers/reference/harness-decision-records.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/harness-decision-records.md
@@ -73,6 +73,26 @@ reworded — and it removes a second place for the same fact to be wrong.
 
 ### A retirement says `Withdrawn.`
 
+### `rejected` — a finding a human weighed and declined
+
+Written by `/harness-propose --reject --reason-file <path>`. It carries
+`## Finding` and a non-empty `## Rejection`, and **nothing else**: no `## Rule`
+because nothing enters force, no `cost` key because nothing is demanded, and no
+tier-2 sections because no layer is being argued for.
+
+Declining has to be cheaper than accepting. If a rejected `harness-loop` record
+needed four tier-2 sections and a cost, nobody would record a refusal, and the
+corpus would go on recording only what entered (#555).
+
+The reason is supplied when the record is written rather than left as a
+placeholder: a rejection has no later gate, so a placeholder would sit in the
+corpus permanently recording that someone said no and nothing about why.
+
+A rejection reaches no artifact, consumes no cycle slot, and is **absent from
+`/harness-timeline`** — the feed records when a rule entered force and when it
+stopped, and a rejection was never in force. It appears in
+`harness/decisions/index.md` with state `rejected`.
+
 A record that withdraws a rule carries the literal `Withdrawn.` in its `## Rule`
 section, with no fenced block, and must name a non-null `supersedes`. Retiring
 nothing is not a decision.

--- a/docs/superpowers/specs/2026-08-25-record-declined-findings-design.md
+++ b/docs/superpowers/specs/2026-08-25-record-declined-findings-design.md
@@ -1,0 +1,137 @@
+# Record a declined finding — design
+
+**Status:** proposed
+**Date:** 2026-08-25
+**Issue:** #555
+**Provenance:** observed during the first end-to-end loop run (#548, PR #550).
+finding-1 of `harness/assay/2026-08-25T08-08Z-assay.md` was read, adversarially
+reviewed (`docs/superpowers/objections/harness-provenance-citation.md`,
+12 objections), investigated against a newly transcribed source, and declined on
+evidence. Nothing in the corpus records that.
+**Scope:** a `rejected` decision record, and what the validator requires of one.
+**Out of scope:** #556, #557, #558, #559.
+
+## 1. Problem statement
+
+The corpus records what **entered**. It has no way to record what a human weighed
+and refused.
+
+- `harness/decisions/` holds records that were proposed. finding-1 never was.
+- The assay records what was *found*, and is append-only, so no disposition can be
+  added to it.
+- `index.md` and `/harness-timeline` are built from HDRs, so a finding that never
+  became one is invisible to both.
+
+The mechanism's own argument leans on refusal being visible. The assay format
+requires a **Rejected candidates** section, and `/harness-assay` treats an empty
+one as evidence the Assayer has stopped checking. `no-change` is a first-class
+classification for the same reason.
+
+That principle is enforced for the **Assayer** and absent for the **human**. The
+one actor whose judgement the gate exists to capture is the one whose refusals
+leave nothing behind.
+
+### The practical cost
+
+A later assay reads prior assays and will re-find the same class of problem.
+Nothing tells it a human already considered and declined it, so it cannot
+distinguish a genuinely recurring problem from one already adjudicated — which is
+the distinction the two-assay promotion threshold turns on. Corroboration by a
+finding that was already refused is not corroboration.
+
+## 2. What already exists and is unreachable
+
+```python
+VALID_STATUS    = {"proposed", "accepted", "rejected", "superseded", "expired"}
+STORABLE_STATUS = {"proposed", "accepted", "rejected"}
+```
+
+`rejected` is a **storable** status. Nothing in the plugin produces one — not
+`/harness-propose`, not `/harness-accept`, not `/harness-review`. The schema
+anticipated this outcome and no command reaches it.
+
+Three mechanisms already behave correctly for a rejected record and need no
+change:
+
+- `compile_plan` skips anything not `accepted`, so a rejection reaches no artifact.
+- `cmd_timeline` skips anything not `accepted`, so it stays out of the feed.
+- `render_index` lists **every** record and falls through to `record.status`, so a
+  rejection already renders with state `rejected`.
+
+## 3. Decision — declining costs one section
+
+`_check_body` is not gated on status. A rejected `harness-loop` record would today
+need `## Rule`, a non-empty `## Cost`, and all four tier-2 sections — so declining
+would cost more than accepting.
+
+That is backwards, and it is fatal to the purpose: friction on the path we want
+people to take means the path is not taken and the hole stays open.
+
+For `status: rejected`:
+
+| Section | Required | Why |
+| --- | --- | --- |
+| `## Finding` | yes | carried from the assay; what was observed |
+| `## Rejection` | yes, non-empty | the human's reason. This is the artifact |
+| `## Rule` | no | nothing enters force |
+| `## Cost` | no | nothing is demanded of anyone |
+| tier-2 sections | no | no layer is being argued for |
+
+The cost rule does not apply — `_check_acceptance` already fires only on
+`accepted`, and a cost for a rule that will never bind is ceremony.
+
+**`## Rejection` must be non-empty and must not be a placeholder.** A rejection
+with no reason records that someone said no and nothing about why, which is the
+half a later reader actually needs.
+
+## 4. Decision — the feed is for interventions
+
+A rejected record does **not** appear in `/harness-timeline`.
+
+The `no-change` precedent argues the other way: 0.79.0 kept `no-change` records in
+the feed as `direction: none`, because they record that governance was examined at
+a known moment and deliberately not changed. The distinction is that a `no-change`
+record is **accepted** and carries `approved_at`; a rejection was never in force
+and has no such date.
+
+The feed's contract is when a rule entered force, in which direction, and when it
+stopped. A rejection is not an intervention of size zero — it is not an
+intervention. It belongs in the index, which is the corpus's record of what exists
+rather than of what was in force.
+
+## 5. Decision — how a rejection is produced
+
+`/harness-propose --reject <assay> <finding>` writes the record at
+`status: rejected` with `## Rejection` as a placeholder for the human to fill,
+mirroring how tier-2 sections are left for a human today.
+
+It is on `propose` rather than `accept` because nothing is being accepted, and
+routing a refusal through the acceptance gate would make the gate mean two
+opposite things.
+
+**It does not consume a cycle slot.** The three-per-cycle cap limits how much
+governance an assay *adds*; a rejection adds none. `_check_cycle_cap` counts
+records in force, and a rejection is never in force, so this needs no change —
+asserted rather than assumed.
+
+## 6. Acceptance criteria
+
+- **A1** — `/harness-propose --reject` writes a record at `status: rejected`.
+- **A2** — the record carries `## Finding` and a `## Rejection` placeholder.
+- **A3** — validation fails while `## Rejection` is a placeholder or empty.
+- **A4** — validation passes with `## Finding` and `## Rejection` alone: no
+  `## Rule`, no `## Cost`, no tier-2 sections, whatever the classification.
+- **A5** — a rejected record reaches no artifact: `compile_plan` ignores it and
+  `/harness-compile` writes nothing for it.
+- **A6** — it is absent from `/harness-timeline`.
+- **A7** — it appears in `harness/decisions/index.md` with state `rejected`.
+- **A8** — it does not consume a cycle slot: three accepted records plus any
+  number of rejections still pass.
+- **A9** — an **accepted** record is unaffected: still requires `## Rule`,
+  `## Cost` and its tier-2 sections. The relaxation must not leak.
+- **A10** — the existing corpus is unaffected; `/harness-check` passes.
+
+## 7. Version
+
+Behaviour change to plugin files: minor bump, `0.82.0` → `0.83.0`, across the
+five CI-checked locations named in `CLAUDE.md`.

--- a/docs/superpowers/specs/2026-08-25-record-declined-findings-design.md
+++ b/docs/superpowers/specs/2026-08-25-record-declined-findings-design.md
@@ -101,9 +101,19 @@ rather than of what was in force.
 
 ## 5. Decision — how a rejection is produced
 
-`/harness-propose --reject <assay> <finding>` writes the record at
-`status: rejected` with `## Rejection` as a placeholder for the human to fill,
-mirroring how tier-2 sections are left for a human today.
+`/harness-propose --reject <assay> <finding> --reason-file <path>` writes the
+record at `status: rejected`, complete.
+
+**The reason is supplied up front, not left as a placeholder.** (Corrected during
+implementation.) The first design left `## Rejection` as `_TODO`, mirroring the
+tier-2 sections — but those survive because they are checked at the *acceptance*
+gate, and a rejection has no later gate. A placeholder would either block the
+write, since `propose` validates before writing, or sit in the corpus permanently
+recording that someone said no and nothing about why.
+
+`--reason-file` is a file rather than an argument for the same reason
+`--cost-file` is: it is prose, and shell history is one copy-paste from the next
+rejection.
 
 It is on `propose` rather than `accept` because nothing is being accepted, and
 routing a refusal through the acceptance gate would make the gate mean two
@@ -117,8 +127,10 @@ asserted rather than assumed.
 ## 6. Acceptance criteria
 
 - **A1** — `/harness-propose --reject` writes a record at `status: rejected`.
-- **A2** — the record carries `## Finding` and a `## Rejection` placeholder.
-- **A3** — validation fails while `## Rejection` is a placeholder or empty.
+- **A2** — the record carries `## Finding` and a `## Rejection` holding the
+  supplied reason, and never a placeholder.
+- **A3** — `--reject` without a reason, or with an empty one, refuses and writes
+  nothing.
 - **A4** — validation passes with `## Finding` and `## Rejection` alone: no
   `## Rule`, no `## Cost`, no tier-2 sections, whatever the classification.
 - **A5** — a rejected record reaches no artifact: `compile_plan` ignores it and

--- a/tdad_tests/layer0_deterministic/test-declined-findings.sh
+++ b/tdad_tests/layer0_deterministic/test-declined-findings.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for recording a declined finding
+# (spec 2026-08-25-record-declined-findings-design.md; D1-D10 -> A1-A10).
+#
+# D9 IS THE GUARD. The relaxation exists so that saying no is cheap; if it leaks
+# into accepted records, a rule could enter force with no Rule section and no
+# cost, which is far worse than the hole being fixed.
+#
+# D4 IS THE POINT. Declining must cost ONE section. If a rejected harness-loop
+# record still needs four tier-2 sections plus a cost, nobody records a refusal
+# and the corpus keeps recording only what entered.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$SCRIPT_DIR/../.."
+REG="$ROOT/ai-literacy-superpowers/scripts/harness-registrar.py"
+VAL="$ROOT/ai-literacy-superpowers/scripts/check-harness-decisions.py"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+[ -f "$REG" ] || fail "harness registrar not found at $REG"
+
+PY=/usr/bin/python3
+command -v "$PY" >/dev/null 2>&1 || PY=python3
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+cd "$TMP"
+mkdir -p harness/decisions harness/assay
+printf '# Harness\n\nHand-written.\n' > HARNESS.md
+
+A="harness/assay/2026-08-25T08-08Z-assay.md"
+
+reg() { set +e; OUT="$( "$PY" "$REG" "$@" 2>&1 )"; RC=$?; set -e; }
+val() { set +e; VOUT="$( "$PY" "$VAL" 2>&1 )"; VRC=$?; set -e; }
+
+cat > harness/surfaces.yaml <<'EOF'
+routes:
+  harness-loop: HARNESS.md
+  turn-instructions: AGENTS.md
+  script-validator: HARNESS.md
+
+surfaces:
+  ci:
+    targets: [.github/workflows/]
+    supports: [validated, blocked]
+EOF
+
+# finding-1 is a harness-loop finding, the heaviest tier, so D4 proves the
+# relaxation on the case that would otherwise cost the most to decline.
+cat > "$A" <<'EOF'
+---
+assay: harness/assay/2026-08-25T08-08Z-assay.md
+date: 2026-08-25
+agent: harness-assayer
+model: claude-opus-5
+---
+
+# Assay 2026-08-25T08-08Z
+
+## Findings
+
+### finding-1 — An epic's authority cited to a document nobody can open
+
+Six specs carry a provenance line naming a build spec supplied in conversation.
+No such document exists in the repository.
+
+```yaml
+classification: harness-loop
+enforcement: advisory
+surfaces: [ci]
+priority: P2
+evidence:
+  - HARNESS.md
+overfitting_risk: low
+```
+
+#### Proposed rule
+
+````markdown
+- **Rule**: A spec naming a source document as its authority must cite something
+  a second reader can open.
+- **Enforcement**: agent
+- **Scope**: pr
+````
+
+#### Cost estimate
+
+Fifteen to forty minutes once per epic.
+EOF
+
+# === D3: a rejection with no reason is refused before anything is written ====
+# There is no later gate for a rejection - it is written at `rejected` and never
+# accepted - so the reason is supplied up front rather than left as a
+# placeholder that would either block the write or sit in the corpus forever.
+reg propose --assay "$A" --finding finding-1 --today 2026-08-25 --slug declined --reject
+[ "$RC" -ne 0 ] || fail "D3: --reject without --reason-file must refuse. Out: $OUT"
+[ -f harness/decisions/HDR-2026-08-25-declined.md ] \
+  && fail "D3: a record was written despite the refusal"
+printf '' > empty.txt
+reg propose --assay "$A" --finding finding-1 --today 2026-08-25 --slug declined \
+  --reject --reason-file empty.txt
+[ "$RC" -ne 0 ] || fail "D3b: an empty reason must refuse. Out: $OUT"
+[ -f harness/decisions/HDR-2026-08-25-declined.md ] \
+  && fail "D3b: a record was written despite the refusal"
+echo "D3 ok (no reason, no record)"
+echo "D3b ok (empty reason, no record)"
+
+# === D1/D2: --reject writes a complete rejected record =======================
+cat > reason.txt <<'EOF'
+The deviations were accurate; the harm was checkability, and transcription fixed
+it without a rule.
+EOF
+reg propose --assay "$A" --finding finding-1 --today 2026-08-25 --slug declined \
+  --reject --reason-file reason.txt
+[ "$RC" -eq 0 ] || fail "D1: propose --reject failed. Out: $OUT"
+H="harness/decisions/HDR-2026-08-25-declined.md"
+[ -f "$H" ] || fail "D1: no record written"
+grep -q '^status: rejected$' "$H" || fail "D1: status is not 'rejected'"
+grep -q '^## Finding$' "$H"       || fail "D2: no '## Finding' section"
+grep -q '^## Rejection$' "$H"     || fail "D2: no '## Rejection' section"
+grep -q 'checkability' "$H"       || fail "D2: the reason was not carried"
+grep -q '_TODO' "$H"              && fail "D2: a rejection must never carry a placeholder"
+echo "D1 ok (rejected record written)"
+echo "D2 ok (Finding carried, reason recorded)"
+
+# === D4: Finding + Rejection alone is enough, even for harness-loop =========
+grep -q '^## Rule$'  "$H" && fail "D4 setup: the record should carry no ## Rule"
+grep -q '^## Cost$'  "$H" && fail "D4 setup: the record should carry no ## Cost"
+grep -q '^## Why this layer$' "$H" && fail "D4 setup: no tier-2 sections expected"
+val
+[ "$VRC" -eq 0 ] || fail "D4: Finding + Rejection should validate. Out: $VOUT"
+echo "D4 ok (one section to decline a harness-loop finding)"
+
+# === D5/D6/D7: no artifact, no feed, but present in the index ===============
+BEFORE="$( "$PY" -c "import hashlib;print(hashlib.sha256(open('HARNESS.md','rb').read()).hexdigest())" )"
+reg compile
+[ "$RC" -eq 0 ] || fail "D5: compile failed. Out: $OUT"
+AFTER="$( "$PY" -c "import hashlib;print(hashlib.sha256(open('HARNESS.md','rb').read()).hexdigest())" )"
+[ "$BEFORE" = "$AFTER" ] || fail "D5: a rejected record reached an artifact"
+echo "D5 ok (reaches no artifact)"
+
+reg timeline
+[ "$RC" -eq 0 ] || fail "D6: timeline failed. Out: $OUT"
+printf '%s' "$OUT" | grep -q 'HDR-2026-08-25-declined' \
+  && fail "D6: a rejection must not appear in the intervention feed"
+echo "D6 ok (absent from the feed)"
+
+grep -q 'HDR-2026-08-25-declined' harness/decisions/index.md \
+  || fail "D7: the rejection is missing from the index"
+grep -E 'HDR-2026-08-25-declined.*\| rejected \|' harness/decisions/index.md >/dev/null \
+  || fail "D7: index should show state 'rejected'. Row: $(grep 'declined' harness/decisions/index.md)"
+echo "D7 ok (in the index, state rejected)"
+
+# === D9: the relaxation must not leak into accepted records =================
+# Same body, flipped to accepted. It must now fail for the sections it lacks.
+cp "$H" harness/decisions/HDR-2026-08-25-leak.md
+"$PY" - harness/decisions/HDR-2026-08-25-leak.md <<'PYEOF'
+import sys
+p = sys.argv[1]; t = open(p).read()
+t = t.replace("id: HDR-2026-08-25-declined", "id: HDR-2026-08-25-leak")
+t = t.replace("status: rejected", "status: accepted")
+open(p, "w").write(t)
+PYEOF
+val
+[ "$VRC" -ne 0 ] || fail "D9: an accepted record with no Rule/Cost validated - the relaxation leaked"
+printf '%s' "$VOUT" | grep -qi 'Rule\|Cost' \
+  || fail "D9: the failure should name the missing sections. Out: $VOUT"
+rm -f harness/decisions/HDR-2026-08-25-leak.md
+echo "D9 ok (accepted records still require everything)"
+
+# === D8: a rejection consumes no cycle slot =================================
+# Three accepted records from one assay is the cap. Add rejections on top and
+# the corpus must still validate.
+for n in 1 2 3; do
+  cp "$H" "harness/decisions/HDR-2026-08-25-extra-$n.md"
+  "$PY" - "harness/decisions/HDR-2026-08-25-extra-$n.md" "$n" <<'PYEOF'
+import sys
+p, n = sys.argv[1], sys.argv[2]
+t = open(p).read().replace("id: HDR-2026-08-25-declined", f"id: HDR-2026-08-25-extra-{n}")
+open(p, "w").write(t)
+PYEOF
+done
+val
+[ "$VRC" -eq 0 ] || fail "D8: rejections consumed a cycle slot. Out: $VOUT"
+echo "D8 ok (rejections do not count against the cap)"
+
+echo "declined findings: all checks passed (D1-D9)"


### PR DESCRIPTION
Closes #555

Spec committed first: `docs/superpowers/specs/2026-08-25-record-declined-findings-design.md`.

## The gap

The corpus recorded what **entered**. It had no way to record what a human weighed
and refused.

During the first loop run, finding-1 of `2026-08-25T08-08Z-assay.md` was read,
adversarially reviewed (12 objections), investigated against a newly transcribed
source, and declined on evidence. Nothing in the corpus shows that happened.

`rejected` was already in `STORABLE_STATUS` and **nothing produced one** — not
propose, not accept, not review. The schema anticipated the outcome and no command
reached it.

## Why it matters beyond tidiness

A later assay reads prior assays and will re-find the same class of problem.
Nothing told it a human had already declined one, so it could not distinguish a
recurring problem from one already adjudicated — the distinction the **two-assay
promotion threshold turns on**. Corroboration by a finding that was already
refused is not corroboration.

## The fix

`/harness-propose --reject --reason-file <path>` writes a record at
`status: rejected` carrying `## Finding` and a non-empty `## Rejection`, and
nothing else.

**Declining costs one section.** `_check_body` was not status-gated, so a rejected
`harness-loop` record would have needed `## Rule`, a non-empty `## Cost` and all
four tier-2 sections — declining would have cost *more* than accepting. That is
fatal to the purpose: friction on the path we want taken means the path is not
taken and the hole stays open.

Three mechanisms already behaved correctly and needed no change: `compile_plan`
and `cmd_timeline` skip anything not `accepted`, and `render_index` falls through
to `record.status`.

## A design flaw found during implementation

The spec originally left `## Rejection` as a `_TODO` placeholder, mirroring the
tier-2 sections. That cannot work: tier-2 placeholders survive because they are
checked at the **acceptance gate**, and a rejection has no later gate. `propose`
validates before writing, so a placeholder either blocks the write outright or —
if permitted — sits in the corpus permanently recording that someone said no and
nothing about why.

The reason is now supplied up front via `--reason-file`, a file rather than an
argument for the same reason `--cost-file` is. **The spec is corrected in this PR
rather than left disagreeing with the implementation.**

## Verification

- `test-declined-findings.sh` (D1–D9). Observed red on the missing flag.
- **D9 is the guard**: an accepted record with the same body must still fail for
  its missing `## Rule` and `## Cost`. A leaked relaxation would let a rule enter
  force with no rule text and no cost — far worse than the hole being fixed.
- **D4 is the point**: `## Finding` + `## Rejection` validates for a
  `harness-loop` finding, the heaviest tier.
- D3/D3b assert no record is written at all without a real reason.
- D8 asserts rejections consume no cycle slot.
- All Layer 0 suites pass; `harness check: OK`; existing corpus untouched.

## Not included, deliberately

I ran this against the real finding-1 to confirm it works end to end, then
**deleted the record**. The rejection reason would have been mine, not the
approver's — the same failure #558 documents. Recording your decision in my words
would be worse than not recording it.

The offer stands separately: one command with your reason and the decision you
actually made this morning becomes part of the corpus.

Version: 0.82.0 → 0.83.0 across the five CI-checked locations.