### PR TITLE
Merge a project's routing table with the defaults

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.84.0",
+  "plugin_version": "0.85.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.84.0"
+      "version": "0.85.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## 0.85.0 — 2026-08-25
+
+### Fixed — a project's routing table merges with the defaults instead of replacing them
+
+`effective_routes`' docstring said "defaults included" and the function returned
+only the project's routes, so declaring one custom route silently dropped every
+default — `harness-loop: HARNESS.md` included. The failure surfaced late, at
+acceptance, on a record someone had already read, argued and costed, and the
+cause was a line in `surfaces.yaml` that reads as additive. See #559.
+
+It also meant a route shipped in a new plugin release could never reach a project
+that had customised the file it lives in — the same shape as the template-currency
+problem in #547. Adding `script-validator` to the defaults in 0.80.0 had no effect
+on this repository until the route was written into `harness/surfaces.yaml` by
+hand.
+
+- **`routes:` now merges**: the plugin's defaults, overlaid with the project's.
+  The docstring is true, and future defaults propagate.
+- **A default is suppressed by mapping it to an empty value**, and a suppressed
+  classification behaves as unrouted — the record names its own `target`, as it
+  already must for classifications with no default.
+- **The `surfaces.yaml` validator accepts an empty route value** as suppression
+  rather than rejecting it as malformed.
+- **Layer 0 suite** `test-routes-merge.sh` (M1–M7).
+
+### Why suppression is not decoration
+
+`target_of` prefers a route over any `target` a record names. So merging a
+default back for a project that lacks its target artifact — `AGENTS.md`, say —
+would leave records of that classification refused at compile **and impossible to
+redirect**, because the route wins. Today such a project omits the route and names
+targets explicitly; a merge without an escape hatch would take that away and offer
+nothing in its place. M6 covers the case.
+
+### Adopter impact
+
+A project declaring a partial `routes:` block will find the omitted defaults back
+in force. This is a fix rather than a change of mind — the documented contract was
+always "defaults included", so those projects were getting behaviour that
+contradicted the documentation. One blank line per route restores the old effect,
+and the refusal that would otherwise appear names the classification.
+
+This repository's routes resolve identically and its enforcement report is
+byte-identical.
+
+### Also corrected
+
+The `surfaces.yaml` comment and the reference page added in 0.80.0 both stated
+that a `routes:` block replaces the defaults. Both now describe merging. A comment
+that contradicts behaviour is the defect this release exists to fix, one level up.
+
 ## 0.84.0 — 2026-08-25
 
 ### Added — assays can be corrected without being edited

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.84.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.85.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-42-2E8B57?style=flat-square)](#skills-42)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.84.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.85.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.84.0",
+  "version": "0.85.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/scripts/check-harness-decisions.py
+++ b/ai-literacy-superpowers/scripts/check-harness-decisions.py
@@ -382,6 +382,11 @@ def check_routes(doc: dict, errors: list[str]) -> dict[str, str]:
                 f"FAIL: {SURFACES_FILE}: 'no-change' cannot be routed — a "
                 "no-change decision has no rule text to place."
             )
+        # An empty value is not a malformed route: it SUPPRESSES the default
+        # for that classification, which is how a project without the default's
+        # target artifact keeps records of that class acceptable (#559).
+        if target is None or (isinstance(target, str) and not target.strip()):
+            continue
         if not isinstance(target, str) or not target.strip():
             errors.append(
                 f"FAIL: {SURFACES_FILE}: route for '{classification}' must be a "
@@ -462,7 +467,27 @@ def check_surfaces(root: str, errors: list[str]) -> dict[str, dict]:
 
 
 def effective_routes(root: str) -> dict[str, str]:
-    """The routing table in force, defaults included."""
+    """The routing table in force: the defaults, overlaid with the project's.
+
+    This MERGES rather than replaces. It used to return only the project's
+    routes, so declaring one custom route silently dropped every default -
+    including `harness-loop: HARNESS.md` - and the failure surfaced late, at
+    acceptance, on a record someone had already argued and costed. It also meant
+    a route added in a new plugin release could never reach a project that had
+    customised the file it lives in (#559).
+
+    A default is SUPPRESSED by mapping it to an empty value:
+
+        routes:
+          turn-instructions:      # this project has no AGENTS.md
+
+    The escape hatch is not decoration. `target_of` prefers a route over any
+    `target` a record names, so a merged-back default pointing at a file the
+    project does not have would leave records of that classification refused at
+    compile and impossible to redirect. Suppression keeps that case reachable,
+    and a suppressed classification simply behaves as unrouted: the record names
+    its own target, as it already must for the classifications with no default.
+    """
     path = os.path.join(root, SURFACES_FILE)
     if not os.path.isfile(path):
         return dict(DEFAULT_ROUTES)
@@ -474,7 +499,15 @@ def effective_routes(root: str) -> dict[str, str]:
     routes = doc.get("routes")
     if not isinstance(routes, dict) or not routes:
         return dict(DEFAULT_ROUTES)
-    return {k: v for k, v in routes.items() if isinstance(v, str) and v.strip()}
+
+    merged = dict(DEFAULT_ROUTES)
+    for key, value in routes.items():
+        if isinstance(value, str) and value.strip():
+            merged[key] = value
+        else:
+            # Declared with no value: suppress the default rather than inherit it.
+            merged.pop(key, None)
+    return merged
 
 
 def check_hdr(path: str, surfaces: dict, errors: list[str],

--- a/docs/plugins/ai-literacy-superpowers/reference/harness-decision-records.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/harness-decision-records.md
@@ -324,8 +324,22 @@ un-evidenced legacy rules ever did.
 
 ## `surfaces.yaml`
 
-A `routes:` block **replaces** the defaults rather than merging with them, so
-every route a project relies on must be listed in its own file:
+A `routes:` block **merges** with the plugin's defaults, so a default this file
+does not mention stays in force. Map a classification to an empty value to
+suppress its default — records of that classification then name their own
+`target`, as they already must for the classifications that have no default:
+
+```yaml
+routes:
+  turn-instructions:      # suppressed: this project has no AGENTS.md
+```
+
+Suppression exists because `target_of` prefers a route over any `target` a record
+names. Without it, a default pointing at an artifact a project does not have
+would leave records of that classification refused at compile and impossible to
+redirect (#559).
+
+A project's own entries override defaults of the same name:
 
 ```yaml
 routes:

--- a/docs/superpowers/specs/2026-08-25-routes-merge-design.md
+++ b/docs/superpowers/specs/2026-08-25-routes-merge-design.md
@@ -1,0 +1,121 @@
+# Routing table merge semantics — design
+
+**Status:** proposed
+**Date:** 2026-08-25
+**Issue:** #559
+**Provenance:** found while fixing #551, documented in
+`harness-decision-records.md` and PR #552, never fixed.
+**Scope:** `effective_routes` in `check-harness-decisions.py`.
+**Out of scope:** #557, #558.
+
+## 1. Problem statement
+
+```python
+def effective_routes(root: str) -> dict[str, str]:
+    """The routing table in force, defaults included."""
+    ...
+    routes = doc.get("routes")
+    if not isinstance(routes, dict) or not routes:
+        return dict(DEFAULT_ROUTES)
+    return {k: v for k, v in routes.items() if isinstance(v, str) and v.strip()}
+```
+
+The last line returns **only** the project's routes. The docstring says "defaults
+included" and is false in exactly the branch it describes — the one where a
+project has declared routes.
+
+A project that declares one custom route silently loses every default, including
+`harness-loop: HARNESS.md`. Those classifications then have no route, and
+`compile_plan` refuses at acceptance:
+
+```text
+FAIL: <record>: classification 'harness-loop' has no route and the HDR names no 'target'.
+```
+
+Loud when it bites, but late: on a record someone has already read, argued and
+written a cost for, and the cause is a line in `surfaces.yaml` that reads as
+additive.
+
+### Observed
+
+This repository declared two routes. Adding `script-validator` to
+`DEFAULT_ROUTES` in #552 therefore had no local effect until the route was also
+written into `harness/surfaces.yaml`:
+
+```text
+resolved routes: {'harness-loop': 'HARNESS.md', 'turn-instructions': 'AGENTS.md'}
+```
+
+That is the upgrade problem in miniature, and the same shape as #547: a default
+the plugin ships cannot reach any project that has customised the thing it lives
+in.
+
+## 2. Decision — merge, with an explicit way to suppress
+
+`effective_routes` returns `DEFAULT_ROUTES` overlaid with the project's routes.
+The docstring becomes true, and a route added in a future release reaches
+projects that have customised their table.
+
+**A default can be suppressed by mapping it to an empty value:**
+
+```yaml
+routes:
+  turn-instructions:      # suppressed: this project has no AGENTS.md
+  script-validator: HARNESS.md
+```
+
+### Why the escape hatch is not optional
+
+A plain merge has a failure case. `target_of` prefers the route over any `target`
+the record names:
+
+```python
+routed = routes.get(str(record.classification))
+if routed:
+    return routed
+```
+
+So for a project with no `AGENTS.md`, restoring `turn-instructions: AGENTS.md`
+means a record of that classification routes to a file that does not exist,
+`compile_plan` refuses, and **nothing can redirect it** — the record cannot name
+its own target, because the route wins.
+
+Today such a project omits the route and names targets explicitly. A merge
+without suppression would take that away and leave no alternative. Three lines
+buys back the case, so the case is bought back.
+
+Suppression is by empty value rather than a separate key because the existing
+filter already drops non-string and blank values; this makes that behaviour
+meaningful instead of incidental.
+
+## 3. Adopter impact, stated plainly
+
+A project that today declares a partial `routes:` block will find the omitted
+defaults **back in force** after upgrading.
+
+This is a fix rather than a change of mind: the documented contract was always
+"defaults included", so those projects were getting behaviour that contradicted
+the documentation. Restoring the documented behaviour is the correction.
+
+Where a project relied on the undocumented behaviour, one blank line per
+suppressed route restores it, and the refusal that would otherwise appear names
+the classification, so the remedy is discoverable.
+
+## 4. Acceptance criteria
+
+- **A1** — with no `surfaces.yaml`, the defaults are returned. Unchanged.
+- **A2** — with no `routes:` block, the defaults are returned. Unchanged.
+- **A3** — a partial `routes:` block yields the defaults **plus** the project's
+  entries.
+- **A4** — a project entry overrides a default of the same name.
+- **A5** — a default mapped to an empty value is **absent** from the result.
+- **A6** — a suppressed classification behaves as unrouted: a record of that
+  classification must name its own `target`, and one that does is accepted.
+- **A7** — the docstring matches the behaviour.
+- **A8** — this repository's corpus is unaffected; `/harness-check` passes and the
+  enforcement report is byte-identical.
+- **A9** — Layer 0 coverage for each of the above, so the trap cannot reopen.
+
+## 5. Version
+
+Behaviour change to plugin files: minor bump, `0.84.0` → `0.85.0`.

--- a/harness/surfaces.yaml
+++ b/harness/surfaces.yaml
@@ -15,8 +15,10 @@
 # Where a rule's TEXT goes, by classification. Two have a fixed home; the rest
 # name their own `target`, because nothing in the schema can infer which of four
 # agent files a given agent instruction belongs in.
-# NOTE: a `routes:` block REPLACES the defaults rather than merging with them
-# (`effective_routes`), so every route this project relies on must be listed here.
+# A `routes:` block MERGES with the plugin's defaults (`effective_routes`), so a
+# default this file does not mention stays in force. Map one to an empty value to
+# suppress it, which makes records of that classification name their own target.
+# The entries below are explicit so this project pins them even if a default moves.
 routes:
   harness-loop: HARNESS.md
   turn-instructions: AGENTS.md

--- a/tdad_tests/layer0_deterministic/test-routes-merge.sh
+++ b/tdad_tests/layer0_deterministic/test-routes-merge.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for routing table merge semantics
+# (spec 2026-08-25-routes-merge-design.md; M1-M9 -> A1-A9).
+#
+# M5/M6 ARE WHY THIS IS NOT A ONE-LINE FIX. `target_of` prefers the route over
+# any target a record names, so a merged-back default that points at a file the
+# project does not have would leave records of that classification unacceptable
+# AND unredirectable. Suppression is what keeps that case reachable.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$SCRIPT_DIR/../.."
+VAL="$ROOT/ai-literacy-superpowers/scripts/check-harness-decisions.py"
+REG="$ROOT/ai-literacy-superpowers/scripts/harness-registrar.py"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+[ -f "$VAL" ] || fail "validator not found at $VAL"
+
+PY=/usr/bin/python3
+command -v "$PY" >/dev/null 2>&1 || PY=python3
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+cd "$TMP"
+mkdir -p harness/decisions harness/assay
+printf '# Harness\n\nHand-written.\n' > HARNESS.md
+export VAL
+
+routes() {  # routes -> "k=v,k=v" sorted
+  "$PY" - <<'PYEOF'
+import importlib.util, os
+spec = importlib.util.spec_from_file_location("val", os.environ["VAL"])
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+r = m.effective_routes(".")
+print(",".join(f"{k}={v}" for k, v in sorted(r.items())))
+PYEOF
+}
+
+DEFAULTS="harness-loop=HARNESS.md,script-validator=HARNESS.md,turn-instructions=AGENTS.md"
+
+# === M1: no surfaces.yaml at all ============================================
+[ "$(routes)" = "$DEFAULTS" ] || fail "M1: expected defaults, got $(routes)"
+echo "M1 ok (no surfaces.yaml -> defaults)"
+
+# === M2: a surfaces.yaml with no routes block ===============================
+cat > harness/surfaces.yaml <<'EOF'
+surfaces:
+  ci:
+    targets: [.github/workflows/]
+    supports: [validated, blocked]
+EOF
+[ "$(routes)" = "$DEFAULTS" ] || fail "M2: expected defaults, got $(routes)"
+echo "M2 ok (no routes block -> defaults)"
+
+# === M3: a partial block keeps the defaults it does not mention =============
+# This is the trap: declaring one route silently dropped every default,
+# including harness-loop, and the failure surfaced only at acceptance.
+cat > harness/surfaces.yaml <<'EOF'
+routes:
+  agent-instruction: .claude/agents/example.agent.md
+surfaces:
+  ci:
+    targets: [.github/workflows/]
+    supports: [validated, blocked]
+EOF
+GOT="$(routes)"
+printf '%s' "$GOT" | grep -q 'harness-loop=HARNESS.md' \
+  || fail "M3: harness-loop default was dropped. Got $GOT"
+printf '%s' "$GOT" | grep -q 'turn-instructions=AGENTS.md' \
+  || fail "M3: turn-instructions default was dropped. Got $GOT"
+printf '%s' "$GOT" | grep -q 'agent-instruction=.claude/agents/example.agent.md' \
+  || fail "M3: the project's own route is missing. Got $GOT"
+echo "M3 ok (partial block merges with defaults)"
+
+# === M4: a project entry overrides a default of the same name ===============
+cat > harness/surfaces.yaml <<'EOF'
+routes:
+  harness-loop: GOVERNANCE.md
+surfaces:
+  ci:
+    targets: [.github/workflows/]
+    supports: [validated, blocked]
+EOF
+printf '%s' "$(routes)" | grep -q 'harness-loop=GOVERNANCE.md' \
+  || fail "M4: the project override did not win. Got $(routes)"
+echo "M4 ok (project entry overrides the default)"
+
+# === M5: an empty value suppresses a default ================================
+cat > harness/surfaces.yaml <<'EOF'
+routes:
+  turn-instructions:
+  script-validator: HARNESS.md
+surfaces:
+  ci:
+    targets: [.github/workflows/]
+    supports: [validated, blocked]
+EOF
+GOT="$(routes)"
+printf '%s' "$GOT" | grep -q 'turn-instructions=' \
+  && fail "M5: the suppressed default is still present. Got $GOT"
+printf '%s' "$GOT" | grep -q 'harness-loop=HARNESS.md' \
+  || fail "M5: suppression must not drop the other defaults. Got $GOT"
+echo "M5 ok (empty value suppresses, others survive)"
+
+# === M6: a suppressed classification behaves as unrouted ====================
+# The record must name its own target, and one that does must be accepted.
+# Without this, a project with no AGENTS.md could never accept a
+# turn-instructions record: the route wins over any target it names.
+cat > harness/assay/2026-08-25T08-08Z-assay.md <<'EOF'
+---
+assay: harness/assay/2026-08-25T08-08Z-assay.md
+date: 2026-08-25
+agent: harness-assayer
+model: claude-opus-5
+---
+
+# Assay
+
+## Findings
+
+### finding-1 — A turn-level instruction
+
+Observed once.
+
+```yaml
+classification: turn-instructions
+enforcement: advisory
+surfaces: [ci]
+target: HARNESS.md
+priority: P2
+evidence:
+  - HARNESS.md
+```
+
+#### Proposed rule
+
+````markdown
+- **Rule**: Something about the turn.
+````
+
+#### Cost estimate
+
+Nothing.
+EOF
+set +e
+OUT="$( "$PY" "$REG" propose --assay harness/assay/2026-08-25T08-08Z-assay.md \
+  --finding finding-1 --today 2026-08-25 --slug routed 2>&1 )"
+RC=$?
+set -e
+[ "$RC" -eq 0 ] || fail "M6: propose failed. Out: $OUT"
+printf 'Written by a human.\n' > cost.txt
+set +e
+OUT="$( "$PY" "$REG" accept --hdr harness/decisions/HDR-2026-08-25-routed.md \
+  --cost-file cost.txt --approver tester --now 2026-08-25T10:00Z 2>&1 )"
+RC=$?
+set -e
+[ "$RC" -eq 0 ] || fail "M6: a suppressed classification must honour its own target. Out: $OUT"
+grep -q 'Something about the turn' HARNESS.md \
+  || fail "M6: the rule was not applied to the named target"
+[ -f AGENTS.md ] && fail "M6: the suppressed route was used anyway"
+echo "M6 ok (suppressed classification honours its own target)"
+
+# === M7: the docstring matches the behaviour ================================
+"$PY" - <<'PYEOF'
+import importlib.util, os
+spec = importlib.util.spec_from_file_location("val", os.environ["VAL"])
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+doc = (m.effective_routes.__doc__ or "")
+assert "defaults" in doc.lower(), "M7: the docstring should still describe defaults"
+PYEOF
+echo "M7 ok (docstring describes what happens)"
+
+echo "routes merge: all checks passed (M1-M7)"


### PR DESCRIPTION
Closes #559

Spec committed first: `docs/superpowers/specs/2026-08-25-routes-merge-design.md`.

## The defect

```python
def effective_routes(root: str) -> dict[str, str]:
    """The routing table in force, defaults included."""
    ...
    return {k: v for k, v in routes.items() if isinstance(v, str) and v.strip()}
```

The docstring was false in exactly the branch it describes. A project declaring
one custom route silently lost every default, including
`harness-loop: HARNESS.md`, and the failure surfaced late — at acceptance, on a
record already read, argued and costed — with the cause a `surfaces.yaml` line
that reads as additive.

It also blocked upgrades: adding `script-validator` to the defaults in 0.80.0 had
no effect here until the route was hand-written into `harness/surfaces.yaml`. Same
shape as the template-currency problem in #547 — a default that cannot propagate.

## The fix, and why it is not one line

`routes:` merges. **A default is suppressed by mapping it to an empty value.**

The escape hatch is load-bearing. `target_of` prefers a route over any `target` a
record names:

```python
routed = routes.get(str(record.classification))
if routed:
    return routed
```

So merging `turn-instructions: AGENTS.md` back for a project with no `AGENTS.md`
would leave records of that classification refused at compile **and impossible to
redirect** — the route wins over the target. Today those projects omit the route
and name targets explicitly; a plain merge takes that away and offers nothing
instead. **M6** covers exactly this: a suppressed classification honours its own
target, applies to it, and never touches the suppressed route's file.

The `surfaces.yaml` validator also had to stop treating an empty route value as
malformed.

## Adopter impact

A project with a partial `routes:` block will find the omitted defaults back in
force. That is a fix, not a change of mind: the documented contract was always
"defaults included", so those projects were getting behaviour that contradicted
the docs. One blank line per route restores the old effect, and the refusal that
would otherwise appear names the classification.

This repository's routes resolve identically; enforcement report byte-identical.

## Also corrected

The `surfaces.yaml` comment and the reference page I added in 0.80.0 both said a
`routes:` block *replaces* the defaults. Both now describe merging. A comment that
contradicts behaviour is this release's own defect one level up, and leaving it
would have been the same mistake in a new place.

## Verification

- `test-routes-merge.sh` (M1–M7). Observed red on M3 — the exact trap.
- M1/M2 pin the unchanged paths; M4 covers override; M5 covers suppression
  without collateral; M7 keeps the docstring honest.
- All Layer 0 suites pass.

Version: 0.84.0 → 0.85.0.