### PR TITLE
Let the approver set the target at the acceptance gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.85.0",
+  "plugin_version": "0.86.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.85.0"
+      "version": "0.86.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 0.86.0 — 2026-08-25
+
+### Fixed — the target can now be set where the reference always said it was
+
+`harness-decision-records.md` has always described `target` as binding at
+acceptance, "because the Assayer frequently identifies a behaviour without
+knowing which of four agent files should own it. That is the human's decision,
+made at the gate beside the cost."
+
+The code fixed it at proposal, copied verbatim from an append-only assay, and
+`/harness-accept` had no way to set one. **The documented workflow was therefore
+impossible**: a finding naming no target proposed cleanly and could never be
+accepted, with no exit but a new assay finding or supersession. See #557.
+
+- **`/harness-accept --target <path>`** supplies the artifact that will host the
+  rule.
+- **Three refusals keep it narrow.** A routed classification refuses `--target`,
+  because `target_of` prefers the route and the value would be silently ignored —
+  and silently discarding what someone typed is what #551 was about. The target
+  must be able to hold the rule (the `.md` check from 0.80.0, reused), and it
+  must exist.
+- **Provenance is recorded.** Where the assay named a target and the approver
+  overrides it, the Assayer's value is preserved as `proposed_target`. Third
+  application of the `proposed_cost` / `cost` pattern: two people contributed to
+  one record and a reader should be able to tell which part came from whom.
+- **Layer 0 suite** `test-target-at-the-gate.sh` (T1–T9), hashing the corpus
+  across every refusal.
+
+### The objection, recorded rather than dismissed
+
+Letting the approver retarget at the gate lets a rule be moved to wherever it
+applies cleanly, which is a cousin of reclassifying to clear a threshold. It is a
+weaker cousin: reclassification changes the evidentiary bar a rule must clear,
+which is what the two-assay threshold turns on, while retargeting only changes
+which prose document hosts the text — and since 0.80.0 that must be markdown, so
+every option is a governance artifact. `proposed_target` makes the move visible.
+
+### Note on the ticket's preferred option
+
+The ticket leaned toward `--target` on `/harness-propose`. Rejected after testing the
+documented flow: if the Assayer cannot know which of four agent files owns a
+behaviour, neither can whoever drafts the record thirty seconds later. The person
+who can decide is the one reading the rule beside its cost, which is what the
+reference said all along.
+
 ## 0.85.0 — 2026-08-25
 
 ### Fixed — a project's routing table merges with the defaults instead of replacing them

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.85.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.86.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-42-2E8B57?style=flat-square)](#skills-42)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.85.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.86.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.85.0",
+  "version": "0.86.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/scripts/harness-registrar.py
+++ b/ai-literacy-superpowers/scripts/harness-registrar.py
@@ -748,6 +748,63 @@ def cmd_precheck(args) -> int:
     return 0
 
 
+def apply_target_override(args, hdr_abs: str) -> None:
+    """Let the approver name the artifact that will host the rule.
+
+    `harness-decision-records.md` has always said `target` binds at ACCEPTANCE,
+    "because the Assayer frequently identifies a behaviour without knowing which
+    of four agent files should own it. That is the human's decision, made at the
+    gate beside the cost." The code fixed it at proposal and offered no way to
+    set one, so that workflow was impossible: such a record proposed cleanly and
+    could never be accepted (#557).
+
+    Where the assay named a target and the approver overrides it, the Assayer's
+    value is preserved as `proposed_target`. Two people contributed to one record
+    and a reader should be able to tell which part came from whom — the same
+    reason `proposed_cost` sits beside `cost`.
+    """
+    target = getattr(args, "target", None)
+    if not target:
+        return
+
+    with open(hdr_abs, encoding="utf-8") as handle:
+        text = handle.read()
+    raw_fm, _ = S0.split_frontmatter(text)
+    fm = S0.parse_yaml(raw_fm) if raw_fm else {}
+
+    routes, _ = load_matrix(args.root)
+    classification = str(fm.get("classification") or "")
+    if routes.get(classification):
+        die(f"classification '{classification}' is routed to "
+            f"'{routes[classification]}' in harness/surfaces.yaml, so --target "
+            "would be silently ignored. Change the route, or suppress it for this "
+            "project, rather than naming a target the compiler will not use.")
+
+    if not hosts_prose(target):
+        die(target_refusal(os.path.relpath(hdr_abs, args.root), target))
+    if not os.path.exists(os.path.join(args.root, target)):
+        die(f"target '{target}' does not exist. The Registrar writes records, "
+            "not governance documents — create the artifact, or name one that "
+            "exists.")
+
+    previous = fm.get("target")
+    lines = text.split("\n")
+    end = next(i for i in range(1, len(lines)) if lines[i] == "---")
+    out, replaced = [], False
+    for i, line in enumerate(lines):
+        if 0 < i < end and line.startswith("target:"):
+            if previous and str(previous) != target:
+                out.append(f"proposed_target: {previous}")
+            out.append(f"target: {target}")
+            replaced = True
+            continue
+        out.append(line)
+    if not replaced:
+        out.insert(end, f"target: {target}")
+    with open(hdr_abs, "w", encoding="utf-8") as handle:
+        handle.write("\n".join(out))
+
+
 def cmd_accept(args) -> int:
     cost_abs = os.path.join(args.root, args.cost_file)
     if not os.path.isfile(cost_abs):
@@ -758,6 +815,7 @@ def cmd_accept(args) -> int:
         die("the cost is empty. The approver writes what this rule will demand "
             "of whoever works here next, and how it might be gamed.")
 
+    apply_target_override(args, os.path.join(args.root, args.hdr))
     hdr_abs, candidate, _ = _accept_common(args, cost, "acceptance")
 
     # Applying and compiling are NOT separate approval gates. Once an HDR is
@@ -1835,6 +1893,10 @@ def main(argv: list[str]) -> int:
                         "shell history one copy-paste from the next HDR")
     p.add_argument("--approver", required=True)
     p.add_argument("--now", required=True, help="ISO timestamp; injected, not read")
+    p.add_argument("--target",
+                   help="the artifact that will host this rule. The Assayer often "
+                        "cannot know which one owns a behaviour; this is where "
+                        "that is decided, beside the cost")
     p.set_defaults(func=cmd_accept)
 
     p = sub.add_parser("correct", help="record a correction to an assay finding")

--- a/docs/plugins/ai-literacy-superpowers/reference/harness-decision-records.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/harness-decision-records.md
@@ -182,7 +182,25 @@ nobody had asked about `.yml`.
 
 It binds at acceptance rather than at proposal because the Assayer frequently
 identifies a behaviour without knowing which of four agent files should own it.
-That is the human's decision, made at the gate beside the cost.
+That is the human's decision, made at the gate beside the cost:
+
+```bash
+/harness-accept <hdr> --target .claude/agents/tdd-agent.agent.md
+```
+
+A finding that names no target proposes normally and is refused at acceptance
+until one is supplied — the refusal names the classification. Until 0.86.0 there
+was no way to supply it, so the workflow this paragraph describes was impossible
+and such a record could never be accepted (#557).
+
+Three refusals bound it. A **routed** classification refuses `--target`, because
+`target_of` prefers the route and the value would be silently ignored. The target
+must be a markdown artifact, and it must exist.
+
+Where the assay named a target and the approver overrides it, the Assayer's value
+is preserved as **`proposed_target`** and the approver's goes in `target` — the
+same split as `proposed_cost` and `cost`, so a reader can tell which part of a
+record came from whom.
 
 **A `validator` must resolve, be runnable, and name the record it enforces.**
 Every listed path must exist; each must carry the executable bit or a `.py`,

--- a/docs/superpowers/specs/2026-08-25-target-at-the-gate-design.md
+++ b/docs/superpowers/specs/2026-08-25-target-at-the-gate-design.md
@@ -1,0 +1,110 @@
+# The target binds at the gate — design
+
+**Status:** proposed
+**Date:** 2026-08-25
+**Issue:** #557
+**Provenance:** deferred deliberately in the #551 spec (§4). The evidence below
+was gathered before this spec was written and changes the conclusion that ticket
+reached.
+**Scope:** where `target` is set, and by whom.
+**Out of scope:** #558.
+
+## 1. Problem statement
+
+`harness-decision-records.md` says:
+
+> **`target`** … binds at **acceptance** rather than at proposal because the
+> Assayer frequently identifies a behaviour without knowing which of four agent
+> files should own it. That is the human's decision, made at the gate beside the
+> cost.
+
+The code fixes `target` at proposal, copied verbatim from an append-only assay,
+and `/harness-accept` has no way to set one.
+
+**The documented workflow is therefore impossible**, not merely inconvenient.
+Observed: an `agent-instruction` finding that names no target proposes cleanly,
+and then
+
+```text
+FAIL: <record>: classification 'agent-instruction' has no route and the HDR
+      names no 'target'.
+FAIL: acceptance refused; nothing was written and the HDR is still proposed.
+```
+
+with no flag that can supply one. The record is permanently unacceptable. The
+only exits are a new assay finding that guesses a target, or supersession.
+
+This is broader than the mis-targeting #551 exposed. #551 made a *wrong* target
+refuse; this is a *missing* target that the reference says is the normal case.
+
+### Why the ticket's preferred option was wrong
+
+#557 leaned toward `--target` on `/harness-propose`, on the reasoning that a
+correction before approval is cleaner than a change at the gate.
+
+That contradicts the documented rationale and does not solve the case. If the
+Assayer cannot know which of four agent files owns a behaviour, neither can
+whoever drafts the record thirty seconds later; the person who can decide is the
+one reading the rule at the gate, next to its cost. Moving the choice earlier
+moves it away from the moment the decision is actually being made.
+
+## 2. Decision — `/harness-accept --target`
+
+The approver may supply the target at the acceptance gate. This implements the
+documented contract rather than changing it.
+
+Three refusals keep it narrow:
+
+- **A routed classification refuses `--target`.** `target_of` prefers the route,
+  so a target would be silently ignored — and silently discarding what someone
+  wrote is what #551 was about. It refuses rather than accepting a value it will
+  not use.
+- **The target must be able to host the rule** — the `.md` check from #551,
+  reused rather than duplicated.
+- **The artifact must exist.** Unchanged; the Registrar writes records, not
+  governance documents.
+
+### Provenance is recorded
+
+Where the approver sets a target that differs from the one the assay named, the
+Assayer's is preserved as `proposed_target` and the approver's goes in `target`.
+
+This is the `proposed_cost` / `cost` pattern, applied a third time, and for the
+same reason: two people contributed to one record and a reader should be able to
+tell which part came from whom. Where the assay named no target, there is nothing
+to preserve and no `proposed_target` is written.
+
+### The objection, recorded rather than dismissed
+
+Letting the approver retarget at the gate lets a rule be moved to wherever it
+applies cleanly, which is a cousin of reclassifying to clear a threshold.
+
+It is a weaker cousin. Reclassification changes the *evidentiary bar* a rule must
+clear — that is what the two-assay threshold turns on. Retargeting changes which
+prose document hosts the text, and since #551 that document must be markdown, so
+the range of "somewhere it applies cleanly" is small and every option is a
+governance artifact. The provenance field makes the move visible either way.
+
+## 3. Acceptance criteria
+
+- **A1** — a record with no `target` and an unrouted classification can be
+  accepted with `--target`, and the rule is applied there.
+- **A2** — without `--target`, that record still refuses, with the existing
+  message. Unchanged.
+- **A3** — `--target` on a record whose classification is **routed** refuses, and
+  says the route decides.
+- **A4** — `--target` naming a non-markdown artifact refuses, reusing #551's
+  message.
+- **A5** — `--target` naming an artifact that does not exist refuses.
+- **A6** — where the assay named a target and the approver overrides it, the
+  record carries `proposed_target` with the assay's value and `target` with the
+  approver's.
+- **A7** — where the assay named no target, no `proposed_target` is written.
+- **A8** — a refusal writes nothing: the record stays `proposed` and the corpus is
+  byte-identical.
+- **A9** — accepting without `--target` is unaffected in every other respect.
+- **A10** — the existing corpus passes `/harness-check`.
+
+## 4. Version
+
+Behaviour change to plugin files: minor bump, `0.85.0` → `0.86.0`.

--- a/tdad_tests/layer0_deterministic/test-target-at-the-gate.sh
+++ b/tdad_tests/layer0_deterministic/test-target-at-the-gate.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for setting the target at the acceptance gate
+# (spec 2026-08-25-target-at-the-gate-design.md; T1-T10 -> A1-A10).
+#
+# T1 IS THE DOCUMENTED WORKFLOW, and before this change it was impossible: the
+# reference says the Assayer often cannot know which of four agent files owns a
+# behaviour and that the human decides at the gate, but such a record proposed
+# cleanly and could never be accepted.
+#
+# T8 IS THE GUARD. Every refusal here happens before anything is written, and
+# "nothing was written" is measured by hashing the corpus rather than read off
+# the code.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$SCRIPT_DIR/../.."
+REG="$ROOT/ai-literacy-superpowers/scripts/harness-registrar.py"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+[ -f "$REG" ] || fail "harness registrar not found at $REG"
+
+PY=/usr/bin/python3
+command -v "$PY" >/dev/null 2>&1 || PY=python3
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+cd "$TMP"
+mkdir -p harness/decisions harness/assay .claude/agents
+printf '# Harness\n\nHand-written.\n' > HARNESS.md
+printf '# Agents\n\nHand-written.\n' > AGENTS.md
+printf -- '---\nname: tdd\n---\n\n# TDD agent\n\nHand-written.\n' > .claude/agents/tdd.agent.md
+printf '#!/usr/bin/env bash\nexit 0\n' > run.sh
+printf 'Written by a human, in their own words.\n' > cost.txt
+
+A="harness/assay/2026-08-25T08-08Z-assay.md"
+reg() { set +e; OUT="$( "$PY" "$REG" "$@" 2>&1 )"; RC=$?; set -e; }
+refuses() {
+  [ "$RC" -ne 0 ] || fail "$1: expected non-zero exit, got 0. Out: $OUT"
+  printf '%s' "$OUT" | grep -q 'Traceback' && fail "$1: crashed. Out: $OUT"
+  printf '%s' "$OUT" | grep -qi -- "$2" || fail "$1: message must mention '$2'. Out: $OUT"
+}
+corpus_hash() {
+  "$PY" -c "
+import hashlib, os
+h = hashlib.sha256()
+for dirpath, dirs, files in os.walk('harness'):
+    dirs.sort()
+    for name in sorted(files):
+        p = os.path.join(dirpath, name)
+        h.update(p.encode()); h.update(open(p,'rb').read())
+print(h.hexdigest())"
+}
+
+cat > harness/surfaces.yaml <<'EOF'
+routes:
+  harness-loop: HARNESS.md
+  turn-instructions: AGENTS.md
+surfaces:
+  claude-code:
+    targets: [CLAUDE.md, .claude/agents/]
+    supports: [advisory, validated, blocked]
+EOF
+
+cat > "$A" <<'EOF'
+---
+assay: harness/assay/2026-08-25T08-08Z-assay.md
+date: 2026-08-25
+agent: harness-assayer
+model: claude-opus-5
+---
+
+# Assay
+
+## Findings
+
+### finding-4 — Belongs to an agent, but the Assayer cannot say which
+
+The behaviour belongs to an agent. Which of four agent files owns it is not
+something this report can determine.
+
+```yaml
+classification: agent-instruction
+enforcement: advisory
+surfaces: [claude-code]
+priority: P2
+evidence:
+  - HARNESS.md
+```
+
+#### Proposed rule
+
+````markdown
+- **Rule**: Cite observed output, never a planned command.
+````
+
+#### Cost estimate
+
+One check per phase boundary.
+
+### finding-6 — The Assayer did name a target, and guessed wrong
+
+Observed once.
+
+```yaml
+classification: agent-instruction
+enforcement: advisory
+surfaces: [claude-code]
+target: AGENTS.md
+priority: P2
+evidence:
+  - HARNESS.md
+```
+
+#### Proposed rule
+
+````markdown
+- **Rule**: Something else.
+````
+
+#### Cost estimate
+
+Nothing.
+
+### finding-8 — A routed classification
+
+Observed once.
+
+```yaml
+classification: harness-loop
+enforcement: advisory
+surfaces: [claude-code]
+priority: P2
+evidence:
+  - harness/assay/2026-08-24T08-08Z-assay.md#finding-8
+  - HARNESS.md
+```
+
+#### Proposed rule
+
+````markdown
+- **Rule**: A loop-layer rule.
+````
+
+#### Cost estimate
+
+Nothing.
+EOF
+
+fill() { "$PY" - "$1" <<'PYEOF'
+import re, sys
+p = sys.argv[1]; t = open(p).read()
+for h in ("Why this layer", "Enforcement", "Validation", "Rejected alternatives"):
+    t = re.sub(rf"(## {h}\n\n)_TODO[^\n]*\n", r"\1Written by a human.\n", t)
+open(p, "w").write(t)
+PYEOF
+}
+
+# === T2: without --target it still refuses, message unchanged ================
+reg propose --assay "$A" --finding finding-4 --today 2026-08-25 --slug notarget
+[ "$RC" -eq 0 ] || fail "T2 setup: propose failed. Out: $OUT"
+H=harness/decisions/HDR-2026-08-25-notarget.md
+BEFORE="$(corpus_hash)"
+reg accept --hdr "$H" --cost-file cost.txt --approver tester --now 2026-08-25T10:00Z
+refuses "T2" "must name its own"
+[ "$(corpus_hash)" = "$BEFORE" ] || fail "T2: the corpus changed during a refusal"
+echo "T2 ok (no target, no flag: refuses as before)"
+
+# === T3/T4/T5: the three refusals, none of which writes ======================
+reg accept --hdr "$H" --cost-file cost.txt --approver tester --now 2026-08-25T10:00Z \
+  --target run.sh
+refuses "T4" "cannot hold"
+reg accept --hdr "$H" --cost-file cost.txt --approver tester --now 2026-08-25T10:00Z \
+  --target docs/missing.md
+refuses "T5" "does not exist"
+[ "$(corpus_hash)" = "$BEFORE" ] || fail "T4/T5: the corpus changed during a refusal"
+echo "T4 ok (non-markdown target refused)"
+echo "T5 ok (absent artifact refused)"
+
+# === T1: the documented workflow now works ==================================
+reg accept --hdr "$H" --cost-file cost.txt --approver tester --now 2026-08-25T10:00Z \
+  --target .claude/agents/tdd.agent.md
+[ "$RC" -eq 0 ] || fail "T1: accept with --target failed. Out: $OUT"
+grep -q 'Cite observed output' .claude/agents/tdd.agent.md \
+  || fail "T1: the rule was not applied to the supplied target"
+grep -q '^target: .claude/agents/tdd.agent.md$' "$H" \
+  || fail "T1: the record does not carry the approver's target"
+echo "T1 ok (a record naming no target is acceptable at the gate)"
+
+# === T7: nothing to preserve, so no proposed_target ==========================
+grep -q '^proposed_target:' "$H" \
+  && fail "T7: proposed_target written when the assay named none"
+echo "T7 ok (no proposed_target when the assay named none)"
+
+# === T6: an override preserves the Assayer's value ==========================
+reg propose --assay "$A" --finding finding-6 --today 2026-08-25 --slug override
+[ "$RC" -eq 0 ] || fail "T6 setup: propose failed. Out: $OUT"
+H6=harness/decisions/HDR-2026-08-25-override.md
+grep -q '^target: AGENTS.md$' "$H6" || fail "T6 setup: the assay's target is missing"
+reg accept --hdr "$H6" --cost-file cost.txt --approver tester --now 2026-08-25T10:05Z \
+  --target .claude/agents/tdd.agent.md
+[ "$RC" -eq 0 ] || fail "T6: override failed. Out: $OUT"
+grep -q '^proposed_target: AGENTS.md$' "$H6" \
+  || fail "T6: the Assayer's target was not preserved"
+grep -q '^target: .claude/agents/tdd.agent.md$' "$H6" \
+  || fail "T6: the approver's target is not in 'target'"
+echo "T6 ok (override preserves the Assayer's value as proposed_target)"
+
+# === T3: a routed classification refuses --target ===========================
+# The route wins in target_of, so accepting a target here would silently discard
+# what the approver typed - the failure #551 was about.
+mkdir -p harness/assay
+cp "$A" harness/assay/2026-08-24T08-08Z-assay.md
+"$PY" - harness/assay/2026-08-24T08-08Z-assay.md <<'PYEOF'
+import sys
+p = sys.argv[1]; t = open(p).read()
+open(p, "w").write(t.replace("2026-08-25T08-08Z", "2026-08-24T08-08Z"))
+PYEOF
+reg propose --assay "$A" --finding finding-8 --today 2026-08-25 --slug routed
+[ "$RC" -eq 0 ] || fail "T3 setup: propose failed. Out: $OUT"
+fill harness/decisions/HDR-2026-08-25-routed.md
+BEFORE="$(corpus_hash)"
+reg accept --hdr harness/decisions/HDR-2026-08-25-routed.md --cost-file cost.txt \
+  --approver tester --now 2026-08-25T10:10Z --target .claude/agents/tdd.agent.md
+refuses "T3" "routed"
+[ "$(corpus_hash)" = "$BEFORE" ] || fail "T3: the corpus changed during a refusal"
+echo "T3 ok (a routed classification refuses --target)"
+
+# === T9: accepting without --target is otherwise unaffected =================
+reg accept --hdr harness/decisions/HDR-2026-08-25-routed.md --cost-file cost.txt \
+  --approver tester --now 2026-08-25T10:15Z
+[ "$RC" -eq 0 ] || fail "T9: a routed record must accept normally. Out: $OUT"
+grep -q 'A loop-layer rule' HARNESS.md || fail "T9: the routed rule was not applied"
+echo "T9 ok (unchanged without --target)"
+
+echo "target at the gate: all checks passed (T1-T9)"


### PR DESCRIPTION
Closes #557

Spec committed first: `docs/superpowers/specs/2026-08-25-target-at-the-gate-design.md`.

## The documented workflow was impossible

`harness-decision-records.md` has always said:

> **`target`** … binds at **acceptance** rather than at proposal because the
> Assayer frequently identifies a behaviour without knowing which of four agent
> files should own it. That is the human's decision, made at the gate beside the
> cost.

I ran exactly that flow before writing the spec. An `agent-instruction` finding
naming no target proposes cleanly, then:

```text
FAIL: classification 'agent-instruction' has no route in harness/surfaces.yaml,
      so the HDR must name its own 'target'.
FAIL: acceptance refused; nothing was written and the HDR is still proposed.
```

`accept` had no flag to supply one. The record was permanently unacceptable —
exits being a new assay finding that guesses, or supersession.

This is broader than #551's mis-targeting. That made a *wrong* target refuse;
this is a *missing* target the reference calls the normal case.

## The fix

`/harness-accept --target <path>` — implementing the documented contract rather
than changing it.

- **A routed classification refuses `--target`.** `target_of` prefers the route,
  so the value would be silently ignored, and silently discarding what someone
  typed is precisely what #551 was about.
- **The target must host prose** (0.80.0's check, reused) **and must exist**.
- **Provenance recorded**: overriding the assay's target preserves it as
  `proposed_target`. Third application of the `proposed_cost` / `cost` split —
  two people contributed to one record and a reader should see which part is
  whose.

## Against the ticket's own recommendation

#557 leaned toward `--target` on `/harness-propose`. Testing the documented flow
changed that: if the Assayer cannot know which of four agent files owns a
behaviour, neither can whoever drafts the record thirty seconds later. The person
who can decide is the one reading the rule beside its cost — which is what the
reference said all along, and moving the choice earlier moves it away from the
moment the decision is made.

## The objection, recorded not dismissed

Retargeting at the gate lets a rule move to wherever it applies cleanly, a cousin
of reclassifying to clear a threshold. A weaker cousin: reclassification changes
the evidentiary bar (what the two-assay threshold turns on), while retargeting
changes only which prose document hosts the text — and since 0.80.0 that must be
markdown, so every option is a governance artifact. `proposed_target` makes the
move visible.

## Verification

- `test-target-at-the-gate.sh` (T1–T9). Red first on the message assertion, then
  on the missing flag.
- **T1 is the workflow that could not previously happen**: a record naming no
  target, accepted with `--target`, applied to the named agent file.
- **T3** covers the routed refusal; **T6** the override preserving
  `proposed_target`; **T7** that nothing is written when there was nothing to
  preserve.
- Every refusal hashes the corpus before and after — "nothing was written" is
  measured, not read off the code.
- All Layer 0 suites pass; corpus unaffected; enforcement report byte-identical.

Version: 0.85.0 → 0.86.0.