### PR TITLE
Regenerate the decision index when a record is proposed

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.83.0",
+  "plugin_version": "0.83.1",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.83.0"
+      "version": "0.83.1"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.83.1 — 2026-08-25
+
+### Fixed — a propose no longer leaves the corpus failing its own check
+
+`/harness-propose` wrote a record and returned. `harness/decisions/index.md` is
+part of the compile plan and `render_index` lists every record, `proposed`
+included, so the index went stale and `/harness-check` reported a build failure
+until someone ran `/harness-compile`. `/harness-accept` was unaffected because it
+runs the compile step inside its transaction. See #564.
+
+That window is not brief. The gates are deliberately separate, and a proposal is
+*supposed* to sit at `proposed` and carry forward when it does not win a slot —
+the cycle cap assumes exactly that. So the CI entry point was red for the whole
+normal mid-cycle state of a corpus, which is how people learn to ignore a red
+check. This repository spent six weeks demonstrating that with the GC workflow.
+
+The failure also misdirected: "Run `/harness-compile` to repair, or supersede the
+decision if the change was intended" describes a hand-edited generated region.
+Nothing had been hand-edited and there was nothing to supersede.
+
+- **`propose` now regenerates the index** after a successful write, with and
+  without `--reject`. There is no decision in regenerating an index — the same
+  reason applying and compiling are not gates.
+- **Only the index.** A proposed record reaches no artifact and is absent from the
+  enforcement report, so nothing else moves. Asserted rather than assumed.
+- **D10** in `test-declined-findings.sh` covers it, including that a plain propose
+  and a `--reject` both leave `/harness-check` passing.
+
 ## 0.83.0 — 2026-08-25
 
 ### Added — a finding a human declines is now recorded

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.83.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.83.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-42-2E8B57?style=flat-square)](#skills-42)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.83.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.83.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.83.0",
+  "version": "0.83.1",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/scripts/harness-registrar.py
+++ b/ai-literacy-superpowers/scripts/harness-registrar.py
@@ -617,6 +617,18 @@ def cmd_propose(args) -> int:
     os.makedirs(os.path.dirname(target), exist_ok=True)
     with open(target, "w", encoding="utf-8") as handle:
         handle.write(text)
+
+    # The index lists every record, `proposed` included, so writing one leaves it
+    # stale and `/harness-check` red until someone compiles. The gates are
+    # deliberately separate and a proposal is SUPPOSED to sit at `proposed` and
+    # carry forward, so that window is not brief — it is the normal state of a
+    # corpus mid-cycle, and a CI entry point that fails throughout it teaches
+    # people to ignore a red check (#564).
+    #
+    # There is no decision in regenerating an index, which is the same reason
+    # applying and compiling are not gates. Only the index: a proposed record
+    # reaches no artifact and is absent from the enforcement report.
+    write_index(root)
     if getattr(args, "reject", False):
         print(f"rejected {rel}")
         return 0

--- a/tdad_tests/layer0_deterministic/test-declined-findings.sh
+++ b/tdad_tests/layer0_deterministic/test-declined-findings.sh
@@ -184,4 +184,33 @@ val
 [ "$VRC" -eq 0 ] || fail "D8: rejections consumed a cycle slot. Out: $VOUT"
 echo "D8 ok (rejections do not count against the cap)"
 
-echo "declined findings: all checks passed (D1-D9)"
+# === D10: a propose leaves the corpus checkable ==============================
+# The gates are deliberately separate and a proposal is SUPPOSED to sit at
+# `proposed` and carry forward. If check fails for that whole interval, the CI
+# entry point is red whenever anyone uses the loop as documented, and people
+# learn to ignore it (#564).
+#
+# D8 and D9 build fixtures by copying files directly, which legitimately leaves
+# the index stale. Sync first, so what D10 measures is whether PROPOSE
+# introduces drift, not whether `cp` does.
+reg index
+[ "$RC" -eq 0 ] || fail "D10 setup: index regeneration failed. Out: $OUT"
+reg check
+[ "$RC" -eq 0 ] || fail "D10 setup: corpus is not clean before the test. Out: $OUT"
+
+reg propose --assay "$A" --finding finding-1 --today 2026-08-25 --slug plainprop
+[ "$RC" -eq 0 ] || fail "D10b setup: propose failed. Out: $OUT"
+reg check
+[ "$RC" -eq 0 ] || fail "D10b: check must pass after a plain propose. Out: $OUT"
+grep -q 'HDR-2026-08-25-plainprop' harness/decisions/index.md   || fail "D10b: the proposed record is missing from the index"
+echo "D10 ok (check passes straight after a propose, rejected or not)"
+
+# Only the index moves: a proposed record reaches no artifact and is absent from
+# the enforcement report.
+grep -q 'HDR-2026-08-25-plainprop' harness/enforcement-report.md 2>/dev/null \
+  && fail "D10c: a proposed record reached the enforcement report"
+grep -q 'BEGIN GENERATED' HARNESS.md \
+  && fail "D10c: a proposed record reached HARNESS.md"
+echo "D10c ok (only the index moved)"
+
+echo "declined findings: all checks passed (D1-D10)"


### PR DESCRIPTION
Closes #564

`fix/` branch prefix: a targeted correction with no design work needed, so no
spec. Patch bump, `0.83.0` → `0.83.1`.

## The defect

```
$ harness-registrar.py propose --assay ... --finding finding-3 --slug driftrepro
proposed harness/decisions/HDR-2026-08-25-driftrepro.md

$ harness-registrar.py check
FAIL: harness/decisions/index.md: drift — the generated content differs from
what the decision corpus produces.

1 harness problem(s). This is a build failure.
```

Nothing was wrong. A record was drafted exactly as intended, and the corpus
reported a build failure.

`index.md` is part of the compile plan (`plan[INDEX_REL] = render_index(records)`)
and `render_index` lists every record, `proposed` included — deliberately, so
pending proposals are visible. `/harness-accept` runs compile inside its
transaction and refreshes it; `/harness-propose` wrote a record and returned.

## Why it mattered

The window is not brief. The gates are deliberately separate, and a proposal is
*supposed* to sit at `proposed` and carry forward when it does not win a slot —
the three-per-cycle cap assumes exactly that. So `/harness-check`, the CI entry
point whose failure is specified as a build failure rather than a warning, was red
for the entire normal mid-cycle state of a corpus.

That is how people learn to ignore a red check. This repository spent six weeks
demonstrating it with the GC workflow, and the S0 spec named the cost while it was
happening.

The message misdirected too: "Run `/harness-compile` to repair, or supersede the
decision if the change was intended" describes a hand-edited generated region.
Nothing had been hand-edited and there was nothing to supersede.

## The fix

`propose` regenerates the index after a successful write. There is no decision in
regenerating an index — the same reasoning the corpus already applies to the steps
around acceptance:

> Applying and compiling are deliberately not gates — once a record is accepted
> there is no decision left in either step.

**Only the index.** A proposed record reaches no artifact and is absent from the
enforcement report, so nothing else moves.

## Verification

- **D10** added to `test-declined-findings.sh`: check passes straight after a
  propose, both plain and `--reject`, and the record appears in the index.
- **D10c** asserts only the index moved — nothing in the enforcement report,
  nothing in `HARNESS.md`.
- Reproduced the ticket's exact commands against the real corpus: `check` now
  exits 0, the index picks the record up, and the enforcement report and
  `HARNESS.md` are untouched.
- All Layer 0 suites pass.

## One thing worth noting about the test

D10 runs `index` first. D8 and D9 build fixtures by copying record files
directly, which legitimately leaves the index stale — so without that sync, D10
would have been measuring whether `cp` introduces drift rather than whether
`propose` does. It failed that way on the first run.