### PR TITLE
Stop the health badge defaulting to green when it cannot tell

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.86.0",
+  "plugin_version": "0.86.1",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.86.0"
+      "version": "0.86.1"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## 0.86.1 — 2026-08-25
+
+### Fixed — the health badge defaulted to green when it could not tell
+
+`update-health-badge.sh` reads the snapshot path from `$2`, and its entire
+detection block sits behind a check that the argument was supplied. Line 22
+initialised `health_status="Healthy"`. Called with no argument it skipped every
+line that reads a snapshot and wrote that hardcoded green straight to the
+badge. See #575.
+
+`/harness-health` **step 8 documented exactly that call**, so the documented way
+to run the command always produced a green badge. Observed on 2026-08-25: an
+argument-less run wrote `Healthy` over a snapshot whose Meta section reads
+`Health: **Degraded**`, and repointed the link from the snapshot to the
+directory.
+
+Every safety net in the script — the sub-70% enforcement override, the signal
+heuristic, the explicit `Health:` line reader — lived inside the branch that
+never ran.
+
+- **The argument-less path now discovers the latest snapshot**, using the same
+  `sort -r | head -1` idiom `gc.yml` uses for its own staleness check. The
+  documented invocation becomes correct rather than merely tolerated.
+- **The default is Degraded.** Healthy is now reachable only from a snapshot
+  that was actually read — either an explicit `Health:` line or a snapshot with
+  no attention signals. When the script cannot tell, it says so.
+- **The link target is normalised** to a repo-relative path. Discovery runs
+  `find "$PROJECT_DIR"`, so `.` yielded `./observability/…` and an absolute
+  project dir yielded an absolute path; neither belongs in a README link.
+- **Layer 0 coverage for the path that had none.** `test-update-health-badge.sh`
+  exercised the detection logic thoroughly and every case passed a snapshot
+  file — the documented invocation was untested. Four new assertions: an
+  argument-less run over a Degraded snapshot reports Degraded (this fails on
+  the old code), the discovered link is repo-relative, discovery picks the
+  newest snapshot, and no snapshots at all is Degraded rather than Healthy.
+- **Step 8 now passes the snapshot path explicitly** and says why: you know
+  which file you just wrote, discovery only infers it.
+
+### Why a default matters more than it looks
+
+This is the same shape as the GC masking defect recorded in 0.86.0's snapshot
+refresh: when the mechanism cannot determine an answer, it reported the one
+that looks best. A green badge meaning "nobody passed an argument" is worse
+than no badge, because it is read as a measurement. The fix is not the
+discovery — it is that absence of evidence now resolves to Degraded.
+
 ## 0.86.0 — 2026-08-25
 
 ### Fixed — the target can now be set where the reference always said it was

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.86.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.86.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-42-2E8B57?style=flat-square)](#skills-42)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.86.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.86.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.86.0",
+  "version": "0.86.1",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/commands/harness-health.md
+++ b/ai-literacy-superpowers/commands/harness-health.md
@@ -131,10 +131,23 @@ Do not regenerate the snapshot. Fix the output directly.
 
 Run the `update-health-badge` command (a plugin `bin/` shim, on PATH; do
 not use a `${CLAUDE_PLUGIN_ROOT}` path — that variable is unset outside
-hooks) to update:
+hooks), **passing the snapshot you just wrote**:
+
+```bash
+update-health-badge . observability/snapshots/YYYY-MM-DD-snapshot.md
+```
+
+It updates:
 
 - The health badge colour and text
 - The health icon link target (point to the new snapshot)
+
+The snapshot argument is optional — the script discovers the latest
+snapshot when it is omitted — but pass it anyway. You know which file you
+just wrote; discovery only infers it. Before #575 the argument-less form
+skipped snapshot reading entirely and wrote a green badge over a Degraded
+snapshot, and this step documented that form. Passing the path keeps the
+badge correct even if discovery is ever broken again.
 
 ### 9. Print Summary
 

--- a/ai-literacy-superpowers/scripts/update-health-badge.sh
+++ b/ai-literacy-superpowers/scripts/update-health-badge.sh
@@ -18,9 +18,28 @@ if [ ! -f "$README_FILE" ]; then
   exit 0
 fi
 
-# Determine health status from snapshot
-health_status="Healthy"
-health_colour="2E8B57"  # green
+# Determine health status from snapshot.
+#
+# The default is Degraded, deliberately (#575). It used to be Healthy, and the
+# entire detection block sits behind a check that a snapshot file was supplied
+# — so an argument-less call skipped every line that reads a snapshot and wrote
+# a green badge, including over a snapshot whose Meta section said Degraded.
+# Every safety net in this script lived inside the branch that never ran.
+#
+# A status of Healthy is now reachable only from a snapshot that was actually
+# read. When this script cannot tell, it says Degraded: absence of evidence is
+# not evidence of health, and a badge that fails toward the reassuring answer
+# is worse than no badge.
+health_status="Degraded"
+health_colour="DC143C"  # crimson
+
+# No snapshot named — discover the most recent one rather than assuming.
+if [ -z "$SNAPSHOT_FILE" ]; then
+  SNAPSHOT_DIR="${PROJECT_DIR}/observability/snapshots"
+  if [ -d "$SNAPSHOT_DIR" ]; then
+    SNAPSHOT_FILE=$(find "$SNAPSHOT_DIR" -maxdepth 1 -name '*-snapshot.md' | sort -r | head -1)
+  fi
+fi
 
 if [ -n "$SNAPSHOT_FILE" ] && [ -f "$SNAPSHOT_FILE" ]; then
   # The /harness-health skill already computes the aggregate health status
@@ -57,6 +76,13 @@ if [ -n "$SNAPSHOT_FILE" ] && [ -f "$SNAPSHOT_FILE" ]; then
       elif [ "$attention_signals" -ge 1 ]; then
         health_status="Attention"
         health_colour="DAA520"
+      else
+        # A snapshot was read and shows no attention signals. This is the one
+        # path to Healthy that does not come from an explicit Health line, and
+        # it is set here rather than inherited from the initial value so that
+        # nothing reaches Healthy without a snapshot behind it.
+        health_status="Healthy"
+        health_colour="2E8B57"
       fi
       ;;
   esac
@@ -72,22 +98,23 @@ if [ -n "$SNAPSHOT_FILE" ] && [ -f "$SNAPSHOT_FILE" ]; then
       health_colour="DC143C"
     fi
   fi
-else
-  # No snapshot provided — check if any snapshot exists
-  SNAPSHOT_DIR="${PROJECT_DIR}/observability/snapshots"
-  if [ ! -d "$SNAPSHOT_DIR" ] || [ -z "$(ls -A "$SNAPSHOT_DIR" 2>/dev/null)" ]; then
-    health_status="Degraded"
-    health_colour="DC143C"
-  fi
 fi
+# No readable snapshot was found, by argument or by discovery. The initial
+# Degraded stands.
 
 # Build badge URL
 encoded_status="${health_status// /%20}"
 badge_url="https://img.shields.io/badge/Harness_Health-${encoded_status}-${health_colour}?style=flat-square"
 
-# Determine snapshot link target
+# Determine snapshot link target.
+#
+# Normalised to a repo-relative path. Discovery runs `find "$PROJECT_DIR"`, so
+# a project dir of "." yields "./observability/..." and an absolute project dir
+# yields an absolute path — neither of which belongs in a README link. Both
+# reduce to the same relative form an explicitly-passed path already produces.
 if [ -n "$SNAPSHOT_FILE" ]; then
-  link_target="$SNAPSHOT_FILE"
+  link_target="${SNAPSHOT_FILE#"$PROJECT_DIR"/}"
+  link_target="${link_target#./}"
 else
   link_target="observability/snapshots/"
 fi

--- a/tdad_tests/layer0_deterministic/test-update-health-badge.sh
+++ b/tdad_tests/layer0_deterministic/test-update-health-badge.sh
@@ -18,6 +18,13 @@ set -euo pipefail
 #     line says Healthy.
 #   - The Health line is honoured even when it sits past line 20 of Meta
 #     (the old `head -20` window could miss it).
+#
+# Second regression guard (#575): called with NO snapshot argument — which is
+# the invocation /harness-health step 8 documents — the script skipped every
+# line that reads a snapshot and fell through to a hardcoded
+# `health_status="Healthy"`. It wrote a green badge over a Degraded snapshot.
+# The argument-less path must discover the latest snapshot, and must never
+# default to Healthy when it cannot.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BADGE="$SCRIPT_DIR/../../ai-literacy-superpowers/scripts/update-health-badge.sh"
@@ -43,6 +50,31 @@ run() {
   STATUS=$(grep -oE 'Harness_Health-[A-Za-z]+' "$WORK/README.md" | head -1 | sed 's/Harness_Health-//')
   [ -n "$STATUS" ] || fail "no Harness Health badge found in README after running on $1"
   LINK=$(grep -oE '\]\([^)]*\)$' "$WORK/README.md" | tail -1)
+}
+
+# run_auto -> same as run(), but passes NO snapshot argument, exercising the
+# documented invocation. Snapshots are seeded under $WORK/observability/snapshots.
+run_auto() {
+  seed_readme
+  bash "$BADGE" "$WORK" >/dev/null 2>&1 || fail "badge script exited non-zero with no snapshot argument"
+  STATUS=$(grep -oE 'Harness_Health-[A-Za-z]+' "$WORK/README.md" | head -1 | sed 's/Harness_Health-//')
+  [ -n "$STATUS" ] || fail "no Harness Health badge found in README after argument-less run"
+  LINK=$(grep -oE '\]\([^)]*\)$' "$WORK/README.md" | tail -1)
+}
+
+seed_snapshot() {  # seed_snapshot <date> <health-word>
+  mkdir -p "$WORK/observability/snapshots"
+  cat > "$WORK/observability/snapshots/$1-snapshot.md" <<EOF
+# Harness Health Snapshot — $1
+
+## Meta
+
+- Snapshot cadence: on schedule
+- Trend alerts: none
+- Health: **$2**
+
+## Changes Since Last Snapshot
+EOF
 }
 
 # --- Regression: Healthy snapshot with "Trend alerts: none" stays Healthy ----
@@ -114,4 +146,35 @@ case "$LINK" in
   *) fail "badge link must target the snapshot file, got '$LINK'" ;;
 esac
 
-echo "PASS: update-health-badge mirrors the authoritative Health line; 'Trend alerts: none' no longer false-positives"
+# --- #575: argument-less call must not invent a green badge -----------------
+# The documented invocation. Before the fix this returned Healthy, because the
+# whole detection block sits behind `if [ -n "$SNAPSHOT_FILE" ]`.
+seed_snapshot 2026-08-25 Degraded
+run_auto
+[ "$STATUS" = "Degraded" ] || fail "argument-less run over a Degraded snapshot must report Degraded, got '$STATUS' (#575: hardcoded Healthy default)"
+
+# --- #575: argument-less link must target the discovered snapshot ------------
+case "$LINK" in
+  *2026-08-25-snapshot.md*) : ;;
+  *) fail "argument-less run must link the discovered snapshot, got '$LINK'" ;;
+esac
+
+# --- #575: discovered link is repo-relative, not "./" or absolute -----------
+case "$LINK" in
+  *'](./'*)  fail "discovered link must not carry a './' prefix, got '$LINK'" ;;
+  *'](/'*)   fail "discovered link must be repo-relative, not absolute, got '$LINK'" ;;
+  *) : ;;
+esac
+
+# --- #575: discovery picks the NEWEST snapshot ------------------------------
+seed_snapshot 2026-01-01 Healthy
+seed_snapshot 2026-08-25 Attention
+run_auto
+[ "$STATUS" = "Attention" ] || fail "argument-less run must read the newest snapshot, got '$STATUS'"
+
+# --- #575: no snapshots at all is Degraded, never Healthy -------------------
+rm -rf "$WORK/observability"
+run_auto
+[ "$STATUS" = "Degraded" ] || fail "argument-less run with no snapshots must be Degraded, got '$STATUS' — absence of evidence is not health"
+
+echo "PASS: update-health-badge mirrors the authoritative Health line; 'Trend alerts: none' no longer false-positives; the argument-less path discovers the latest snapshot and never defaults to Healthy (#575)"


### PR DESCRIPTION
Closes #575.

## The defect

`update-health-badge.sh` reads the snapshot path from `$2`. Line 22 initialised `health_status="Healthy"`, and the entire detection block sits behind `if [ -n "$SNAPSHOT_FILE" ] && [ -f "$SNAPSHOT_FILE" ]`. Called with no argument, every line that reads a snapshot was skipped and the hardcoded green reached the badge.

`/harness-health` **step 8 documented exactly that invocation.** The documented way to run the command always wrote a green badge.

Observed on 2026-08-25, against a snapshot whose Meta section reads `Health: **Degraded**`:

```
$ bash ai-literacy-superpowers/bin/update-health-badge
[harness-health] Badge updated: Healthy
```

Every safety net in the script — the sub-70% enforcement override, the signal heuristic, the explicit `Health:` line reader — lived inside the branch that never ran.

## The fix

- **Discovery.** With no argument, the latest snapshot is found using the same `sort -r | head -1` idiom `gc.yml` uses for its staleness check. The documented invocation becomes correct rather than merely tolerated.
- **The default is Degraded.** Healthy is now reachable only from a snapshot that was actually read — an explicit `Health:` line, or a snapshot showing no attention signals. That second path sets Healthy explicitly rather than inheriting it, so nothing reaches green without a snapshot behind it.
- **Normalised link target.** Discovery runs `find "$PROJECT_DIR"`, so `.` produced `./observability/…` and an absolute project dir produced an absolute path. Neither belongs in a README link.
- **Step 8 now passes the path explicitly** and says why: you know which file you just wrote, discovery only infers it.

## Why the suite missed it

`test-update-health-badge.sh` covered the detection logic thoroughly — the "Trend alerts: none" substring regression, the sub-70% net, a `Health:` line past 20 lines of Meta — and **passed a snapshot file in every case**. The documented invocation had no coverage at all. The suite tested the call nobody was told to use.

Four assertions added:

| Assertion | Fails on old code |
| --- | --- |
| Argument-less run over a Degraded snapshot reports Degraded | **yes** |
| Discovered link is repo-relative, not `./` or absolute | yes |
| Discovery picks the newest snapshot | yes |
| No snapshots at all is Degraded, never Healthy | no (already held) |

Verified falsifiable — the new tests were run against the pre-fix script and fail on the first assertion:

```
FAIL: argument-less run over a Degraded snapshot must report Degraded,
      got 'Healthy' (#575: hardcoded Healthy default)
```

## Verification

- All **42** Layer 0 bash suites pass (pytest is not installed locally; these are what the wrapper shells out to)
- `shellcheck` clean on both changed shell files
- The argument-less call is now idempotent against the committed README — zero diff
- Version consistency replicated locally: all five CI-checked locations agree at `0.86.1`, and each marketplace entry matches its own `plugin.json`

## Why a default is worth a patch release

Same shape as the GC masking defect recorded in the 0.86.0 snapshot refresh: when the mechanism could not determine an answer, it reported the one that looks best. A green badge meaning "nobody passed an argument" is worse than no badge, because it is read as a measurement. The fix is not really the discovery — it is that absence of evidence now resolves to Degraded.

## Exemption

`fix` label at creation, on a `fix/` branch. Patch bump 0.86.0 → 0.86.1: plugin files changed, no behavioural addition.