### PR TITLE
Refresh the observability snapshot, unblocking every GC rule after step 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,50 @@ behaviour, neither can whoever drafts the record thirty seconds later. The perso
 who can decide is the one reading the rule beside its cost, which is what the
 reference said all along.
 
+### Observability snapshot refreshed — and the badge script's green default
+
+The snapshot was 35 days stale against a 30-day cadence. It is also step 5 of
+the GC job, so its failure had been skipping every rule after it for six
+consecutive weeks — including the two `Auto-fix: true` rules that would have
+closed the release-tag gap and the reflection archival backlog.
+
+- **`observability/snapshots/2026-08-25-snapshot.md`** — full quick-mode
+  snapshot, all 16 sections, generated straight after the `/harness-audit`
+  run so the enforcement figures are observed rather than re-derived. Health:
+  **Degraded**, on four grounds — the investigative loop has not completed a
+  run in 36 days, the snapshot cadence had lapsed, four constraints fail, and
+  `/assess` is 106 days overdue against a 90-day target.
+- **Two GC findings recorded**, both discovered by the audit rather than by
+  the GC job: six untagged releases and fifteen archivable reflection
+  fragments.
+- **The health badge now reads Degraded** and links to the new snapshot.
+
+### Fixed — `update-health-badge` defaulted to a green badge
+
+`update-health-badge.sh` reads the snapshot path from `$2`. Called with no
+argument it skips the entire detection block and falls through to
+`health_status="Healthy"`, hardcoded, and points the link at the snapshots
+directory rather than a snapshot.
+
+`/harness-health` step 8 documents exactly that argument-less invocation, so
+**the documented way to run it always wrote a green badge** regardless of what
+the snapshot said. Observed directly: the argument-less call wrote `Healthy`
+over a snapshot whose Meta section reads `Health: **Degraded**`.
+
+The script is not changed here — the defect is recorded and the badge written
+correctly by passing the snapshot path. A default that fails toward the most
+reassuring value is the same shape as the masking defect this snapshot
+documents, and the fix belongs with its own evidence rather than bundled into
+a snapshot refresh.
+
+### Also recorded
+
+The `Compound Learning` count basis is now stated in the snapshot. The format
+reference says to count `GOTCHA:` and `ARCH_DECISION:` lines; neither string
+exists in `AGENTS.md`, which uses `##` headings with top-level bullets. The
+26 -> 22 delta against the previous snapshot is a change of counting basis,
+not a removal of entries, and the reference is what needs correcting.
+
 ## 0.85.0 — 2026-08-25
 
 ### Fixed — a project's routing table merges with the defaults instead of replacing them

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Agents](https://img.shields.io/badge/Agents-22-2E8B57?style=flat-square)](#agents-22)
 [![Commands](https://img.shields.io/badge/Commands-39-2E8B57?style=flat-square)](#commands-39)
 [![Harness](https://img.shields.io/badge/Harness-31%2F32_enforced-4682B4?style=flat-square)](HARNESS.md)
-[![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/2026-07-21-snapshot.md)
+[![Harness Health](https://img.shields.io/badge/Harness_Health-Degraded-DC143C?style=flat-square)](observability/snapshots/2026-08-25-snapshot.md)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
 [![Copilot CLI](https://img.shields.io/badge/Copilot_CLI-Plugin-000000?style=flat-square&logo=githubcopilot&logoColor=white)](https://github.com/features/copilot)
 [![Agent Harness Enabled](https://img.shields.io/badge/Agent_Harness-Enabled-000000?style=flat-square)](HARNESS.md)

--- a/observability/snapshots/2026-08-25-snapshot.md
+++ b/observability/snapshots/2026-08-25-snapshot.md
@@ -1,0 +1,284 @@
+# Harness Health Snapshot — 2026-08-25
+
+Generated in quick mode, immediately after a full `/harness-audit` run
+(discovery + enforcement across all 36 constraints + audit). Where the audit
+observed a value directly, this snapshot carries the observed value rather
+than re-deriving it.
+
+Computed on `main` at `b1982b0`. Two open PRs are not reflected here: #571
+(the second assay and two objection records) and #572 (the audit's Status and
+badge writes). The Diaboli counts below therefore exclude two objection
+records that exist but are not yet merged.
+
+## Enforcement
+
+- Constraints: 35/36 enforced (97%)
+- Deterministic: 25 | Agent: 10 | Unverified: 1
+- Drift detected: yes
+
+Read the ratio narrowly. It counts **declared** enforcement, which is the
+definition the previous snapshots used and is kept for comparability. The
+2026-08-25 audit established that it overstates what is in force:
+`grep -rn 'harness-enforcer' .github/workflows/` returns nothing, so all ten
+agent-enforced constraints have no automated dispatch path and cannot fail a
+build. They run only when a human types `/harness-audit`.
+
+Four constraints are failing: *Release traceability*, *Output validation
+checkpoints*, *PRs have adjudicated objections*, *PRs have adjudicated choice
+stories*. The single unverified constraint remains "Tests must pass" (by
+design — no application suite). Two template blocks (`Spec conformance`,
+`[Governance constraint name]`) live inside HTML comments and are excluded.
+
+## Enforcement Loop History
+
+- Advisory (edit-time): active since 2026-04-06
+- Strict (merge-time): active since 2026-04-10
+- Investigative (scheduled): active since 2026-04-06 — **active but failing**;
+  see Garbage Collection
+
+## Garbage Collection
+
+- Rules active: 19/19
+- Last run: 2026-08-24 (scheduled `gc.yml` — **failed**)
+- Cadence compliance: overdue in effect — the job has run weekly on schedule
+  and failed on every run since 2026-07-20 (6 consecutive: 07-20, 07-27,
+  08-03, 08-10, 08-17, 08-24), so no rule after step 5 has produced a result
+  in 36 days
+- Findings since last snapshot: 2 confirmed, both discovered by the audit
+  rather than by the GC job itself
+
+The GC job fails at step 5 (*Snapshot staleness*) and records steps 6–14
+`skipped`. Only `Summary` carries `if: always()`. Verified on run
+`32712709028`:
+
+```text
+step 5   failure   GC: Snapshot staleness
+step 9   skipped   GC: Release tag completeness (ai-literacy-superpowers)
+step 13  skipped   GC: Reflection log archival of promoted entries (Path 1)
+```
+
+Both skipped steps are `Auto-fix: true` rules, and both have unfixed work
+waiting: six untagged releases (`v0.28.1`–`v0.28.5`, `v0.29.1`, verified
+absent on the remote) and fifteen archivable reflection fragments. Those are
+this snapshot's two GC findings, and they are the same defect's bill rather
+than independent problems.
+
+Worth recording against the previous snapshot: 2026-07-21 reported
+"GC effectiveness: quiet (no findings this window; no drift to catch)". The
+job had already failed once, the day before. A silent GC job and a green GC
+job were indistinguishable in the snapshot format, and this is the window in
+which that cost something.
+
+The four affordance GC rules remain commented out and are excluded from the
+19/19 active total.
+
+## Mutation Testing
+
+- Not applicable — no application code or mutation-tested suite. The TDAD
+  suite under `tdad_tests/` covers the plugin's own components; Layers 0 and 1
+  are CI-gated on every PR via `tdad-tests-fast.yml`. The audit ran all seven
+  modules: 150 tests, zero failures.
+
+## Compound Learning
+
+- REFLECTION_LOG entries: 56 (2 new since 2026-07-21 — `2026-08-13-cadence-sentinels-epic`
+  and `2026-08-14-agents-md-test-strategy-drift`)
+- AGENTS.md entries: 22 (6 gotchas, 16 arch decisions; last modified
+  2026-08-14)
+- Promotions since last snapshot: 0 new `Promoted` markers
+
+Note on the AGENTS.md count: the format reference says to count `GOTCHA:` and
+`ARCH_DECISION:` lines, and neither string exists in the file — the sections
+use `##` headings with top-level bullets. This snapshot counts top-level
+bullets under `## GOTCHAS` and `## ARCH_DECISIONS`. The previous snapshot
+reported 26 on an unstated basis, so the 26 → 22 delta is a change of counting
+basis, **not** a removal of entries. The format reference is wrong about this
+file and should be corrected rather than the count fudged to match.
+
+### Reflection log + archive
+
+- Active log entry count: 56
+- Archive entry count: 0
+- Curation debt (unpromoted entries older than 180 days): 0 — the oldest
+  active fragment is 2026-04-06, 141 days, inside the 180-day threshold
+
+17 fragments carry a `**Promoted**:` marker.
+`archive-promoted-reflections.sh --dry-run=true` reports **15 archivable** and
+2 failing `verify_rhs` (unchanged since 2026-08-13, reported rather than
+silently edited). The archive is empty because Path 1 is step 13 of the GC job
+and has been masked for six weeks — the rule is declared, `Auto-fix: true`,
+and has never fired.
+
+Note for anyone running it by hand: `archive-promoted-reflections.sh` defaults
+to `--dry-run=false`. It writes unless told not to.
+
+## Session Quality
+
+- Reflections with signal: 52/56 (93%)
+- Signal distribution: not itemised this snapshot — the four signal-less
+  entries all predate the Signal field (2026-04-08) and count as "none"
+- Quality trend: stable (93% → 93%, within the ±2% threshold)
+
+## Diaboli
+
+Overall:
+
+- In-scope specs: 71 (specs dated ≥ 2026-04-19)
+- Exempt specs (pre-feature): 26
+- Objection records present: 48 (spec-mode: 34 | code-mode: 14)
+- In-scope specs without any record: **37**
+- Objections total: 465 (critical: 19 | high: 176 | medium: 203 | low: 58)
+- Mean objections per record: 9.7
+
+Spec-mode:
+
+- Records present: 34
+- Fully-resolved rate: 97% (33 of 34)
+- Mean objections per record: 9.7
+
+Code-mode:
+
+- Records present: 14
+- Fully-resolved rate: 100%
+
+Two things this section now shows that it did not before. First, the
+in-scope-specs-without-a-record figure has grown to 37, and six of those are
+the 2026-08-25 wave (#552, #560, #561, #562, #566, #568) — the failure the
+audit records under *PRs have adjudicated objections*. Second, all 12 pending
+objections sit in one record, `harness-provenance-citation.md`, which is
+12/12 `pending` with null rationales and is cited as the evidence base by two
+merged specs.
+
+Nine records use a non-canonical severity vocabulary (`major`, `minor` —
+4 and 5 occurrences). `check-objection-taxonomy.py` passes on all 50 records
+it checks, so the taxonomy constraint governs categories rather than severity
+values.
+
+## Cartographer
+
+- In-scope specs: 66 (specs dated ≥ 2026-04-27)
+- Choice-story records present: 14
+- In-scope specs without a record: **52**
+- Stories total: 120
+- Mean stories per record: 8.6
+- `cartograph_pending_count`: 0
+- Fully-resolved rate: 100% (14 of 14 records fully resolved)
+
+The 100% resolved rate is true and misleading on its own: every record that
+exists is fully adjudicated, and 52 in-scope specs have no record at all. The
+directory has received nothing since the Cadence Sentinels epic.
+
+## Operational Cadence
+
+- Last /harness-audit: 2026-08-25 (0 days ago — on schedule, target 90)
+- Last /assess: 2026-05-11 (106 days ago — **overdue**, target 90)
+- Last /reflect: 2026-08-14 (11 days ago — on schedule, target 30)
+- Last /cost-capture: 2026-06-13 (73 days ago — on schedule, target 90)
+- Last /governance-audit: 2026-06-13 (73 days ago — on schedule, target 90)
+- Outer loop overdue: **yes** (assess)
+
+## Cost Indicators
+
+- Model routing configured: yes (MODEL_ROUTING.md present)
+- Tier distribution: documented (most-capable, standard, capable tiers)
+- Last cost capture: 2026-06-13
+- Monthly average: not tracked (single-session sample only — $287.64 for one
+  multi-day local session, not a billing-period aggregate)
+- Budget status: not set
+- Cost trend: unknown (still a single capture, no second point to compare)
+
+## Sustainable Pace
+
+- This month's pace: unknown
+- Note: no self-report was captured for this window, so this records `unknown`
+  rather than inferring one. What is observable is a heavy window — 12 PRs
+  merged 2026-08-23 to 2026-08-25, ten of them on a single day, seven minor
+  version bumps in one working day, six of them fixes to a mechanism released
+  two days earlier.
+- Trend: not computable (sustainable → unknown is not a band change)
+
+## Portfolio Adoption
+
+- Plugin installs (cumulative): not tracked
+- /assess invocations from other projects: not tracked
+- Upstream PRs into ai-literacy-for-software-engineers: not tracked this
+  window
+- agent-harness-enabled tagged repos discovered: not tracked
+- Trend: stable (telemetry still unwired)
+
+## Regression Indicators
+
+- Snapshot stale: **yes** (previous 2026-07-21, 35 days, over the 30-day
+  monthly threshold)
+- Snapshot age: 35 days
+- Cadence non-compliance: 2 of 4 activities overdue (assess; GC in effect)
+- Consecutive weeks without reflections: 1
+- Regression flag: **yes**
+
+## Meta
+
+- Snapshot cadence: **overdue** (35-day gap, over the 30-day threshold) — this
+  snapshot closes it
+- Cadence compliance: 2/4 on schedule (audit ✓, assess ✗, reflect ✓, GC ✗)
+- Learning flow: active — two reflections and an AGENTS.md correction landed in
+  the window; the promotion pipeline is blocked downstream at archival, not at
+  capture
+- GC effectiveness: **broken rather than silent** — the job has produced no
+  result past step 5 for 36 days. The distinction matters: a silent GC job
+  reports nothing because there is nothing to find, and this one reports
+  nothing because it stops
+- Trend alerts: GC job failing 6 consecutive runs; in-scope specs without an
+  objection record rising to 37; without a choice story, 52
+- Health: **Degraded**
+
+Health is Degraded rather than Attention because more than one layer is
+affected: the investigative loop has not completed a run in 36 days, the
+snapshot cadence had lapsed, four constraints fail, and the outer loop is
+overdue on assessment. None of this is new damage — the audit found all of it
+in place before this snapshot was written. What is new is that it is now
+written down.
+
+## Changes Since Last Snapshot
+
+- Constraints added: 4 net (32 → 36) — *Harness decision records are
+  well-formed* and *Harness governance is applied and undrifted* (harness
+  evolution S0/S2), plus *PRs have disposed consultation voices* and *Specs
+  cite the source of a claimed convention* (Cadence Sentinels, 2026-08-13)
+- Constraints promoted: none
+- Constraints removed: none
+- GC rules added: none (19 active, unchanged)
+- Assessments completed: none since 2026-05-11
+- Governance audits completed: none since 2026-06-13
+- New subsystem: the **harness evolution loop** — `/harness-assay`,
+  `/harness-propose`, `/harness-accept`, `/harness-check`, `/harness-review`,
+  `/harness-compile`, `/harness-timeline`, backed by `harness/decisions/`,
+  `harness/assay/`, `harness/surfaces.yaml` and `harness-registrar.py`
+- Governance corpus: 0 → 3 decision records (one rejected, one accepted and
+  superseded, one retirement). **Nothing in force** — the loop ran end to end,
+  produced three records, and produced no rule
+- Assays: 0 → 2, with the first carrying a sibling errata record
+- Plugin version: 0.73.2 → 0.86.0
+
+## Trends (vs 2026-07-21)
+
+| Metric | Previous | Current | Change |
+| --- | --- | --- | --- |
+| Enforcement ratio | 97% (31/32) | 97% (35/36) | 0% |
+| Constraints total | 32 | 36 | +4 |
+| Mutation (all languages) | n/a | n/a | unchanged |
+| Reflections | 54 | 56 | +2 |
+| Promotions | 0 | 0 | 0 |
+| Reflections with signal | 93% (50/54) | 93% (52/56) | 0% |
+| Objection records | 38 | 48 | +10 |
+| In-scope specs without objection record | ~1 | 37 | +36 |
+| Story records | 11 | 14 | +3 |
+| In-scope specs without story record | ~34 | 52 | +18 |
+| GC findings | 0 | 2 | +2 |
+| GC job runs succeeded | 2 of 2 | 0 of 6 | −6 |
+| Cadence status | 5/5 on schedule | 2/4 on schedule | changed |
+| Health | Healthy | Degraded | changed |
+
+The enforcement ratio is flat at 97% across a window in which the harness
+acquired a governance loop, four constraints, and four failures. That is the
+clearest available evidence that the ratio is not measuring what a reader
+assumes it measures.


### PR DESCRIPTION
Closes #573.

The snapshot was 35 days stale against a 30-day cadence. It is also **step 5 of the GC job**, and only `Summary` carries `if: always()` — so its failure had been recording steps 6–14 `skipped` for six consecutive weeks.

```text
GC run 32712709028 (2026-08-24)
  step 5   failure   GC: Snapshot staleness
  step 9   skipped   GC: Release tag completeness (ai-literacy-superpowers)
  step 13  skipped   GC: Reflection log archival of promoted entries (Path 1)
```

Both skipped steps are `Auto-fix: true` rules with work waiting: **six untagged releases** (`v0.28.1`–`v0.28.5`, `v0.29.1`) and **fifteen archivable reflection fragments** (`archive-promoted-reflections.sh --dry-run=true` confirms; 2 more fail `verify_rhs`). One file closes the block.

## What landed

- `observability/snapshots/2026-08-25-snapshot.md` — quick mode, all 16 sections in order, validated against `references/snapshot-format.md`. Generated immediately after the `/harness-audit` run so the enforcement figures are observed rather than re-derived.
- Health badge: **Healthy → Degraded**, now linking to the new snapshot.

**Health: Degraded**, on four grounds — the investigative loop has not completed a run in 36 days, the snapshot cadence had lapsed, four constraints fail, and `/assess` is 106 days overdue against a 90-day target. None of it is new damage; the audit found all of it already in place. What is new is that it is written down.

## A defect found while running step 8

`update-health-badge.sh` reads the snapshot path from `$2`. Called with no argument it skips the whole detection block and falls through to a hardcoded `health_status="Healthy"`, pointing the link at the snapshots directory rather than a snapshot.

`/harness-health` step 8 documents precisely that argument-less invocation. **The documented way to run it always wrote a green badge.** Observed directly — the argument-less call wrote `Healthy` over a snapshot whose Meta section reads `Health: **Degraded**`.

Recorded, not fixed here. A default that fails toward the most reassuring value is the same shape as the masking defect this snapshot documents, and it deserves its own change with its own evidence rather than riding along in a snapshot refresh.

## One honest discrepancy

The `Compound Learning` count reads 22 against the previous snapshot's 26. That is a change of **counting basis**, not a removal: the format reference says to count `GOTCHA:` and `ARCH_DECISION:` lines, and neither string exists in `AGENTS.md`, which uses `##` headings with top-level bullets. The snapshot states the basis it used. The reference is what needs correcting.

## What the trend table shows

The enforcement ratio is flat at 97% across a window in which the harness acquired a governance loop, four constraints, and four failures. That is the clearest evidence available that the ratio does not measure what a reader assumes it measures.

## Exemption

`chore` label at creation. No plugin file changes, so no version bump.