### PR TITLE
Record the approver's decision to decline finding-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,27 @@ anticipated this outcome and no command reached it.
   because a leak would let a rule enter force with no rule text and no cost.
 - **Layer 0 suite** `test-declined-findings.sh` (D1–D9).
 
+### The first declined finding is on the record
+
+`HDR-2026-08-25-an-epic-s-authority-cited-to-a-document-nobody-else-can-open`
+records the disposition of finding-1 from the first assay: proposed by the
+Assayer as a `harness-loop` rule, adversarially reviewed, investigated against
+the transcribed build spec, and declined by the approver.
+
+The reason is the approver's, written in their own words and copied verbatim:
+
+> My feeling was that the rule was pointed at the wrong problem.
+
+Worth noting what the record contains, because it is the first artifact to
+exercise two changes made today: the finding as observed, the Assayer's own
+argument for the layer (carried by 0.81.0, which would previously have discarded
+it), and the human's disposition. Read together they are the whole decision —
+what was seen, what was argued, and what a person concluded.
+
+The corpus now holds one rejection, one retirement and one superseded rule, and
+nothing in force. That is an honest state rather than an embarrassing one: three
+records of governance being examined, and no rule that survived the examination.
+
 ### Why it matters beyond tidiness
 
 A later assay reads prior assays and will re-find the same class of problem.

--- a/harness/decisions/HDR-2026-08-25-an-epic-s-authority-cited-to-a-document-nobody-else-can-open.md
+++ b/harness/decisions/HDR-2026-08-25-an-epic-s-authority-cited-to-a-document-nobody-else-can-open.md
@@ -1,0 +1,79 @@
+---
+id: HDR-2026-08-25-an-epic-s-authority-cited-to-a-document-nobody-else-can-open
+title: An epic's authority cited to a document nobody else can open
+status: rejected
+classification: harness-loop
+enforcement: advisory
+surfaces: [claude-code, codex, cursor, copilot, windsurf]
+provisional: false
+evidence:
+  - docs/superpowers/specs/2026-08-23-harness-evolution-s0-schema-validator-design.md
+  - docs/superpowers/specs/2026-08-23-harness-evolution-s2-compile-check-design.md
+  - docs/superpowers/cadence-sentinels-charter.md
+  - HARNESS.md
+  - harness/assay/2026-08-25T08-08Z-assay.md#finding-1
+proposer:
+  agent: harness-assayer
+  model: claude-opus-5
+  assay: harness/assay/2026-08-25T08-08Z-assay.md
+supersedes: null
+superseded_by: null
+---
+
+## Finding
+
+Six specs — `2026-08-23-harness-evolution-s0` through `-s5` — carry the line
+`**Provenance:** the Harness Assayer / Harness Registrar build spec, supplied
+in conversation 2026-08-23`. No such document exists in the repository. The six
+specs then make thirteen separate claims about what that spec says, and four of
+them are recorded deviations from it: S0 §7 "This is the fix for an
+unimplementable clause in the build spec", S2 §2 "The build spec's compilation
+model does not survive contact with this repo", S4 §132 "The build spec
+requires `provisional: true` with a mandatory `expires` date", S5 §35 "The
+build spec's example line does not say whether 'expired' appears in the feed".
+Each deviation is argued, and none can be checked, because the thing deviated
+from is not retrievable.
+
+This is a recurrence, not a first occurrence. Commit `1133b9c` (2026-08-13,
+#518) is titled "Point the epic's provenance at something retrievable, and
+transcribe the charter" and its message reads: "Seven specs cited a deck that
+never existed — it was a label for a build spec supplied in conversation…
+those specs cite constitutional constraints BY NUMBER, fifteen times across
+seven distinct constraints, against a list that was nowhere in the repository."
+The fix produced `docs/superpowers/cadence-sentinels-charter.md`, transcribing
+all nine constraints verbatim. It produced no rule. Ten days later the next
+epic reproduced the defect at the same scale.
+
+The 2026-08-13 reflection entry did promote a sibling constraint — *Specs cite
+the source of a claimed convention* — but scoped it to claims about existing
+repository conventions, not to the source document a spec names as its
+authority. The narrower half was generalised; the wider half was not.
+
+## Assayer's reasoning
+
+_Written by the Assayer, carried verbatim._
+
+**Why this is a tightening, not a new rule.** `HARNESS.md` already carries
+*Specs cite the source of a claimed convention*, agent-enforced by the
+advocatus-diaboli spec gate, driven by the same class of failure. It cannot
+absorb this behaviour as written because its subject is a **claim about the
+repository** ("the pattern here is X"), verifiable by opening a file that
+exists; this finding's subject is a **source outside the repository**, where
+there is no file to open. The rule below extends that constraint's scope rather
+than adding a second heading, and the proposed text is written to sit inside
+it.
+
+**Overfitting risk: low.** Two independent occurrences, two different epics,
+two different authors' sessions, thirteen and fifteen citation instances
+respectively. The rule does not encode either epic's specifics.
+
+**Validation plan.** Take the six harness-evolution specs as the negative
+fixture: under the rule they must fail the spec gate. Take
+`cadence-sentinels-s1` post-`1133b9c` as the positive fixture: it cites
+`cadence-sentinels-charter.md` by path and must pass. If the gate cannot
+separate those two without reading either spec's content, the rule is not
+falsifiable and should be refused.
+
+## Rejection
+
+My feeling was that the rule was pointed at the wrong problem.

--- a/harness/decisions/index.md
+++ b/harness/decisions/index.md
@@ -6,6 +6,7 @@ One row per Harness Decision Record. Generated from `harness/decisions/`; the fi
 
 | ID | Status | Classification | Enforcement | Surfaces | Provisional | Expires | State |
 | --- | --- | --- | --- | --- | --- | --- | --- |
+| HDR-2026-08-25-an-epic-s-authority-cited-to-a-document-nobody-else-can-open | rejected | harness-loop | advisory | claude-code, codex, cursor, copilot, windsurf | no | — | rejected |
 | HDR-2026-08-25-retire-periodic-check-suite-runner | accepted | script-validator | validated | ci | no | — | retirement |
 | HDR-2026-08-25-the-periodic-check-suite-stops-at-its-first-failure-and-reports-the-rest-as-nothing | accepted | script-validator | validated | ci | yes | 2026-11-23 | superseded |
 


### PR DESCRIPTION
The first `rejected` record in the corpus, and the first use of
`/harness-propose --reject` (shipped in 0.83.0, #555).

## What it records

finding-1 of `harness/assay/2026-08-25T08-08Z-assay.md` — proposed by the Assayer
as a `harness-loop` rule about spec provenance, adversarially reviewed
(12 objections, 4 critical), investigated against the build spec transcribed in
#550, and **declined by the approver**.

The reason is the approver's, verbatim:

> My feeling was that the rule was pointed at the wrong problem.

## Why this record is worth having

It is the first artifact to carry all three parts of a decision:

- **`## Finding`** — what the Assayer observed
- **`## Assayer's reasoning`** — its own argument for the layer, carried by 0.81.0.
  Before that change this was discarded at the metadata fence, so this record
  could not have existed in complete form yesterday
- **`## Rejection`** — what a person concluded

Read together: what was seen, what was argued, and what was decided. Until 0.83.0
the corpus could record only the first two, and only for findings that became
rules.

It also matters for the **two-assay promotion threshold**. A later assay
re-finding this class can now tell that a human already adjudicated it, which is
the distinction that threshold turns on.

## Corpus state

```
rejected     an epic's authority cited to a document nobody can open
retirement   retire-periodic-check-suite-runner
superseded   the-periodic-check-suite-stops-at-its-first-failure
```

One rejection, one retirement, one superseded rule, and **nothing in force**. An
honest state rather than an embarrassing one: three records of governance being
examined, and no rule that survived the examination.

Absent from `/harness-timeline` and from the enforcement report, as designed — a
rejection was never in force, so it is not an intervention.

## Unrelated observation, not fixed here

`/harness-propose` writes a record but does not regenerate `decisions/index.md`,
so `/harness-check` fails on index drift until someone runs `/harness-compile`.
Verified to be **general**, not specific to `--reject` — a normal propose does the
same. Pre-existing; worth a ticket rather than a silent fix in a records PR.

Records only. No plugin change, no version bump.