### PR TITLE
Give /harness-audit a validation checkpoint for the Status block it writes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.86.1",
+  "plugin_version": "0.86.2",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.86.1"
+      "version": "0.86.2"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.86.2 — 2026-08-25
+
+### Added — /harness-audit now validates the Status block it writes
+
+`/harness-audit` writes `HARNESS.md`'s `## Status` section — structured output
+with three downstream parsers (`/harness-status`, `harness-auditor` on its next
+run, `harness-gc`) — and had no read-back step. It was the one command missing
+from CLAUDE.md's checkpoint list, and its own constraint *Output validation
+checkpoints* was failing because of it.
+
+The cost was measurable rather than theoretical: the block sat reading
+`Last audit: 2026-08-13`, `Constraints enforced: 33/34`, `Drift detected: no`
+for twelve days, against a tree with 36 active constraints and four failing.
+An audit that records "no drift" while drift exists is worse than one that
+never ran, because the next reader stops looking.
+
+- **Step 5 is a mandatory validation checkpoint.** Five assertions: the four
+  fields present and ordered, `Last audit` is today, `Constraints enforced`
+  counted from the tree rather than carried forward, `Drift detected: yes`
+  whenever the enforcer reported a failure, and the enforcement figure
+  qualified wherever agent-enforced constraints have no dispatch path.
+- **The enforcer results win any disagreement.** They were observed; the Status
+  block is a summary of them.
+- **Fix in place, do not re-dispatch.** A second opinion on a number you can
+  count yourself is slower and no more reliable.
+- `/harness-audit` added to CLAUDE.md's checkpoint list, where its absence is
+  why the omission went unnoticed rather than being a regression.
+
 ## 0.86.1 — 2026-08-25
 
 ### Fixed — the health badge defaulted to green when it could not tell

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,10 +179,10 @@ consumers must include a validation checkpoint step. The pattern:
 3. Check structure against the format spec reference
 4. Fix deviations in place (do not re-dispatch the agent)
 
-Commands with checkpoints: `/harness-health`, `/assess`, `/reflect`,
-`/cost-capture`, `/cost-estimate`, `/harness-constrain`, `/harness-init`,
-`/superpowers-init`, `/governance-audit`, `/harness-onboarding`,
-`/diagnose`, `/pipeline-map`.
+Commands with checkpoints: `/harness-health`, `/harness-audit`, `/assess`,
+`/reflect`, `/cost-capture`, `/cost-estimate`, `/harness-constrain`,
+`/harness-init`, `/superpowers-init`, `/governance-audit`,
+`/harness-onboarding`, `/diagnose`, `/pipeline-map`.
 
 When adding a new command that writes structured markdown, add a
 validation step following this pattern. Reference the format spec

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.86.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.86.2-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-42-2E8B57?style=flat-square)](#skills-42)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.86.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.86.2 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.86.1",
+  "version": "0.86.2",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/commands/harness-audit.md
+++ b/ai-literacy-superpowers/commands/harness-audit.md
@@ -40,7 +40,41 @@ enforcer results. The auditor will:
 - Update HARNESS.md's Status section
 - Update the README badge
 
-### 5. Present Results
+### 5. Validation Checkpoint
+
+**This step is mandatory.** The auditor writes the `## Status` block, which
+is structured output with downstream parsers — `/harness-status`,
+`harness-auditor` itself on its next run, and `harness-gc`. Before #575 this
+command had no read-back step, and the Status block sat claiming
+`Drift detected: no` against a tree with four failing constraints for twelve
+days.
+
+Read `HARNESS.md`'s `## Status` section back and verify:
+
+1. **The four fields are present and in order** — `Last audit`,
+   `Constraints enforced`, `Garbage collection active`, `Drift detected`.
+2. **`Last audit` is today's date**, not the previous run's.
+3. **`Constraints enforced: N/M`** — `M` equals the number of `### ` headings
+   under `## Constraints` with HTML-commented blocks excluded, and `N` equals
+   `M` minus the count of constraints whose `- **Enforcement**:` is
+   `unverified`. Count them; do not carry the previous run's figure forward.
+4. **`Drift detected`** is `yes` whenever the enforcer reported any constraint
+   failing, or discovery reported a declared tool missing. A `no` beside a
+   non-empty findings list is the specific failure this checkpoint exists to
+   catch.
+5. **The enforcement figure is qualified** wherever agent-enforced constraints
+   have no dispatch path. `N/M` counts *declared* enforcement; if no CI
+   workflow dispatches `harness-enforcer`, say so beside the number rather
+   than leaving a reader to infer that every counted constraint can fail a
+   build.
+
+Fix deviations in place. Do not re-dispatch the auditor — a second opinion on
+a number you can count yourself is slower and no more reliable.
+
+If the Status block disagrees with the enforcer results you were given, the
+enforcer results win: they were observed, and the Status block is a summary.
+
+### 6. Present Results
 
 Show the user:
 
@@ -49,7 +83,7 @@ Show the user:
 - Constraint pass/fail results
 - Badge update summary
 
-### 6. Recommend Actions
+### 7. Recommend Actions
 
 Based on audit findings, suggest next steps:
 


### PR DESCRIPTION
Item 2 of the harness-health remediation plan. Addresses the *Output validation checkpoints* failure recorded in #572.

## The gap

`/harness-audit` writes `HARNESS.md`'s `## Status` section. That block is structured output with three downstream parsers — `/harness-status`, `harness-auditor` on its next run, and `harness-gc` — and the command had no read-back step. It was also the one command missing from CLAUDE.md's checkpoint list, which is why the omission was never noticed: nothing pointed at it.

Its own constraint was failing because of it.

## The cost, which was not theoretical

The Status block read this for twelve days:

```
Last audit: 2026-08-13
Constraints enforced: 33/34
Drift detected: no
```

against a tree with **36 active constraints and four failing**. An audit that records "no drift" while drift exists is worse than one that never ran, because the next reader stops looking. The 2026-08-25 audit found every one of those failures already in place.

## The checkpoint

Step 5, mandatory, five assertions:

1. The four fields present and in order
2. `Last audit` is today's date, not the previous run's
3. `Constraints enforced: N/M` **recounted from the tree** — `M` from `### ` headings under `## Constraints` with HTML-commented blocks excluded, `N` minus the `unverified` ones — never carried forward
4. `Drift detected: yes` whenever the enforcer reported any failure. **A `no` beside a non-empty findings list is the specific failure this checkpoint exists to catch**
5. The enforcement figure is qualified wherever agent-enforced constraints have no dispatch path, so `N/M` is not read as "all of these can fail a build"

Two rules for resolving disagreement:

- **The enforcer results win.** They were observed; the Status block summarises them.
- **Fix in place, do not re-dispatch.** A second opinion on a number you can count yourself is slower and no more reliable.

`/harness-audit` is added to CLAUDE.md's checkpoint list.

## Verification

- 42/42 Layer 0 bash suites pass
- Convention parity 36/36; constraint enum parity 3 enums / 45 member checks
- All five CI-checked version locations agree at `0.86.2`; every marketplace entry matches its own `plugin.json`

## Note on item 1

The companion item — the six missing release tags — is **not** in this PR, and should not be done as specified. Investigating it showed the existing tags already point at commits unrelated to the CHANGELOG entries sharing their version numbers: `v0.28.0` is dated 2026-04-27 ("/harness-affordance discover") while `## 0.28.0 — 2026-03-10` describes a harness-enforcement workflow this repo has never contained, from before its first commit on 2026-03-30.

The rule checks that a tag *named* `vX.Y.Z` exists, never that it corresponds to that entry. 110 of 116 versions pass by coincidence of numbering. Creating the six would turn it green while making the tag history more wrong. Raised separately for a decision.

## Exemption

`fix` label at creation, `fix/` branch. Patch bump 0.86.1 → 0.86.2 — plugin file changed, no behavioural addition.