### PR TITLE
Correct an assay without editing it

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.83.1",
+  "plugin_version": "0.84.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.83.1"
+      "version": "0.84.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## 0.84.0 — 2026-08-25
+
+### Added — assays can be corrected without being edited
+
+Assays are append-only and never edited, correctly: they record what an agent
+observed at a moment. But nothing carried a **correction**, so an error was
+permanent, uncited, and propagated. See #556.
+
+The first assay contains two confirmed errors, both load-bearing: finding-1 said
+six specs carry a provenance line (four do), and finding-2 said `gc.yml` runs
+nineteen declared GC rules (it carries eleven steps covering five). Both are now
+corrected in `harness/assay/2026-08-25T08-08Z-assay.errata.md`, with the assay
+byte-identical.
+
+- **`correct --assay --finding --correction-file`** writes a sibling errata
+  record. One section per corrected finding; a later correction appends rather
+  than substitutes. Nothing edits either file.
+- **`/harness-propose` refuses** on a corrected finding, quotes the correction,
+  and proceeds only with `--acknowledge-correction`. Not a warning — a warning
+  from a command that just succeeded is a warning nobody reads, and the record it
+  produces is frozen. The record notes the acknowledgement.
+- **The two-assay promotion threshold stops counting a corrected finding.** It
+  exists so a single incident cannot reach the loop layer, and without this a
+  falsified observation could be the second assay that lets a rule through.
+  Corroboration by a finding that was wrong is not corroboration.
+- **The exclusion is per finding, not per assay.** An assay may hold six findings
+  and be wrong about one.
+- **Layer 0 suite** `test-assay-corrections.sh` (E1–E7), fixtured on the two real
+  errors. E3 hashes the assay before and after: "the record was not touched" is a
+  measurable claim, and asserting it by reading the code is not.
+
+### Deliberately not done
+
+There is **no pointer inside the assay**. It cannot be added without editing the
+record, and a mechanism that pressures anyone to edit an append-only document is
+worse than the gap it closes. Discovery is met by a sibling with a predictable
+name and by refusals at the two points where a correction changes what someone
+should do. The trade is stated rather than the requirement quietly redefined.
+
 ## 0.83.1 — 2026-08-25
 
 ### Fixed — a propose no longer leaves the corpus failing its own check

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.83.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.84.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-42-2E8B57?style=flat-square)](#skills-42)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.83.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.84.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.83.1",
+  "version": "0.84.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/scripts/check-harness-decisions.py
+++ b/ai-literacy-superpowers/scripts/check-harness-decisions.py
@@ -514,6 +514,9 @@ def check_hdr(path: str, surfaces: dict, errors: list[str],
         return None
 
     fm["__path"] = where
+    # <root>/harness/decisions/HDR-*.md — the promotion threshold needs the root
+    # to find an assay's errata sibling.
+    fm["__root"] = os.path.dirname(os.path.dirname(os.path.dirname(path)))
 
     for field in ALWAYS_REQUIRED:
         if field not in fm:
@@ -841,6 +844,24 @@ def _check_body(fm, body, classification, is_no_change, is_retirement, where, er
         errors.append(f"FAIL: {where}: the '## Rule' block is empty.")
 
 
+def _corrected_findings(root: str, assay_rel: str) -> set:
+    """Finding ids carrying a correction in the assay's errata sibling.
+
+    Read here rather than imported so the validator stays runnable on its own -
+    it is the CI entry point's inner check and must not depend on the registrar.
+    """
+    base = assay_rel[:-3] if assay_rel.endswith(".md") else assay_rel
+    path = os.path.join(root, base + ".errata.md")
+    if not os.path.isfile(path):
+        return set()
+    try:
+        with open(path, encoding="utf-8") as handle:
+            text = handle.read()
+    except OSError:
+        return set()
+    return set(re.findall(r"^## (finding-\d+)\s*$", text, re.M))
+
+
 def _check_promotion_threshold(
     fm, status, classification, imported, where, errors
 ) -> None:
@@ -866,11 +887,22 @@ def _check_promotion_threshold(
     evidence = fm.get("evidence")
     if not isinstance(evidence, list):
         return
-    assays = {
-        str(item).split("#", 1)[0]
-        for item in evidence
-        if str(item).startswith(ASSAY_DIR + os.sep) or str(item).startswith(ASSAY_DIR + "/")
-    }
+    # A CORRECTED finding does not corroborate. The threshold exists so a single
+    # incident cannot reach the loop layer, and it is satisfied by counting
+    # distinct assay files — so without this, a falsified observation could be
+    # the second assay that lets a rule through (#556).
+    #
+    # Deliberately narrow: it excludes the corrected FINDING, not the whole
+    # assay. An assay may hold six findings and be wrong about one.
+    assays = set()
+    for item in evidence:
+        ref = str(item)
+        if not (ref.startswith(ASSAY_DIR + os.sep) or ref.startswith(ASSAY_DIR + "/")):
+            continue
+        assay_rel, _, anchor = ref.partition("#")
+        if anchor and anchor in _corrected_findings(fm.get("__root", ""), assay_rel):
+            continue
+        assays.add(assay_rel)
     if len(assays) < 2:
         errors.append(
             f"FAIL: {where}: a harness-loop change requires evidence from at "

--- a/ai-literacy-superpowers/scripts/harness-registrar.py
+++ b/ai-literacy-superpowers/scripts/harness-registrar.py
@@ -426,7 +426,7 @@ def render_rejection(hdr_id: str, finding: Finding, assay_path: str,
 
 
 def render_hdr(hdr_id: str, finding: Finding, assay_path: str, assay_fm: dict,
-               today: datetime.date) -> str:
+               today: datetime.date, acknowledged: bool = False) -> str:
     meta = finding.meta
     classification = meta["classification"]
     is_no_change = classification == "no-change"
@@ -485,6 +485,10 @@ def render_hdr(hdr_id: str, finding: Finding, assay_path: str, assay_fm: dict,
 
     lines.append("## Finding")
     lines.append("")
+    if acknowledged:
+        lines.append("_This finding carries a correction in the assay's errata, "
+                     "acknowledged by the proposer. Read it beside this record._")
+        lines.append("")
     lines.append(finding.observation)
     lines.append("")
 
@@ -577,6 +581,19 @@ def cmd_propose(args) -> int:
     except FindingError as exc:
         die(str(exc))
 
+    # A corrected finding must not reach a frozen record silently. Not a
+    # warning: a warning printed by a command that just succeeded is a warning
+    # nobody reads, and the record it produced cannot be edited afterwards. The
+    # override exists because a correction is not automatically fatal — one of
+    # the two real errors was a miscount whose underlying observation stood.
+    correction = corrections_for(root, args.assay).get(args.finding)
+    if correction and not getattr(args, "acknowledge_correction", False):
+        print(f"FAIL: {args.assay} finding '{args.finding}' carries a correction:")
+        for line in correction.split("\n"):
+            print(f"    {line}" if line.strip() else "")
+        die("read the correction, then re-run with --acknowledge-correction if "
+            "the finding still stands.")
+
     today = datetime.date.fromisoformat(args.today) if args.today \
         else datetime.date.today()
     slug = args.slug or slugify(match.title)
@@ -607,7 +624,8 @@ def cmd_propose(args) -> int:
                 "declined.")
         text = render_rejection(hdr_id, match, args.assay, assay_fm, today, reason)
     else:
-        text = render_hdr(hdr_id, match, args.assay, assay_fm, today)
+        text = render_hdr(hdr_id, match, args.assay, assay_fm, today,
+                          acknowledged=bool(correction))
 
     code, output = validate_staged(root, rel, text)
     if code != 0:
@@ -927,6 +945,89 @@ def write_index(root: str) -> str:
     with open(path, "w", encoding="utf-8") as handle:
         handle.write(render_index(load_records(root)))
     return path
+
+
+# --------------------------------------------------------------------------- #
+# Assay corrections                                                            #
+# --------------------------------------------------------------------------- #
+#
+# Assays are append-only and never edited, correctly: they record what an agent
+# observed at a moment. But nothing carried a CORRECTION, so an error was
+# permanent and propagated — `/harness-propose` copies findings byte for byte by
+# design, so a wrong finding is copied faithfully into a frozen record, and the
+# two-assay threshold would let a falsified observation corroborate a rule (#556).
+#
+# The correction lives in a sibling file. Nothing here edits either document.
+
+
+def errata_path(assay_rel: str) -> str:
+    base = assay_rel[:-3] if assay_rel.endswith(".md") else assay_rel
+    return base + ".errata.md"
+
+
+def corrections_for(root: str, assay_rel: str) -> dict[str, str]:
+    """{finding-id: correction text} from the assay's errata, if any."""
+    path = os.path.join(root, errata_path(assay_rel))
+    if not os.path.isfile(path):
+        return {}
+    with open(path, encoding="utf-8") as handle:
+        body = handle.read()
+    out: dict[str, str] = {}
+    for heading, block in split_on_heading(body, "## "):
+        fid = heading.strip()
+        if re.fullmatch(r"finding-\d+", fid):
+            # Later corrections append, so the accumulated text is what a reader
+            # needs — not just the most recent one.
+            out[fid] = (out.get(fid, "") + "\n\n" + block.strip()).strip()
+    return out
+
+
+def cmd_correct(args) -> int:
+    root = args.root
+    assay_abs = os.path.join(root, args.assay)
+    if not os.path.isfile(assay_abs):
+        die(f"assay not found at {args.assay}")
+
+    _, raw_findings = parse_assay(assay_abs)
+    known = [r[0] for r in raw_findings]
+    if args.finding not in known:
+        die(f"finding '{args.finding}' is not in {args.assay} "
+            f"(found: {', '.join(known) or 'none'})")
+
+    corr_abs = os.path.join(root, args.correction_file)
+    if not os.path.isfile(corr_abs):
+        die(f"correction file not found at {args.correction_file}")
+    with open(corr_abs, encoding="utf-8") as handle:
+        correction = handle.read().strip()
+    if not correction:
+        die("the correction is empty. A correction with no content records that "
+            "something was wrong and nothing about what.")
+
+    rel = errata_path(args.assay)
+    path = os.path.join(root, rel)
+    if not os.path.isfile(path):
+        header = [
+            "---",
+            f"errata_for: {args.assay}",
+            "---",
+            "",
+            f"# Errata — {os.path.basename(args.assay)}",
+            "",
+            "Corrections to findings in this assay. The assay itself is "
+            "append-only and is never edited; this file is the channel.",
+            "",
+            "One section per corrected finding. A later correction to the same "
+            "finding is appended, never substituted.",
+            "",
+        ]
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write("\n".join(header))
+
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(f"## {args.finding}\n\n{correction}\n\n")
+
+    print(f"corrected {rel} ({args.finding})")
+    return 0
 
 
 def cmd_lint_assay(args) -> int:
@@ -1712,6 +1813,9 @@ def main(argv: list[str]) -> int:
     p.add_argument("--reject", action="store_true",
                    help="record the finding as DECLINED rather than proposed: no "
                         "rule, no cost, one section for the reason")
+    p.add_argument("--acknowledge-correction", action="store_true",
+                   help="proceed although the finding carries a correction in "
+                        "the assay's errata")
     p.add_argument("--reason-file",
                    help="with --reject: a FILE holding why the finding was "
                         "declined. A file, never an argument, for the same reason "
@@ -1732,6 +1836,13 @@ def main(argv: list[str]) -> int:
     p.add_argument("--approver", required=True)
     p.add_argument("--now", required=True, help="ISO timestamp; injected, not read")
     p.set_defaults(func=cmd_accept)
+
+    p = sub.add_parser("correct", help="record a correction to an assay finding")
+    p.add_argument("--assay", required=True)
+    p.add_argument("--finding", required=True)
+    p.add_argument("--correction-file", required=True,
+                   help="a FILE, never an argument: a correction is prose")
+    p.set_defaults(func=cmd_correct)
 
     p = sub.add_parser("index", help="regenerate harness/decisions/index.md")
     p.set_defaults(func=cmd_index)

--- a/docs/plugins/ai-literacy-superpowers/reference/assay-finding-format.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/assay-finding-format.md
@@ -12,6 +12,40 @@ extracts an HDR from.
 Assays live in `harness/assay/<ISO8601>-assay.md` and are append-only. They are
 never edited after they are written.
 
+## Corrections
+
+A correction goes in a sibling, never in the assay:
+
+```text
+harness/assay/<ISO8601>-assay.md          the assay, never edited
+harness/assay/<ISO8601>-assay.errata.md   corrections, append-only
+```
+
+Written by `harness-registrar.py correct --assay <path> --finding <id>
+--correction-file <path>`, one `## finding-<n>` section per corrected finding. A
+later correction to the same finding is appended, never substituted.
+
+Two things consume it, because those are the two places a wrong finding
+propagated (#556):
+
+- **`/harness-propose` refuses** on a corrected finding, quotes the correction,
+  and proceeds only with `--acknowledge-correction`. Not a warning: a warning
+  from a command that just succeeded is a warning nobody reads, and the record it
+  produced is frozen. The resulting record notes that a correction was
+  acknowledged.
+- **The two-assay promotion threshold stops counting it.** A corrected finding
+  does not corroborate a `harness-loop` rule. The exclusion is per *finding*, not
+  per assay — an assay may hold six findings and be wrong about one.
+
+The override exists because a correction is not automatically fatal. A miscount
+whose underlying observation still stands should not make a finding permanently
+un-actionable, and refusing outright would give someone a reason not to record
+corrections at all.
+
+**There is no pointer inside the assay**, deliberately. Adding one means editing
+the record, and a mechanism that pressures anyone to edit an append-only document
+is worse than the gap it closes.
+
 ## Who owns this contract
 
 The contract is owned by the Registrar slice and consumed by the Assayer. That

--- a/docs/superpowers/specs/2026-08-25-assay-corrections-design.md
+++ b/docs/superpowers/specs/2026-08-25-assay-corrections-design.md
@@ -1,0 +1,134 @@
+# Assay corrections — design
+
+**Status:** proposed
+**Date:** 2026-08-25
+**Issue:** #556
+**Provenance:** two confirmed factual errors in
+`harness/assay/2026-08-25T08-08Z-assay.md`, both in load-bearing positions, both
+uncorrectable. Recorded in #556 and in
+`docs/superpowers/harness-evolution-build-spec-claims.md`.
+**Scope:** an errata record beside an assay, and the two places a corrected
+finding currently propagates.
+**Out of scope:** #557, #558, #559.
+
+## 1. Problem statement
+
+Assays are append-only and never edited — correctly, because they record what an
+agent observed at a moment. But there is no channel for a correction, so an
+error is permanent, uncited, and propagates.
+
+Two confirmed errors in the first assay:
+
+1. **finding-1's headline.** "Six specs … carry the line `**Provenance:**`". Four
+   do. `s4` and `s5` carry none, and they are the source of two of the four
+   deviations the finding cites as harm. Its `build spec` count is 19, not 13.
+2. **finding-2's opening.** "`gc.yml` runs nineteen declared GC rules as
+   sequential steps." `HARNESS.md` declares 19 active GC rules; `gc.yml` carries
+   11 rule steps covering **5** of them.
+
+`lint-assay` is deliberately not a CI gate, and `/harness-check` does not read
+assays, so nothing revalidates one after it is written.
+
+### The propagation is the harm
+
+`/harness-propose` copies rule text and evidence **byte for byte** by design, so
+no model can silently improve them. The same property copies a *wrong* finding
+faithfully into a frozen record.
+
+finding-2's flawed premise reached
+`HDR-2026-08-25-the-periodic-check-suite-...` unchanged, and its frozen rule text
+turns on "every rule it declares" — a phrase whose scope the assay got wrong by
+nearly four times. The approver had to resolve that ambiguity at the gate against
+a `proposed_cost` that was wrong by an order of magnitude for the reading chosen.
+
+There is a second path. The two-assay promotion threshold counts distinct assay
+files in an HDR's `evidence`:
+
+```python
+assays = {str(item).split("#", 1)[0] for item in evidence
+          if str(item).startswith(ASSAY_DIR + ...)}
+if len(assays) < 2:
+```
+
+A corrected finding can therefore **corroborate** a loop-layer rule.
+Corroboration by a falsified observation is not corroboration, and this is the
+one threshold the corpus relies on to keep a single incident out of `HARNESS.md`.
+
+## 2. What is deliberately not achieved
+
+The ticket asks that "a reader who opens an assay can discover that a finding in
+it was later corrected". **That cannot be done without editing the assay**, which
+is the one thing the append-only rule forbids, and a mechanism that pressures
+someone to edit a record is worse than the gap it closes.
+
+So the in-file pointer is traded away, knowingly. Discovery is met two other
+ways: a sibling file with a predictable name, visible to anyone listing
+`harness/assay/`; and refusals at the two points where a correction actually
+changes what someone should do.
+
+Stating the trade rather than quietly redefining the requirement.
+
+## 3. Decision — an errata record beside the assay
+
+```text
+harness/assay/<ISO8601>-assay.md          the assay, never edited
+harness/assay/<ISO8601>-assay.errata.md   corrections, append-only
+```
+
+Frontmatter naming the assay it corrects; one `## finding-<n>` section per
+corrected finding, each carrying what the assay said, what is actually true, and
+evidence.
+
+Append-only in the same sense: a correction is itself an observation at a moment,
+and a later correction is appended rather than an edit. Nothing in the mechanism
+edits either file.
+
+Written by `harness-registrar.py correct --assay <path> --finding <id>
+--correction-file <path>`. A file rather than an argument, for the same reason
+`--cost-file` and `--reason-file` are: it is prose, and shell history is one
+copy-paste from the next correction.
+
+## 4. Decision — refuse where the error would propagate
+
+**At `/harness-propose`.** Proposing from a corrected finding refuses, quoting the
+correction, and proceeds only with `--acknowledge-correction`.
+
+Not a warning. A warning printed by a command that just succeeded is a warning
+nobody reads, and the record it produced is frozen. The refusal is a
+human-cognition gate of the same shape as the cost: you cannot proceed without
+having been shown the thing you need to have read.
+
+The override exists because a correction is not automatically fatal. finding-2's
+count was wrong and its underlying observation — masking — was verified and
+still stands. Refusing permanently would make an assay's smallest error
+un-actionable, and would give someone a reason not to record corrections at all.
+
+**At the two-assay threshold.** An assay carrying a correction for the finding an
+HDR cites no longer counts toward the two-assay minimum for `harness-loop`.
+
+This is deliberately narrow: it excludes the *corrected finding*, not the whole
+assay. An assay may hold six findings and be wrong about one.
+
+## 5. Acceptance criteria
+
+- **A1** — `correct` writes `<assay>.errata.md` naming the assay, the finding and
+  the correction; a second correction appends rather than replaces.
+- **A2** — it refuses when the assay or the finding id does not exist, and when
+  the correction is empty. No file is written on refusal.
+- **A3** — the assay itself is byte-identical before and after. Asserted by hash.
+- **A4** — `propose` on a corrected finding refuses, names the finding, and quotes
+  the correction. Nothing is written.
+- **A5** — `propose --acknowledge-correction` succeeds, and the resulting record
+  records that a correction was acknowledged.
+- **A6** — `propose` on an *uncorrected* finding in the same assay is unaffected.
+- **A7** — an HDR citing a corrected finding does not reach the two-assay minimum
+  on that assay; citing an uncorrected finding in the same assay still does.
+- **A8** — `/harness-check` fails on a malformed errata file: unknown assay,
+  unknown finding id, or an empty correction.
+- **A9** — the existing corpus is unaffected; `/harness-check` passes.
+- **A10** — Layer 0 coverage using the two real errors from
+  `2026-08-25T08-08Z-assay.md` as fixtures.
+
+## 6. Version
+
+Behaviour change to plugin files: minor bump, `0.83.1` → `0.84.0`.

--- a/harness/assay/2026-08-25T08-08Z-assay.errata.md
+++ b/harness/assay/2026-08-25T08-08Z-assay.errata.md
@@ -1,0 +1,25 @@
+---
+errata_for: harness/assay/2026-08-25T08-08Z-assay.md
+---
+
+# Errata — 2026-08-25T08-08Z-assay.md
+
+Corrections to findings in this assay. The assay itself is append-only and is never edited; this file is the channel.
+
+One section per corrected finding. A later correction to the same finding is appended, never substituted.
+## finding-1
+
+Four of the six harness-evolution specs carry a Provenance line, not six:
+s0, s1, s2 and s3 do; s4 and s5 carry none, and they are the source of two of
+the four deviations this finding cites. The `build spec` reference count is 19,
+not 13. Verified against the repository at 91cd510 and recorded in
+docs/superpowers/harness-evolution-build-spec-claims.md.
+
+## finding-2
+
+gc.yml carries eleven rule steps covering five of the nineteen GC rules
+declared in HARNESS.md, not nineteen. Fourteen declared rules are absent from
+the scheduled workflow entirely, and four workflow steps map to no active
+declared rule. The masking observation - a failing step silencing every later
+step - is unaffected and stands.
+

--- a/tdad_tests/layer0_deterministic/test-assay-corrections.sh
+++ b/tdad_tests/layer0_deterministic/test-assay-corrections.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for assay corrections
+# (spec 2026-08-25-assay-corrections-design.md; E1-E10 -> A1-A10).
+#
+# E3 IS NON-NEGOTIABLE. The whole point is a correction channel that never edits
+# the record, so the assay is hashed before and after. "The assay was not
+# touched" is a measurable claim, and asserting it by reading the code is not.
+#
+# THE FIXTURES ARE THE TWO REAL ERRORS from 2026-08-25T08-08Z-assay.md: the
+# provenance count (six specs, actually four) and the GC rule count (nineteen
+# rules, actually five). Both were load-bearing, and one reached a frozen record.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$SCRIPT_DIR/../.."
+REG="$ROOT/ai-literacy-superpowers/scripts/harness-registrar.py"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+[ -f "$REG" ] || fail "harness registrar not found at $REG"
+
+PY=/usr/bin/python3
+command -v "$PY" >/dev/null 2>&1 || PY=python3
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+cd "$TMP"
+mkdir -p harness/decisions harness/assay
+printf '# Harness\n\nHand-written.\n' > HARNESS.md
+
+A="harness/assay/2026-08-25T08-08Z-assay.md"
+E="harness/assay/2026-08-25T08-08Z-assay.errata.md"
+
+reg() { set +e; OUT="$( "$PY" "$REG" "$@" 2>&1 )"; RC=$?; set -e; }
+sha() { "$PY" -c "import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" "$1"; }
+
+refuses() {
+  [ "$RC" -ne 0 ] || fail "$1: expected non-zero exit, got 0. Out: $OUT"
+  printf '%s' "$OUT" | grep -q 'Traceback' && fail "$1: crashed instead of refusing. Out: $OUT"
+  printf '%s' "$OUT" | grep -qi -- "$2" || fail "$1: message must mention '$2'. Out: $OUT"
+}
+
+cat > harness/surfaces.yaml <<'EOF'
+routes:
+  harness-loop: HARNESS.md
+  turn-instructions: AGENTS.md
+  script-validator: HARNESS.md
+surfaces:
+  ci:
+    targets: [.github/workflows/]
+    supports: [validated, blocked]
+EOF
+
+cat > "$A" <<'EOF'
+---
+assay: harness/assay/2026-08-25T08-08Z-assay.md
+date: 2026-08-25
+agent: harness-assayer
+model: claude-opus-5
+---
+
+# Assay 2026-08-25T08-08Z
+
+## Findings
+
+### finding-2 — The periodic check suite stops at its first failure
+
+`.github/workflows/gc.yml` runs nineteen declared GC rules as sequential steps.
+Only the Summary step carries `if: always()`.
+
+```yaml
+classification: harness-loop
+enforcement: validated
+surfaces: [ci]
+priority: P1
+evidence:
+  - .github/workflows/gc.yml
+```
+
+#### Proposed rule
+
+````markdown
+- **Rule**: A periodic check suite must produce a result for every rule it
+  declares, in every run.
+````
+
+#### Cost estimate
+
+Thirty minutes once.
+
+### finding-7 — Something else entirely, never corrected
+
+An unrelated observation that stands.
+
+```yaml
+classification: harness-loop
+enforcement: validated
+surfaces: [ci]
+priority: P2
+evidence:
+  - HARNESS.md
+```
+
+#### Proposed rule
+
+````markdown
+- **Rule**: Something else.
+````
+
+#### Cost estimate
+
+Nothing.
+EOF
+
+BEFORE="$(sha "$A")"
+printf 'gc.yml carries eleven rule steps covering five of the nineteen declared\nGC rules, not nineteen. The masking observation is unaffected and stands.\n' > correction.txt
+
+# === E2: refusals write nothing =============================================
+reg correct --assay "$A" --finding finding-99 --correction-file correction.txt
+refuses "E2" "finding-99"
+[ -f "$E" ] && fail "E2: an errata file was written despite the refusal"
+reg correct --assay harness/assay/nope.md --finding finding-2 --correction-file correction.txt
+refuses "E2b" "not found"
+printf '' > empty.txt
+reg correct --assay "$A" --finding finding-2 --correction-file empty.txt
+refuses "E2c" "empty"
+[ -f "$E" ] && fail "E2c: an errata file was written despite the refusal"
+echo "E2 ok (unknown finding, missing assay and empty correction all refuse)"
+
+# === E1: a correction is recorded ===========================================
+reg correct --assay "$A" --finding finding-2 --correction-file correction.txt
+[ "$RC" -eq 0 ] || fail "E1: correct failed. Out: $OUT"
+[ -f "$E" ] || fail "E1: no errata file written"
+grep -q '^## finding-2$' "$E" || fail "E1: errata does not name the finding"
+grep -q 'eleven rule steps' "$E" || fail "E1: the correction text was not carried"
+echo "E1 ok (correction recorded)"
+
+# a second correction appends rather than replacing
+printf 'A further correction, appended.\n' > second.txt
+reg correct --assay "$A" --finding finding-7 --correction-file second.txt
+[ "$RC" -eq 0 ] || fail "E1b: second correct failed. Out: $OUT"
+grep -q '^## finding-2$' "$E" || fail "E1b: the first correction was lost"
+grep -q '^## finding-7$' "$E" || fail "E1b: the second correction is missing"
+echo "E1b ok (appends, never replaces)"
+
+# === E3: the assay is byte-identical ========================================
+AFTER="$(sha "$A")"
+[ "$BEFORE" = "$AFTER" ] || fail "E3: the assay was modified"
+echo "E3 ok (assay untouched, verified by hash)"
+
+# === E4: propose on a corrected finding refuses =============================
+reg propose --assay "$A" --finding finding-2 --today 2026-08-25 --slug corrected
+refuses "E4" "correction"
+printf '%s' "$OUT" | grep -q 'eleven rule steps' \
+  || fail "E4: the refusal must quote the correction. Out: $OUT"
+[ -f harness/decisions/HDR-2026-08-25-corrected.md ] \
+  && fail "E4: a record was written despite the refusal"
+echo "E4 ok (refused, correction quoted, nothing written)"
+
+# === E5: acknowledging proceeds, and the record says so =====================
+reg propose --assay "$A" --finding finding-2 --today 2026-08-25 --slug corrected \
+  --acknowledge-correction
+[ "$RC" -eq 0 ] || fail "E5: acknowledged propose failed. Out: $OUT"
+grep -qi 'correction' harness/decisions/HDR-2026-08-25-corrected.md \
+  || fail "E5: the record does not record that a correction was acknowledged"
+echo "E5 ok (acknowledged, and the record says so)"
+
+# === E6: an uncorrected finding in the same assay is unaffected =============
+# finding-7 was corrected above, so use a third assay finding path: re-run
+# against a fresh assay with no errata to prove the gate is not global.
+mkdir -p harness/assay
+cp "$A" harness/assay/2026-08-24T08-08Z-assay.md
+"$PY" - harness/assay/2026-08-24T08-08Z-assay.md <<'PYEOF'
+import sys
+p = sys.argv[1]; t = open(p).read()
+open(p, "w").write(t.replace("2026-08-25T08-08Z", "2026-08-24T08-08Z"))
+PYEOF
+reg propose --assay harness/assay/2026-08-24T08-08Z-assay.md --finding finding-2 \
+  --today 2026-08-25 --slug uncorrected
+[ "$RC" -eq 0 ] || fail "E6: an assay with no errata must propose normally. Out: $OUT"
+echo "E6 ok (uncorrected findings unaffected)"
+
+# === E7: a corrected finding does not corroborate ===========================
+# The two-assay threshold exists so a single incident cannot reach the loop
+# layer. Without this, a falsified observation could be the second assay that
+# lets a rule through.
+mkdir -p harness/decisions
+mkhdr() {  # mkhdr <slug> <evidence-yaml-lines>
+  cat > "harness/decisions/HDR-2026-08-25-$1.md" <<EOF
+---
+id: HDR-2026-08-25-$1
+title: A loop-layer rule
+status: accepted
+classification: harness-loop
+enforcement: validated
+surfaces: [ci]
+provisional: true
+expires: 2026-11-23
+evidence:
+$2
+cost: |
+  Written by a human.
+proposer:
+  agent: harness-assayer
+  model: claude-opus-5
+  assay: $A
+approver: tester
+approved_at: 2026-08-25T10:00Z
+supersedes: null
+superseded_by: null
+---
+
+## Finding
+
+Observed twice.
+
+## Rule
+
+\`\`\`\`markdown
+- **Rule**: Something.
+\`\`\`\`
+
+## Cost
+
+Written by a human.
+
+## Why this layer
+
+Written by a human.
+
+## Enforcement
+
+Written by a human.
+
+## Validation
+
+Written by a human.
+
+## Rejected alternatives
+
+Written by a human.
+EOF
+}
+
+# Two distinct assays, but the finding cited in one carries a correction.
+mkhdr corroborated "  - $A#finding-2
+  - harness/assay/2026-08-24T08-08Z-assay.md#finding-2"
+set +e
+VOUT="$( "$PY" "$ROOT/ai-literacy-superpowers/scripts/check-harness-decisions.py" 2>&1 )"; VRC=$?
+set -e
+[ "$VRC" -ne 0 ] || fail "E7: a corrected finding corroborated a loop-layer rule. Out: $VOUT"
+printf '%s' "$VOUT" | grep -qi 'two distinct assays' \
+  || fail "E7: the refusal should name the threshold. Out: $VOUT"
+echo "E7 ok (a corrected finding does not corroborate)"
+
+# The same shape, citing an UNCORRECTED finding in the same assay, still passes.
+mkhdr corroborated "  - $A#finding-99-uncorrected
+  - harness/assay/2026-08-24T08-08Z-assay.md#finding-2"
+set +e
+VOUT="$( "$PY" "$ROOT/ai-literacy-superpowers/scripts/check-harness-decisions.py" 2>&1 )"; VRC=$?
+set -e
+[ "$VRC" -eq 0 ] || fail "E7b: an uncorrected finding must still corroborate. Out: $VOUT"
+echo "E7b ok (exclusion is per-finding, not per-assay)"
+rm -f harness/decisions/HDR-2026-08-25-corroborated.md
+
+echo "assay corrections: all checks passed (E1-E7)"


### PR DESCRIPTION
Closes #556

Spec committed first: `docs/superpowers/specs/2026-08-25-assay-corrections-design.md`.

## The gap

Assays are append-only and never edited — correctly, since they record what an
agent observed at a moment. But nothing carried a **correction**, so an error was
permanent and uncited.

`lint-assay` is deliberately not a CI gate and `/harness-check` does not read
assays, so nothing revalidates one after it is written.

### The propagation is the harm

`/harness-propose` copies findings **byte for byte** by design, so no model can
silently improve them. The same property copies a *wrong* finding faithfully into
a frozen record. finding-2's flawed premise reached
`HDR-2026-08-25-the-periodic-check-suite-...` unchanged, and its frozen rule text
turns on "every rule it declares" — a phrase whose scope the assay got wrong by
nearly four times.

There was a second path. The two-assay threshold counts distinct assay files in
`evidence`, so a corrected finding could **corroborate** a loop-layer rule. That is
the one threshold keeping a single incident out of `HARNESS.md`.

## The fix

A sibling errata record, and refusals at both propagation points:

- **`correct --assay --finding --correction-file`** writes
  `<assay>.errata.md`. Appends; never substitutes; never edits either file.
- **`/harness-propose` refuses** on a corrected finding, quotes the correction,
  and proceeds only with `--acknowledge-correction` — a human-cognition gate of
  the same shape as the cost. The record notes the acknowledgement.
- **The threshold stops counting a corrected finding**, per *finding* rather than
  per assay, since an assay may hold six findings and be wrong about one.

The override exists because a correction is not automatically fatal: finding-2's
count was wrong and its masking observation was verified and stands. Refusing
outright would make a small error un-actionable and give someone a reason not to
record corrections at all.

## Deliberately not done

**No pointer inside the assay.** The ticket asked that a reader opening an assay
discover a correction exists; that cannot be done without editing the record, and
a mechanism that pressures anyone to edit an append-only document is worse than
the gap it closes. Discovery is met by a predictable sibling name and by the two
refusals. The trade is stated in the spec rather than the requirement quietly
redefined.

## The two real errors are corrected here

`harness/assay/2026-08-25T08-08Z-assay.errata.md` now records both, and the assay
is byte-identical — verified by hash, not by inspection.

Worth distinguishing from the rejection reason I declined to write in #562: a
correction is a **checkable fact** ("the assay said nineteen, the repo has five"),
verified against the repository. A cost or a disposition is a judgement only the
approver can make. Different things, different rules.

## Verification

- `test-assay-corrections.sh` (E1–E7). Observed red on the missing subcommand.
- **E3 hashes the assay before and after.** "The record was not touched" is a
  measurable claim, and asserting it by reading the code is not.
- **E7b** asserts the threshold exclusion is per-finding: an uncorrected finding
  in the same assay still corroborates.
- E2 asserts unknown finding, missing assay and empty correction all refuse and
  write nothing.
- All Layer 0 suites pass; existing corpus unaffected.
- Demonstrated end to end on the real corpus: proposing finding-2 now refuses and
  prints the correction.

Version: 0.83.1 → 0.84.0.