### PR TITLE
Record the third assay and propose the reassuring-default rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,49 @@ never ran, because the next reader stops looking.
 - `/harness-audit` added to CLAUDE.md's checkpoint list, where its absence is
   why the omission went unnoticed rather than being a regression.
 
+### The third assay, and the first rule proposed at the loop layer
+
+`/harness-assay` over the audit-and-health wave (#574, #572, #571, #576, #577).
+Four findings — two proposing rules, two `no-change` — seven rejected
+candidates, five unresolved questions. `lint-assay` passes; S1–S6 checked by
+hand.
+
+- **`harness/assay/2026-08-25T14-31Z-assay.md`** — its headline finding is that
+  four separate mechanisms in this repository report the reassuring answer when
+  they cannot determine the real one, and the principle forbidding it is
+  written down exactly once, in a code comment added yesterday. The four: the
+  health badge's `Healthy` default (#575), the `## Status` block's
+  `Drift detected: no` against four failing constraints, a GC step that did not
+  run being recorded `skipped`, and *Release tag completeness* passing 110 of
+  117 versions because a same-named tag happens to exist.
+- **`HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one`**
+  — proposed, `harness-loop`, advisory across all five surfaces. The first
+  record to reach the loop layer, and the first to satisfy the two-assay
+  promotion threshold: its evidence cites assay 2's finding-2 and assay 3's
+  finding-1, two distinct assay files. Assay 1's finding-2 observed the same
+  masking instance and is **deliberately not cited**, because it carries an
+  erratum and a corrected finding does not corroborate.
+- **Four tier-2 sections and the cost are placeholders.** They are the
+  approver's to write, at the gate, and `precheck` refuses acceptance until
+  they are.
+
+### Corrected — a claim in the 2026-08-25 snapshot, and in #573
+
+The snapshot states the GC job "failed on every run since 2026-07-20 … so no
+rule after step 5 has produced a result in 36 days". Assay 3 finding-3 falsifies
+it against per-step conclusions this repository could have read at the time: on
+run `29739302793` steps 6 and 7 are `success` with the failure at step 8, and on
+`32015897112` steps 6–8 are `success` with the failure at step 9. Only the
+2026-08-24 run failed at step 5.
+
+The consequence is not cosmetic. Five of the six runs blocked at *Release tag
+completeness*, so refreshing the snapshot returns the next scheduled run to that
+step rather than clearing the path. *Reflection log archival (Path 1)* stays
+masked, the fifteen archivable fragments stay unarchived, and #573's closing
+claim that "the two auto-fix rules can run again on the next scheduled sweep" is
+wrong. The generalisation was made from a single run's conclusions without
+reading the other five — the same shape as the finding proposed above.
+
 ## 0.86.1 — 2026-08-25
 
 ### Fixed — the health badge defaulted to green when it could not tell

--- a/harness/assay/2026-08-25T14-31Z-assay.md
+++ b/harness/assay/2026-08-25T14-31Z-assay.md
@@ -1,0 +1,788 @@
+---
+assay: harness/assay/2026-08-25T14-31Z-assay.md
+date: 2026-08-25
+agent: harness-assayer
+model: claude-opus-5
+---
+
+# Assay — the audit-and-health wave, and the defects found by exercising the machinery
+
+Third assay this repository has run. The first is
+`harness/assay/2026-08-25T08-08Z-assay.md`, with corrections at
+`harness/assay/2026-08-25T08-08Z-assay.errata.md`; the second is
+`harness/assay/2026-08-25T11-59Z-assay.md`. Nothing below is carried forward
+from either. Where a prior finding is cited, the underlying artifact was
+re-observed at `0048ae5`.
+
+Phase under assay: `10520d2` (#574) through `0048ae5` (#577) — five merged PRs
+(#574, #572, #571, #576, #577), issues #569, #570, #573 and #575 opened and
+closed alongside them, and issue #578, which is open. Plugin version moved
+0.86.0 → 0.86.2 across two patch releases.
+
+This window differs in kind from the two before it. It contains no feature
+work. It is a `/harness-audit` run, a `/harness-health` run, and repairs
+arising from both.
+
+## Sources
+
+Read (`observed`):
+
+- `HARNESS.md` at `0048ae5` (1189 lines; 36 active constraint headings and 19
+  active GC rule headings with HTML-commented blocks excluded — counted, and
+  matching the Status block's own figures), `AGENTS.md` (544 lines),
+  `CLAUDE.md`, `CHANGELOG.md`, `README.md`
+- `harness/decisions/` — `README.md`, `index.md` and the same **three**
+  records as at `b1982b0`: one `rejected`, one `accepted`/`retirement`, one
+  `accepted`/`superseded`. No record was added in this window.
+- `harness/enforcement-report.md` (reads "No accepted decisions."),
+  `harness/surfaces.yaml`
+- Both prior assays and the errata, in full
+- `docs/superpowers/objections/command-cli-parity.md` (12 objections) and
+  `harness-workflow-step-masking.md` (11 objections) — **23 of 23
+  `disposition: pending`**, counted
+- `.github/workflows/harness.yml` (one `if: always()`, on `Summary`) and
+  `.github/workflows/gc.yml` (one `if: always()`, on `Summary`; eleven `GC:`
+  steps, first at line 45, release-tag at 110, observability archive at 197,
+  reflection archival at 230, affordance staleness at 258)
+- `ai-literacy-superpowers/scripts/update-health-badge.sh` at `b1982b0` and at
+  `0048ae5`; `commands/harness-audit.md` and `commands/harness-health.md`
+  diffs
+- `observability/snapshots/2026-08-25-snapshot.md` in full
+- `git log`, full commit bodies, and per-file history for `10520d2~1..0048ae5`
+- GitHub Actions **per-step conclusions** via `gh api .../jobs` for GC runs
+  `29739302793` (2026-07-20), `32015897112` (2026-08-17) and `32712709028`
+  (2026-08-24); run lists for *Garbage Collection* and *Harness Constraints*
+- `gh issue view` for #569, #570, #573, #575, #578; `gh pr list` for labels and
+  merge times
+- `git tag` against every `## X.Y.Z` heading in `CHANGELOG.md` — 117 headings,
+  7 with no matching tag; tag commit dates and subjects sampled for `v0.27.0`,
+  `v0.28.0`, `v0.29.0`; repository first commit `26b55ae`, 2026-03-30
+
+`reported`:
+
+- `REFLECTION_LOG.md` — last dated entry **2026-08-14**, unchanged across all
+  three assay windows. The "what people noticed at the time" half of the
+  evidence pool is empty for this phase too, so every finding below rests on
+  artifacts.
+- Commit-message claims about test outcomes. #576 states "Four assertions
+  added; the first fails against the old script." I did not run the suite and
+  do not claim it passes. The file changed by +65 lines is `observed`; the
+  assertion outcome is `reported`.
+
+Absent, not empty:
+
+- **The Mast boundary-note store** — `$HOME/.claude/mast` does not exist on
+  this machine. I make no claim about whether a boundary notice fired.
+  "Nothing fired" and "nothing was recorded here" are different facts and I
+  observed only the second.
+- **`.claude/settings.local.json`** — not present in this working tree, so the
+  per-machine hooks `CLAUDE.md` describes are not installed here.
+- **Any *Garbage Collection* run after `10520d2`.** The last scheduled run is
+  2026-08-24, before the snapshot was refreshed. Nothing has exercised the
+  workflow since, so **no claim below asserts that any GC step now passes.**
+  Where I state what the next run will do, it is flagged `inferred` and rests
+  on the step order and the three runs whose conclusions I read.
+
+Present and holding no records:
+
+- `docs/superpowers/parked/` — `README.md` only, unchanged since assay 1.
+- `docs/superpowers/consultations/` — `README.md` only.
+- No spec dated after 2026-08-25's earlier wave. All five PRs in this window
+  used a `chore` or `fix` exemption.
+
+---
+
+## Executive summary
+
+The phase was effective in the way an instrument check is effective: the
+machinery was pointed at the repository, it found four failing constraints and
+two GC defects the scheduled job had never reported, and three separate
+mechanisms were repaired within four hours (`observed`, `gh pr list` merge
+times 14:05–14:30Z). One repair was deliberately deferred to its own PR with
+its own evidence rather than folded into the change that discovered it
+(`10520d2` body: "the script's default belongs in its own change with its own
+evidence"), and it landed two commits later as #576.
+
+The single most important opportunity is that **four separate mechanisms in
+this repository report the reassuring answer when they cannot determine the
+real one, and the principle that says they must not was written down exactly
+once, in a code comment.** `update-health-badge.sh` initialised
+`health_status="Healthy"` above a detection block guarded on an argument that
+`/harness-health` step 8 documented omitting. The `## Status` block read
+`Drift detected: no` for twelve days against four failing constraints. A GC
+step that never ran is recorded `skipped`, which the run summary does not
+distinguish from passing. And *Release tag completeness* passes 110 of 117
+versions because a same-named tag happens to exist, pointing at unrelated
+work. Three were repaired in this window. The fourth is open as #578. The
+governing documents carry the principle in none of the four cases; the fix in
+`update-health-badge.sh` states it in a comment — "a badge that fails toward
+the reassuring answer is worse than no badge" (`observed`) — and that is the
+only place it exists.
+
+That is the shape this assay exists to catch: not a rule that is wrong, but a
+principle the repository has now discovered four times and never written where
+the next mechanism's author would read it.
+
+## What worked
+
+**The audit reported its own command as one of the failures.** The Status
+block written by #572 names four failing constraints, and (2) is *Output
+validation checkpoints* — failing because `/harness-audit`, the command that
+writes the block, had no read-back step (`observed`, `HARNESS.md` line 1181
+region). It was fixed three commits later in #577. An audit that indicts the
+tool performing it is the opposite of the failure this agent's honesty rule is
+written against.
+
+**The enforcement number was qualified rather than restated.** The block keeps
+`Constraints enforced: 35/36` "so it stays comparable" and then says plainly
+why it overstates: "`grep -rn 'harness-enforcer' .github/workflows/` returns
+nothing, so all ten agent-enforced constraints have no automated path and
+cannot fail a build" (`observed`). The figure was not quietly redefined to look
+better, and it was not left unqualified.
+
+**A defect was recorded and deliberately not fixed in the PR that found it.**
+`10520d2`'s body records the health-badge default in full, states the badge in
+that PR was written by passing the path explicitly, and defers the fix. #576
+then carries its own issue (#575), its own observed reproduction — "an
+argument-less run wrote Healthy over a snapshot reading Health: Degraded" — and
+its own tests (`observed`, commit bodies and `git show --stat`).
+
+**The repair wrote the principle into the code rather than only the diff.**
+The post-fix `update-health-badge.sh` carries eleven lines of comment
+explaining what the old default did, why `Degraded` is now the default, and
+"absence of evidence is not evidence of health" (`observed`). The default is
+reachable-by-construction: `health_status="Degraded"` is set before any
+discovery, and `Healthy` is assigned only inside the branch that read a
+snapshot.
+
+**#578 refuses the green-making repair and says why.** "Do not create the six
+tags as an interim measure. That is the one option that destroys the evidence"
+(`observed`). It also declines to choose among four options and routes the
+decision to the loop rather than fixing a governing rule by hand. That is the
+behaviour `CLAUDE.md`'s *Changing a Harness Rule* section asks for, exercised
+by a human without a rule compelling it.
+
+**The snapshot changed a counting basis and said so instead of matching the
+old number.** "The previous snapshot reported 26 on an unstated basis, so the
+26 → 22 delta is a change of counting basis, **not** a removal of entries. The
+format reference is wrong about this file and should be corrected rather than
+the count fudged to match" (`observed`).
+
+**The adversarial gate produced objections that argue against proposing at
+all.** Two objection records, 23 objections, five at `critical`
+(`observed`, counted). `26a51f2`'s body says five of them argue their finding
+should not be proposed (`reported` — I verified five `severity: critical`
+entries; I did not independently classify all 23 by that criterion). One of
+them, `command-cli-parity.md` O9, argues finding-1 should be routed to
+`/harness-audit` instead of becoming a rule. `/harness-audit` was then run in
+this window and found the constraint O9 named — *Output validation
+checkpoints* — failing, and it was repaired. The gate's prediction and events
+agree.
+
+## What created friction
+
+**The snapshot generalised a six-run history from its most recent run.**
+`observability/snapshots/2026-08-25-snapshot.md` states the GC job "failed on
+every run since 2026-07-20 (6 consecutive …), so no rule after step 5 has
+produced a result in 36 days" (`observed`). That is false for five of the six
+runs. On run `29739302793` (2026-07-20) steps 6 and 7 are `success` and the
+failure is at step 8; on run `32015897112` (2026-08-17) steps 6, 7 and 8 are
+`success` and the failure is at step 9, *GC: Release tag completeness*
+(`observed`, per-step conclusions). Only the 2026-08-24 run failed at step 5.
+Impact: this is the reading that produced the remediation described below.
+
+**The remediation's stated benefit does not follow from the run history it
+cites.** `10520d2`'s title is "Refresh the observability snapshot, unblocking
+every GC rule after step 5", and issue #573 — closed by it — says "the two
+auto-fix rules can run again on the next scheduled sweep". Refreshing the
+snapshot removes the step-5 failure. It does not remove the step-9 failure
+that blocked steps 10–14 on the five runs before it, and issue #578 states the
+step cannot be made to pass honestly: the six missing tags must not be created,
+and its auto-fix "has never repaired anything and never could" because
+`git log --grep` searches commit messages for a string that only appears in
+the diff (`observed`, #578 and `gc.yml` lines 110–133). *GC: Reflection log
+archival (Path 1)* is step 13. It stays masked (`inferred`, on the step order
+and three runs of observed conclusions). Fifteen archivable fragments and an
+empty archive remain (`observed`, snapshot).
+
+**This is the second recorded unblock claim of the same shape.** The Status
+block written 2026-08-13 says "Path-1 auto-archive is unblocked for the first
+time" (`observed`, `git show b1982b0:HARNESS.md`). Run `32015897112`, four days
+later, records step 13 `skipped`, and the archive count is still 0
+(`observed`).
+
+**The two P1 findings from assay 2 are entirely undisposed.** All 23
+objections carry `disposition: pending` and `disposition_rationale: null`
+(`observed`, counted). No HDR was proposed from either; the decision corpus is
+unchanged at three records and `harness/enforcement-report.md` still reads "No
+accepted decisions" (`observed`). The masking defect that both assays observed
+is unrepaired: `harness.yml` and `gc.yml` each still carry exactly one
+`if: always()`, on `Summary` (`observed`, counted). Four hours is not a
+reasonable window in which to demand a disposition, and the loop says
+dispositions are the approver's — so this is stated as a fact about the queue,
+not as a fault.
+
+**Every PR in the window merged under a spec-first exemption.** #571 and #572
+carry `chore`; #574 `chore`; #576 and #577 `fix` (`observed`,
+`gh pr list --json labels`). No spec was written. Two of those PRs — the assay
+record and the Status-block correction — are governance adjudications landing
+under an exemption written for maintenance. Assay 2 routed that question to
+`/governance-audit`; it recurs here and is routed there again.
+
+**Nothing was learned in writing, for the third consecutive window.**
+`REFLECTION_LOG.md`'s last dated entry remains 2026-08-14 (`observed`), now
+across seventeen merged PRs spanning two epics and three assays.
+
+## Findings
+
+### finding-1 — Four mechanisms report the reassuring answer when they cannot determine the real one
+
+Four separate mechanisms in this repository resolve an indeterminate state to
+the passing value. Each was observed directly, and they share no
+implementation.
+
+**The health badge.** At `b1982b0`,
+`ai-literacy-superpowers/scripts/update-health-badge.sh` set
+`health_status="Healthy"` and `health_colour="2E8B57"` at line 22, then placed
+its entire detection block behind `if [ -n "$SNAPSHOT_FILE" ] && [ -f
+"$SNAPSHOT_FILE" ]`, where `SNAPSHOT_FILE="${2:-}"`. `/harness-health` step 8
+documented the argument-less invocation. Every safety net — the explicit
+`- Health:` line reader, the sub-70% override, the signal heuristic — lived
+inside the branch an argument-less call skipped (`observed`, `git show
+b1982b0:...`). #575 records the reproduction: a run against a snapshot whose
+Meta section read `Health: **Degraded**` wrote a green badge.
+
+**The Status block.** At `b1982b0`, `HARNESS.md` read `Last audit: 2026-08-13`,
+`Constraints enforced: 33/34`, `Drift detected: no`, against a tree carrying 36
+active constraints and, by the 2026-08-25 audit's own account, four failing
+ones that predated the 2026-08-13 audit (`observed`, `git show
+b1982b0:HARNESS.md` and the current block). The command that writes it had no
+read-back step, so `no` was the value it produced when nothing checked.
+
+**A GC step that did not run.** `gc.yml` carries one `if: always()`, on
+`Summary`. On run `32712709028` steps 6–14 are `skipped`; on `32015897112`
+steps 10–14 are `skipped` (`observed`, per-step conclusions). A `skipped`
+conclusion is not a failure and is not a pass; the run reports one red step and
+between five and nine unknowns, and a reader asking "did GC pass?" sees the
+single failure.
+
+**A check that passes on a weaker property than it names.** `gc.yml`'s
+*Release tag completeness* runs `git tag -l "v$version" | grep -q "v$version"`
+over `grep -oP '(?<=^## )\d+\.\d+\.\d+' CHANGELOG.md`. I ran that comparison:
+117 version headings, 7 with no matching tag. Of the 110 that pass, I sampled
+three — `## 0.27.0 — 2026-03-01` is satisfied by tag `v0.27.0` whose commit is
+dated 2026-04-26 and titled "Add sync check on /harness-upgrade and PR workflow
+on /reflect"; `## 0.28.0 — 2026-03-10` by a tag dated 2026-04-27 for
+"/harness-affordance discover"; `## 0.29.0 — 2026-03-28` by a tag dated
+2026-04-27 for the Choice Cartographer. The repository's first commit is
+`26b55ae`, 2026-03-30, after all three CHANGELOG dates (`observed`). The check
+verifies that a name exists, not that a release happened.
+
+Three of the four were repaired in this window. The fourth is open as #578,
+which names the pattern in its own words: "a mechanism reporting the reassuring
+answer because it cannot determine the real one" (`reported`). The repaired
+badge states the principle in a comment: "When this script cannot tell, it says
+Degraded: absence of evidence is not evidence of health, and a badge that fails
+toward the reassuring answer is worse than no badge" (`observed`). That comment
+is the only place in the repository the principle is written. `HARNESS.md`'s 36
+constraints and `AGENTS.md`'s six gotchas contain no equivalent (`observed`,
+read in full).
+
+```yaml
+classification: harness-loop
+enforcement: advisory
+surfaces: [claude-code, codex, cursor, copilot, windsurf]
+priority: P1
+evidence:
+  - ai-literacy-superpowers/scripts/update-health-badge.sh
+  - HARNESS.md
+  - .github/workflows/gc.yml
+  - harness/assay/2026-08-25T11-59Z-assay.md#finding-2
+overfitting_risk: low
+```
+
+**Why `harness-loop`, and why the threshold is met honestly.** The behaviour is
+a design property of this repository's own machinery — the same species as
+*Output validation checkpoints*, which sits in `HARNESS.md` — so `HARNESS.md`
+is the layer that owns it, and `harness-loop` routes there. I considered
+`turn-instructions`, which routes to `AGENTS.md` and would need no CI and no
+two-assay threshold. I rejected it because `harness/surfaces.yaml` gives
+`AGENTS.md` as the target of `codex` alone, so the rule would reach one surface
+and be silent on the one where the work happens. That is classifying at the
+layer that is cheapest rather than the one that owns the behaviour.
+
+The two-assay threshold is therefore live, and it is met: assay 2's finding-2
+observed the masking instance directly and is uncorrected, so it counts; this
+assay observes three further instances in three unrelated mechanisms. Assay 1's
+finding-2 also observed masking, but it carries an erratum and I have
+deliberately **not** cited it — a corrected finding does not corroborate. I
+name no `target`: `harness-loop` is routed, and since #568 a routed
+classification refuses one.
+
+**Why no existing owner absorbs it.** *Output validation checkpoints* is the
+nearest, and it is the reason `/harness-audit` gained a read-back step in #577.
+It cannot absorb this: its subject is a command reading its own structured
+output back and checking it against a **format spec**, which is a question
+about shape. Three of the four instances here are correctly shaped and wrong
+about the world — a green badge is a well-formed badge. The 2026-08-13 Status
+block would have passed a structural check on all four fields. *Docs site kept
+current* and the GC rule *Command-prompt sync* compare prose surfaces to each
+other. `/harness-audit` **found** three of these four instances, which is why
+they are not rejected candidates for it — but it has no rule to cite when the
+next mechanism ships with the same default, and it found them because a human
+typed the command, twelve days after the previous run.
+
+**Overfitting risk: low.** Four instances across a bash script's variable
+initialisation, an agent-authored prose block, GitHub Actions step ordering,
+and a shell string comparison. The rule encodes none of their specifics and
+would have fired on each independently.
+
+**Validation plan.** Reconstruct the tree at `b1982b0` and assert the rule
+flags `update-health-badge.sh`, the `## Status` block and `gc.yml`'s
+release-tag step. Then assert it does **not** flag
+`check-harness-decisions.py` or `harness-registrar.py check`, both of which
+exit non-zero when they cannot read their input. If the rule cannot separate
+those two sets without an author's cooperation, it is not falsifiable and
+should be refused rather than softened.
+
+#### Proposed rule
+
+````markdown
+- **Rule**: A mechanism that reports a status — a badge, a `## Status`
+  block, a check result, a snapshot field, a summary line — must have a
+  defined value for the case where it could not determine the answer, and
+  that value may not be the passing one. Where an input is missing,
+  unreadable or not supplied, the mechanism reports the degraded or unknown
+  state and names the input it could not read. A reachable code path that
+  reaches a passing value without reading the thing it reports on is a
+  defect, not a default. Separately, a check may not report a pass on the
+  strength of a property weaker than the one it names: if the check is
+  called "release tag completeness" it verifies that the release has a tag,
+  not that a string exists. Absence of evidence is not evidence of health,
+  and a mechanism that fails toward the reassuring answer is worse than an
+  absent one, because the next reader stops looking.
+- **Enforcement**: agent
+- **Tool**: advocatus-diaboli (spec-mode gate) and harness-enforcer
+- **Scope**: pr
+````
+
+#### Cost estimate
+
+Per PR that adds or changes a reporting mechanism: one question the author must
+answer in the spec or the PR body — what does this report when it cannot tell,
+and which code path reaches that value — plus, where the answer is "the passing
+one", the work to change it. Five minutes to answer, thirty to two hours to
+fix. Most PRs add no reporting mechanism and pay nothing.
+
+The heavy cost is honest and the approver should price it before the per-PR
+one. **This becomes the eleventh agent-enforced constraint in a tree where the
+2026-08-25 audit established that none of them can fire.** `grep -rn
+'harness-enforcer' .github/workflows/` returns nothing (`observed`, and
+recorded in the Status block). An agent-enforced constraint runs when a human
+types `/harness-audit`, which happened once in the twelve days before this
+window. So the realistic sequence after acceptance is: `HARNESS.md` gains a P1
+rule; it is not dispatched by anything; and it is next read at the following
+`/harness-audit`, which may be a quarter away. An approver who wants this to
+bite is buying the dispatch path, not the rule text, and the cost they write
+should say who builds it and when. An approver who does not want to buy that
+should decline this finding rather than accept a rule they know cannot fire —
+that is a legitimate outcome and I would rather it be chosen deliberately than
+arrived at.
+
+Three ways it can be gamed, in descending order of likelihood. **Declaring an
+`Unknown` state and never routing to it** — the branch exists, the reviewer
+sees it, nothing reaches it. This is the likely evasion; the rule's phrase
+"reachable code path" is the only defence and it depends on a reviewer asking
+what makes the branch reachable, which is exactly the kind of question that
+does not get asked at 17:00. **Renaming the passing value** — shipping
+`Healthy (unverified)` in green, which satisfies the letter and produces the
+same badge. **Arguing the mechanism does not report a status** — available for
+anything that only returns an exit code, and the second sentence about weaker
+properties is what closes it for checks, at the cost of being the vaguest
+clause in the rule. I could not tighten "weaker property" into something
+mechanical without narrowing it to release tags, which would overfit it to
+finding-2.
+
+---
+
+### finding-2 — *Release tag completeness* verifies that a name exists, and it is the step the GC job will block on next
+
+`gc.yml` line 110 declares *GC: Release tag completeness (ai-literacy-superpowers
+— bare vX.Y.Z)*. Its test is `git tag -l "v$version" | grep -q "v$version"`,
+over every `## X.Y.Z` heading in `CHANGELOG.md`. Nothing relates the tag to the
+entry.
+
+I ran the comparison at `0048ae5`: 117 headings, 7 without a tag —
+`v0.28.1`–`v0.28.5`, `v0.29.1` and `v0.86.2`. Of the passing 110 I sampled
+three, and in all three the tag points at unrelated work committed six to eight
+weeks after the CHANGELOG entry's date: `0.27.0` (entry 2026-03-01) →
+`v0.27.0`, 2026-04-26, "Add sync check on /harness-upgrade and PR workflow on
+/reflect"; `0.28.0` (entry 2026-03-10) → `v0.28.0`, 2026-04-27,
+"/harness-affordance discover"; `0.29.0` (entry 2026-03-28) → `v0.29.0`,
+2026-04-27, "Choice Cartographer". The repository's first commit `26b55ae` is
+dated 2026-03-30, after every one of those entries (`observed`). Those versions
+were released by another repository and their entries were imported. The check
+passes on them because a same-named tag from this repository's own later
+sequence happens to exist.
+
+The six that fail are the residue: patch releases this repository's own
+sequence never minted, so no coincidental tag was ever created. Creating them
+would take the check to green while making the tag history more wrong. The
+step's auto-fix cannot do it either — `git log --all --format="%H"
+--grep="$version" -- CHANGELOG.md` searches commit **messages** for a version
+string, and its error branch `Cannot find commit for v$version — manual tag
+needed` is the one observed to run (`observed`, `gc.yml` lines 110–133 and
+assay 1's reading of run `32015897112`'s log).
+
+This is not only a wrong measurement. It is the step the GC job blocks on. On
+runs `29739302793`, `30265180481`, `30812879075`, `31378013794` and
+`32015897112` the job failed here and recorded every later step `skipped`
+(`observed` for the first and last; `reported` from run conclusions and assay 1
+for the middle three). Refreshing the snapshot in #574 cleared the step-5
+failure, and the next scheduled run therefore returns to this step
+(`inferred`, on step order plus those observed conclusions). Steps 12–14 —
+*Observability archive*, *Reflection log archival (Path 1)*, *Affordance review
+staleness* — stay masked behind a check that cannot be satisfied without
+falsifying the tag history.
+
+```yaml
+classification: harness-loop
+enforcement: validated
+surfaces: [ci]
+priority: P1
+evidence:
+  - .github/workflows/gc.yml
+  - HARNESS.md
+  - CHANGELOG.md
+overfitting_risk: low
+```
+
+**Why `harness-loop`, and why it will be refused.** The rule *Release tag
+completeness* is declared in `HARNESS.md`'s Garbage Collection section, and
+the constraint *Release traceability* sits in the Constraints section; changing
+either is a change to `HARNESS.md`, which is `harness-loop`. `script-validator`
+would route to the same file and would clear the two-assay threshold, and I am
+not taking it: `harness-workflow-step-masking.md` O3 names that exact move —
+"classifying as `script-validator` writes rule text into `HARNESS.md` while
+bypassing the two-assay corroboration threshold that exists to protect
+`HARNESS.md`" — and it would be worse for me to make it knowingly, having read
+the objection.
+
+This is the first assay to observe the vacuity. Assays 1 and 2 both observed
+the missing tags and both routed them to `/harness-gc` as rule failures rather
+than rule defects (`observed`, both Rejected candidates sections). So this
+finding cites one assay and `/harness-accept` will refuse it. That is the
+threshold working, and the refusal record is the second observation a fourth
+assay would need.
+
+**Why no existing owner absorbs it.** `/harness-audit` reports *Release
+traceability* failing and did so on 2026-08-25 — that failure is a rejected
+candidate below. What it does not report, and has no way to report, is that the
+rule it is enforcing measures something other than what it names. `/harness-gc`
+runs the rule and would report the same six. `/governance-audit` asks whether a
+constraint has drifted from its intent, which is the closest question, and the
+honest answer here is that the rule never measured its intent — there is no
+drift to find, because there was no correspondence to lose.
+
+**Overfitting risk: low.** The rule states a property of release traceability
+generally and encodes neither the six version numbers nor the import boundary's
+date.
+
+**Validation plan.** Assert the amended check fails on `v0.86.2` — a release
+this repository genuinely made, currently untagged (`observed`, `git tag`) —
+and passes on `0.28.0`–`0.29.0` only by excluding them as imported, never by
+matching a name. Assert that creating a tag named `v0.28.1` at an arbitrary
+commit does **not** make the check pass. If it does, the amendment has
+reproduced the defect with more code.
+
+#### Proposed rule
+
+````markdown
+- **Rule**: *Release tag completeness* verifies that a release this
+  repository made carries a tag pointing at the commit that made it, not
+  that a tag of the same name exists. Versions whose CHANGELOG entries were
+  imported from another repository are out of scope and are marked as
+  imported in `CHANGELOG.md`, outside the `## X.Y.Z — YYYY-MM-DD` heading
+  that `Version Check` parses. The auto-fix is removed: a tag is never
+  created by searching commit messages for a version string, and a missing
+  tag for a release this repository made is reported for a human to place.
+  A check named for a property verifies that property; passing on a weaker
+  one is worse than failing, because 110 green rows are read as coverage.
+- **Enforcement**: deterministic
+- **Tool**: `.github/workflows/gc.yml` (weekly schedule)
+- **Scope**: pr
+````
+
+#### Cost estimate
+
+One-off, and larger than it looks. Marking the imported range in
+`CHANGELOG.md` cannot be done in the headings: `CLAUDE.md` mandates
+`## X.Y.Z — YYYY-MM-DD` and `Version Check` CI reads the first
+whitespace-delimited token after `##`, so the marker must live on its own line
+or in a comment and the GC step must learn to read it. Rewriting the step to
+verify correspondence — resolving each version to the commit that introduced
+its entry, via `git log --diff-filter` on `CHANGELOG.md` rather than `--grep` —
+is where the work is. Two to four hours including a Layer 0 test, once.
+
+Then a presentational cost that is easy to misread: the check's declared domain
+falls from 117 versions to this repository's own sequence, so a reader
+comparing the next run against the last sees a much smaller number and may read
+the fall as regression. Whoever lands it should say in the same PR what the new
+denominator is and why.
+
+Two ways it can be gamed. **Marking a version imported to silence it** — one
+line, and it inverts the rule into a mute button; the mitigation is that the
+marker sits beside the release entry in `CHANGELOG.md`, in the diff a reviewer
+is already reading for the version bump, rather than in a config file nobody
+opens. This is the likely evasion and it is the direct analogue of the
+`# undocumented:` hazard the previous assay identified in its own proposal.
+**Resolving correspondence loosely** — accepting any tag whose commit touches
+`CHANGELOG.md` at all, which most release commits do, restoring near-total
+green by a slightly better argument.
+
+What this rule does **not** do is choose among the four options #578 lists. It
+takes options 1 and 3 together and rejects 2 and 4, and #578 says of the set
+"none obviously right". An approver who prefers retirement — option 4, on the
+grounds that a rule that has never verified its subject has no claim to
+continue — should decline this and propose the retirement, and the cost of that
+is one fewer GC rule and a reflection-archival backlog that unblocks
+immediately. I have not weighed that against the rule text above with any
+confidence, and I would rather say so than pick the one that reads more
+decisive.
+
+---
+
+### finding-3 — Two remediations claimed a blocked mechanism was unblocked, on evidence that already said otherwise
+
+`10520d2`'s title is "Refresh the observability snapshot, unblocking every GC
+rule after step 5" and issue #573, which it closes, says the two auto-fix rules
+"can run again on the next scheduled sweep" (`observed`). The snapshot
+committed by the same PR states "no rule after step 5 has produced a result in
+36 days" (`observed`).
+
+That last claim is false, and the data falsifying it is the same run history
+the PR cites. On run `29739302793` (2026-07-20) steps 6 and 7 are `success`;
+on `32015897112` (2026-08-17) steps 6, 7 and 8 are `success` (`observed`,
+per-step conclusions). Five of the six failing runs blocked at *Release tag
+completeness*, not at *Snapshot staleness*. Clearing step 5 returns the job to
+the older blocker, which finding-2 shows cannot be satisfied honestly, so
+*Reflection log archival (Path 1)* at step 13 — one of the two auto-fix rules
+named as the benefit — stays masked (`inferred`).
+
+This is the second instance of the shape. The Status block written 2026-08-13
+says "Path-1 auto-archive is unblocked for the first time" (`observed`,
+`git show b1982b0:HARNESS.md`). Run `32015897112`, four days later, records
+step 13 `skipped`, and the archive count is still 0 across 15 archivable
+fragments (`observed`, snapshot). Both claims were about a scheduled run that
+had not happened, both were written as achieved, and both are wrong.
+
+I am proposing no rule, and the reason is not that the observation is weak. It
+is that the remedy already exists as a pending finding. The masking defect —
+assay 2's finding-2, with an objection record and eleven undisposed objections
+— is what makes these claims unverifiable in the first place: with every step
+reporting a conclusion, "unblocked" becomes a thing the next run states rather
+than a thing a commit message predicts. A rule about how to phrase a claim,
+written while the mechanical fix that would settle the claim sits undisposed,
+is prose over an unrun repair. It would also be the third proposal from this
+assay, filling the per-cycle cap while two P1 findings from the previous assay
+are still unproposed.
+
+If a fourth assay observes an unblock claim of this shape **after** the masking
+question has been disposed, this record is its corroborating observation and
+the case for a rule is then made on evidence that the mechanical fix did not
+suffice. If it does not, this is the evidence that the mechanical fix was the
+whole answer.
+
+```yaml
+classification: no-change
+enforcement: advisory
+surfaces: []
+priority: P2
+evidence:
+  - observability/snapshots/2026-08-25-snapshot.md
+  - HARNESS.md
+  - .github/workflows/gc.yml
+  - harness/assay/2026-08-25T11-59Z-assay.md#finding-2
+overfitting_risk: low
+```
+
+#### Proposed rule
+
+No change.
+
+#### Cost estimate
+
+None from the record. The cost of the alternative — a rule requiring every
+claim about a future scheduled run to cite the run that demonstrated it — is
+a week of latency on any issue whose fix lands between weekly sweeps, which is
+most of them, and it would have made #573 unclosable until 2026-08-31. That is
+a real price for a problem that a step-level conclusion would make visible for
+free.
+
+The cost of doing nothing, which the approver should also see: the reflection
+archival backlog and the observability archive are currently believed unblocked
+and are not, and #573 is closed. Somebody should reopen the expectation even if
+nobody writes a rule.
+
+---
+
+### finding-4 — No constraint entered or left `HARNESS.md` outside the loop, which is the condition assay 2 named for a third assay
+
+Assay 2's finding-3 was a `no-change` recording that the loop had produced
+three records and no rule, and it named its own corroboration condition: "If a
+third assay observes a constraint appearing without a record, this is its
+corroborating observation."
+
+It did not occur. I extracted the `### ` headings under `## Constraints` and
+`## Garbage Collection` from `HARNESS.md` at `b1982b0` and at `0048ae5` with
+HTML-commented blocks stripped, sorted both, and diffed: **identical, 55
+headings each** — 36 constraints and 19 GC rules (`observed`). `HARNESS.md`
+changed once in the window, 17 insertions and 3 deletions, entirely within the
+`## Status` section beginning at line 1168 — the block whose own HTML comment
+says it is auto-updated by `/harness-audit` (`observed`,
+`git diff --stat` and the single `@@ -1169,7 +1169,21 @@` hunk).
+
+The decision corpus is likewise unchanged: three records, one `rejected`, one
+`retirement`, one `superseded`, and `harness/enforcement-report.md` still reads
+"No accepted decisions" (`observed`). Across three assays and seventeen merged
+PRs, the loop has produced no rule in force and the document it governs has
+gained no constraint by hand.
+
+This is the second consecutive assay to record that condition unmet. A fourth
+assay that observes a hand-added constraint has two prior `no-change`
+observations to cite; one that does not has the strongest available evidence
+that the restraint is real rather than incidental.
+
+```yaml
+classification: no-change
+enforcement: advisory
+surfaces: []
+priority: P3
+evidence:
+  - HARNESS.md
+  - harness/decisions/index.md
+  - harness/enforcement-report.md
+  - harness/assay/2026-08-25T11-59Z-assay.md#finding-3
+overfitting_risk: low
+```
+
+#### Proposed rule
+
+No change.
+
+#### Cost estimate
+
+None. The alternative remains importing the 36 legacy constraints as
+`imported: true` records to make the corpus look occupied, which would produce
+36 records citing evidence nobody observed. The reason to keep writing this
+finding down is that "three records, no rule in force" reads as a dead
+mechanism at a glance, and the observation that the document it governs has not
+been edited around it is the thing that distinguishes restraint from neglect.
+
+---
+
+## Rejected candidates
+
+Each is real and observed at `0048ae5`. None is a finding, because an existing
+owner already reports it.
+
+**Three of the four constraints the 2026-08-25 audit found failing are still
+failing.** *Release traceability* (six untagged versions, now seven with
+`v0.86.2`), *PRs have adjudicated objections* and *PRs have adjudicated choice
+stories* (`observed`, Status block and `git tag`). Owner: **`/harness-audit`**,
+via `harness-enforcer`. It found all three, wrote them into the Status block it
+authored, and named the fourth — *Output validation checkpoints* — which was
+then repaired in #577. This is the audit working; the remedy is running it
+again, not writing a rule. Finding-2 is not this: it is about what *Release
+tag completeness* measures, which the audit has no way to report.
+
+**All ten agent-enforced constraints have no automated dispatch path.**
+`grep -rn 'harness-enforcer' .github/workflows/` returns nothing (`observed`).
+Owner: **`/harness-audit`** — it established this in the window under assay and
+wrote it into the Status block in its own words. Carried here because it is the
+dominant cost term in finding-1 and an approver will need it.
+
+**Two governance-adjudication PRs merged under the `chore` spec-first
+exemption.** #571 (the second assay and both objection records) and #572 (the
+Status-block correction) carry `chore`; #576 and #577 carry `fix` (`observed`,
+`gh pr list --json labels`). Owner: **`/governance-audit`**. Whether an
+exemption written for maintenance still serves its intent when applied to a
+governance adjudication is exactly the governance-audit question, and this is
+the **second consecutive assay** to route it there — assay 2 raised it about
+#550. Answering it here would be me widening a constraint to cover a case I
+found convenient.
+
+**No reflection entry for any of the five PRs, or the twelve before them.**
+`REFLECTION_LOG.md`'s last dated entry is 2026-08-14 (`observed`), now across
+three assay windows. Owner: **`/reflect`**, backed by the
+`reflection-prompt.sh` Stop hook and the GC rule *Reflection-driven regression
+detection*. **Third consecutive assay to route this there.** The recurrence is
+the fact; I am not converting it into a rule, because the owner exists and has
+not been run.
+
+**`v0.86.2` is not tagged.** `git tag` ends at `v0.86.1` (`observed`), minutes
+after #577 merged. Rejected on **materiality** — nothing shows anyone looking
+for it — and because it is the exact class of failure finding-2 says the rule
+cannot verify anyway. Assay 2 rejected the same observation about `v0.86.0` on
+the same grounds, and `v0.86.0` has since been tagged.
+
+**`/harness-audit`'s new step 5 cites `#575` for the read-back gap, which is
+the health-badge issue; the audit gap is `#570`/`#577`.** Observed in
+`commands/harness-audit.md`. Rejected on **materiality**: nothing in the
+evidence shows a reader following the citation and being misled, and the step's
+own prose describes the defect correctly. An observation, not a finding.
+
+**`/harness-audit`'s validation checkpoint has never run against an audit.**
+#572 wrote the Status block at 14:09Z; #577 added the checkpoint at 14:30Z
+(`observed`, merge times). Rejected on **materiality**: this is the ordinary
+state of a check on the day it lands, and #577's step 5 is prose an agent
+executes, so there is no suite that could have exercised it. Worth one line to
+whoever runs the next audit — the block currently in `HARNESS.md` was written
+before the checkpoint existed and has not been read back under it.
+
+## Unresolved questions
+
+**Does objection O9's prediction count as validated?**
+`command-cli-parity.md` O9 argues assay 2's finding-1 should become a rejected
+candidate routed to `/harness-audit`, "with the four prompt updates done as
+repair", on the grounds that *Output validation checkpoints* already owned the
+behaviour and had never been dispatched. In this window `/harness-audit` ran,
+found that constraint failing, and #577 repaired the instance it named
+(`observed`). That is O9's mechanism working. It is not the whole of O9's
+claim — the four divergent registrar options are still unnamed in any command
+file, which I did not re-verify in this assay and do not assert either way. An
+approver disposing that objection now has an event to weigh; whether one
+repaired instance settles a critical objection is their judgement.
+
+**Should this assay's proposals be queued behind assay 2's?** Two P1 findings
+from assay 2 are unproposed with 23 undisposed objections, and this assay adds
+two more proposals, one of which will be refused at the threshold. Four
+candidates against a three-per-cycle cap is a queue, not a backlog, but it is
+the first time the cap is within reach. Nothing in the loop schedules
+disposition, and `/harness-propose` and `/harness-accept` write records without
+opening anything that tracks the ones nobody chose.
+
+**Does the snapshot's factual accuracy have an owner?** `/harness-health`
+carries a validation checkpoint per `CLAUDE.md`, and the 2026-08-25 snapshot is
+structurally correct and carries a claim about six runs that three runs'
+per-step conclusions contradict (finding-3). A checkpoint that checks structure
+against a format spec cannot catch it. I have not proposed anything here
+because I cannot describe a checkpoint that verifies prose against GitHub
+Actions history without becoming a second audit, and the same snapshot's
+careful handling of the AGENTS.md counting basis is evidence that the author's
+own discipline usually catches this. Whether "usually" is the standard is a
+human's call.
+
+**Was any Mast boundary notice raised during this phase?** Unanswerable from
+here. `$HOME/.claude/mast` does not exist on this machine and the store is
+per-machine and gitignored. I make no claim either way. This is the third
+consecutive assay to record the source as absent, which is itself worth a
+human's attention: a sentinel whose output no assay has ever been able to read
+is a sentinel nobody has checked.
+
+**Was `/coda` run at the close of these sessions?** `docs/superpowers/parked/`
+holds its `README.md` and no records, unchanged across all three assays
+(`observed`). Equally consistent with "no thread was worth parking across
+seventeen PRs" and with "the Coda was not run". The record format still cannot
+distinguish them, and assay 1 already flagged that as a question for a later
+assay. Three assays in, that question has not been picked up.

--- a/harness/decisions/HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one.md
+++ b/harness/decisions/HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one.md
@@ -1,0 +1,240 @@
+---
+id: HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one
+title: Four mechanisms report the reassuring answer when they cannot determine the real one
+status: proposed
+classification: harness-loop
+enforcement: advisory
+surfaces: [claude-code, codex, cursor, copilot, windsurf]
+provisional: true
+expires: 2026-11-23
+overfitting_risk: low
+evidence:
+  - ai-literacy-superpowers/scripts/update-health-badge.sh
+  - HARNESS.md
+  - .github/workflows/gc.yml
+  - harness/assay/2026-08-25T11-59Z-assay.md#finding-2
+  - harness/assay/2026-08-25T14-31Z-assay.md#finding-1
+proposed_cost: |
+  Per PR that adds or changes a reporting mechanism: one question the author must
+  answer in the spec or the PR body — what does this report when it cannot tell,
+  and which code path reaches that value — plus, where the answer is "the passing
+  one", the work to change it. Five minutes to answer, thirty to two hours to
+  fix. Most PRs add no reporting mechanism and pay nothing.
+
+  The heavy cost is honest and the approver should price it before the per-PR
+  one. **This becomes the eleventh agent-enforced constraint in a tree where the
+  2026-08-25 audit established that none of them can fire.** `grep -rn
+  'harness-enforcer' .github/workflows/` returns nothing (`observed`, and
+  recorded in the Status block). An agent-enforced constraint runs when a human
+  types `/harness-audit`, which happened once in the twelve days before this
+  window. So the realistic sequence after acceptance is: `HARNESS.md` gains a P1
+  rule; it is not dispatched by anything; and it is next read at the following
+  `/harness-audit`, which may be a quarter away. An approver who wants this to
+  bite is buying the dispatch path, not the rule text, and the cost they write
+  should say who builds it and when. An approver who does not want to buy that
+  should decline this finding rather than accept a rule they know cannot fire —
+  that is a legitimate outcome and I would rather it be chosen deliberately than
+  arrived at.
+
+  Three ways it can be gamed, in descending order of likelihood. **Declaring an
+  `Unknown` state and never routing to it** — the branch exists, the reviewer
+  sees it, nothing reaches it. This is the likely evasion; the rule's phrase
+  "reachable code path" is the only defence and it depends on a reviewer asking
+  what makes the branch reachable, which is exactly the kind of question that
+  does not get asked at 17:00. **Renaming the passing value** — shipping
+  `Healthy (unverified)` in green, which satisfies the letter and produces the
+  same badge. **Arguing the mechanism does not report a status** — available for
+  anything that only returns an exit code, and the second sentence about weaker
+  properties is what closes it for checks, at the cost of being the vaguest
+  clause in the rule. I could not tighten "weaker property" into something
+  mechanical without narrowing it to release tags, which would overfit it to
+  finding-2.
+
+  ---
+cost: ""
+proposer:
+  agent: harness-assayer
+  model: claude-opus-5
+  assay: harness/assay/2026-08-25T14-31Z-assay.md
+supersedes: null
+superseded_by: null
+---
+
+## Finding
+
+Four separate mechanisms in this repository resolve an indeterminate state to
+the passing value. Each was observed directly, and they share no
+implementation.
+
+**The health badge.** At `b1982b0`,
+`ai-literacy-superpowers/scripts/update-health-badge.sh` set
+`health_status="Healthy"` and `health_colour="2E8B57"` at line 22, then placed
+its entire detection block behind `if [ -n "$SNAPSHOT_FILE" ] && [ -f
+"$SNAPSHOT_FILE" ]`, where `SNAPSHOT_FILE="${2:-}"`. `/harness-health` step 8
+documented the argument-less invocation. Every safety net — the explicit
+`- Health:` line reader, the sub-70% override, the signal heuristic — lived
+inside the branch an argument-less call skipped (`observed`, `git show
+b1982b0:...`). #575 records the reproduction: a run against a snapshot whose
+Meta section read `Health: **Degraded**` wrote a green badge.
+
+**The Status block.** At `b1982b0`, `HARNESS.md` read `Last audit: 2026-08-13`,
+`Constraints enforced: 33/34`, `Drift detected: no`, against a tree carrying 36
+active constraints and, by the 2026-08-25 audit's own account, four failing
+ones that predated the 2026-08-13 audit (`observed`, `git show
+b1982b0:HARNESS.md` and the current block). The command that writes it had no
+read-back step, so `no` was the value it produced when nothing checked.
+
+**A GC step that did not run.** `gc.yml` carries one `if: always()`, on
+`Summary`. On run `32712709028` steps 6–14 are `skipped`; on `32015897112`
+steps 10–14 are `skipped` (`observed`, per-step conclusions). A `skipped`
+conclusion is not a failure and is not a pass; the run reports one red step and
+between five and nine unknowns, and a reader asking "did GC pass?" sees the
+single failure.
+
+**A check that passes on a weaker property than it names.** `gc.yml`'s
+*Release tag completeness* runs `git tag -l "v$version" | grep -q "v$version"`
+over `grep -oP '(?<=^## )\d+\.\d+\.\d+' CHANGELOG.md`. I ran that comparison:
+117 version headings, 7 with no matching tag. Of the 110 that pass, I sampled
+three — `## 0.27.0 — 2026-03-01` is satisfied by tag `v0.27.0` whose commit is
+dated 2026-04-26 and titled "Add sync check on /harness-upgrade and PR workflow
+on /reflect"; `## 0.28.0 — 2026-03-10` by a tag dated 2026-04-27 for
+"/harness-affordance discover"; `## 0.29.0 — 2026-03-28` by a tag dated
+2026-04-27 for the Choice Cartographer. The repository's first commit is
+`26b55ae`, 2026-03-30, after all three CHANGELOG dates (`observed`). The check
+verifies that a name exists, not that a release happened.
+
+Three of the four were repaired in this window. The fourth is open as #578,
+which names the pattern in its own words: "a mechanism reporting the reassuring
+answer because it cannot determine the real one" (`reported`). The repaired
+badge states the principle in a comment: "When this script cannot tell, it says
+Degraded: absence of evidence is not evidence of health, and a badge that fails
+toward the reassuring answer is worse than no badge" (`observed`). That comment
+is the only place in the repository the principle is written. `HARNESS.md`'s 36
+constraints and `AGENTS.md`'s six gotchas contain no equivalent (`observed`,
+read in full).
+
+## Assayer's reasoning
+
+_Written by the Assayer, carried verbatim. Not the approver's words, and not a substitute for the sections below._
+
+**Why `harness-loop`, and why the threshold is met honestly.** The behaviour is
+a design property of this repository's own machinery — the same species as
+*Output validation checkpoints*, which sits in `HARNESS.md` — so `HARNESS.md`
+is the layer that owns it, and `harness-loop` routes there. I considered
+`turn-instructions`, which routes to `AGENTS.md` and would need no CI and no
+two-assay threshold. I rejected it because `harness/surfaces.yaml` gives
+`AGENTS.md` as the target of `codex` alone, so the rule would reach one surface
+and be silent on the one where the work happens. That is classifying at the
+layer that is cheapest rather than the one that owns the behaviour.
+
+The two-assay threshold is therefore live, and it is met: assay 2's finding-2
+observed the masking instance directly and is uncorrected, so it counts; this
+assay observes three further instances in three unrelated mechanisms. Assay 1's
+finding-2 also observed masking, but it carries an erratum and I have
+deliberately **not** cited it — a corrected finding does not corroborate. I
+name no `target`: `harness-loop` is routed, and since #568 a routed
+classification refuses one.
+
+**Why no existing owner absorbs it.** *Output validation checkpoints* is the
+nearest, and it is the reason `/harness-audit` gained a read-back step in #577.
+It cannot absorb this: its subject is a command reading its own structured
+output back and checking it against a **format spec**, which is a question
+about shape. Three of the four instances here are correctly shaped and wrong
+about the world — a green badge is a well-formed badge. The 2026-08-13 Status
+block would have passed a structural check on all four fields. *Docs site kept
+current* and the GC rule *Command-prompt sync* compare prose surfaces to each
+other. `/harness-audit` **found** three of these four instances, which is why
+they are not rejected candidates for it — but it has no rule to cite when the
+next mechanism ships with the same default, and it found them because a human
+typed the command, twelve days after the previous run.
+
+**Overfitting risk: low.** Four instances across a bash script's variable
+initialisation, an agent-authored prose block, GitHub Actions step ordering,
+and a shell string comparison. The rule encodes none of their specifics and
+would have fired on each independently.
+
+**Validation plan.** Reconstruct the tree at `b1982b0` and assert the rule
+flags `update-health-badge.sh`, the `## Status` block and `gc.yml`'s
+release-tag step. Then assert it does **not** flag
+`check-harness-decisions.py` or `harness-registrar.py check`, both of which
+exit non-zero when they cannot read their input. If the rule cannot separate
+those two sets without an author's cooperation, it is not falsifiable and
+should be refused rather than softened.
+
+## Rule
+
+````markdown
+- **Rule**: A mechanism that reports a status — a badge, a `## Status`
+  block, a check result, a snapshot field, a summary line — must have a
+  defined value for the case where it could not determine the answer, and
+  that value may not be the passing one. Where an input is missing,
+  unreadable or not supplied, the mechanism reports the degraded or unknown
+  state and names the input it could not read. A reachable code path that
+  reaches a passing value without reading the thing it reports on is a
+  defect, not a default. Separately, a check may not report a pass on the
+  strength of a property weaker than the one it names: if the check is
+  called "release tag completeness" it verifies that the release has a tag,
+  not that a string exists. Absence of evidence is not evidence of health,
+  and a mechanism that fails toward the reassuring answer is worse than an
+  absent one, because the next reader stops looking.
+- **Enforcement**: agent
+- **Tool**: advocatus-diaboli (spec-mode gate) and harness-enforcer
+- **Scope**: pr
+````
+
+## Cost
+
+_Proposed by the Assayer. To be replaced at acceptance by the approver's own words:_
+
+Per PR that adds or changes a reporting mechanism: one question the author must
+answer in the spec or the PR body — what does this report when it cannot tell,
+and which code path reaches that value — plus, where the answer is "the passing
+one", the work to change it. Five minutes to answer, thirty to two hours to
+fix. Most PRs add no reporting mechanism and pay nothing.
+
+The heavy cost is honest and the approver should price it before the per-PR
+one. **This becomes the eleventh agent-enforced constraint in a tree where the
+2026-08-25 audit established that none of them can fire.** `grep -rn
+'harness-enforcer' .github/workflows/` returns nothing (`observed`, and
+recorded in the Status block). An agent-enforced constraint runs when a human
+types `/harness-audit`, which happened once in the twelve days before this
+window. So the realistic sequence after acceptance is: `HARNESS.md` gains a P1
+rule; it is not dispatched by anything; and it is next read at the following
+`/harness-audit`, which may be a quarter away. An approver who wants this to
+bite is buying the dispatch path, not the rule text, and the cost they write
+should say who builds it and when. An approver who does not want to buy that
+should decline this finding rather than accept a rule they know cannot fire —
+that is a legitimate outcome and I would rather it be chosen deliberately than
+arrived at.
+
+Three ways it can be gamed, in descending order of likelihood. **Declaring an
+`Unknown` state and never routing to it** — the branch exists, the reviewer
+sees it, nothing reaches it. This is the likely evasion; the rule's phrase
+"reachable code path" is the only defence and it depends on a reviewer asking
+what makes the branch reachable, which is exactly the kind of question that
+does not get asked at 17:00. **Renaming the passing value** — shipping
+`Healthy (unverified)` in green, which satisfies the letter and produces the
+same badge. **Arguing the mechanism does not report a status** — available for
+anything that only returns an exit code, and the second sentence about weaker
+properties is what closes it for checks, at the cost of being the vaguest
+clause in the rule. I could not tighten "weaker property" into something
+mechanical without narrowing it to release tags, which would overfit it to
+finding-2.
+
+---
+
+## Why this layer
+
+_TODO — why this change belongs at this layer and not one layer down._
+
+## Enforcement
+
+_TODO — how the rule binds on each listed surface, and where it is only advisory._
+
+## Validation
+
+_TODO — how anyone would know later whether this rule helped._
+
+## Rejected alternatives
+
+_TODO — including the 'no change' option, with the reason it was not taken._

--- a/harness/decisions/index.md
+++ b/harness/decisions/index.md
@@ -7,6 +7,7 @@ One row per Harness Decision Record. Generated from `harness/decisions/`; the fi
 | ID | Status | Classification | Enforcement | Surfaces | Provisional | Expires | State |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | HDR-2026-08-25-an-epic-s-authority-cited-to-a-document-nobody-else-can-open | rejected | harness-loop | advisory | claude-code, codex, cursor, copilot, windsurf | no | — | rejected |
+| HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one | proposed | harness-loop | advisory | claude-code, codex, cursor, copilot, windsurf | yes | 2026-11-23 | proposed |
 | HDR-2026-08-25-retire-periodic-check-suite-runner | accepted | script-validator | validated | ci | no | — | retirement |
 | HDR-2026-08-25-the-periodic-check-suite-stops-at-its-first-failure-and-reports-the-rest-as-nothing | accepted | script-validator | validated | ci | yes | 2026-11-23 | superseded |
 


### PR DESCRIPTION
## The finding

Four separate mechanisms in this repository report the reassuring answer when they cannot determine the real one. They share no implementation:

| Mechanism | The indeterminate case | What it reported |
| --- | --- | --- |
| `update-health-badge.sh` | no snapshot argument | `Healthy`, hardcoded above the detection block |
| `## Status` block | nothing read it back | `Drift detected: no`, for twelve days, against four failing constraints |
| `gc.yml` step | the step never ran | `skipped` — not a failure, not a pass |
| *Release tag completeness* | a version with no release here | passes on 110 of 117, because a same-named tag exists |

The principle forbidding this is written down **exactly once in the repository**, in a comment added to `update-health-badge.sh` yesterday: "absence of evidence is not evidence of health, and a badge that fails toward the reassuring answer is worse than no badge". `HARNESS.md`'s 36 constraints and `AGENTS.md`'s six gotchas carry no equivalent.

Three of the four were repaired in the window under assay. The fourth is #578.

## The record

`HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one` — `proposed`, `harness-loop`, advisory across all five surfaces.

**The first record to reach the loop layer, and the first to satisfy the two-assay promotion threshold.** Its evidence cites two distinct assay files — assay 2's finding-2 and assay 3's finding-1. Assay 1's finding-2 observed the same masking instance and is **deliberately not cited**: it carries an erratum, and a corrected finding does not corroborate. That exclusion is the #566 mechanism doing exactly what it was built for, on the first record where it could have mattered.

The Assayer also declined the cheaper classification and said so: `turn-instructions` would route to `AGENTS.md`, need no CI and skip the threshold entirely, and it rejected that as "classifying at the layer that is cheapest rather than the one that owns the behaviour".

## What is left for the approver

Four tier-2 sections — *Why this layer*, *Enforcement*, *Validation*, *Rejected alternatives* — and the cost are placeholders. `precheck` refuses acceptance until they are written, and they are not an agent's to write.

The cost estimate names the term that should dominate that decision: this would become the **eleventh agent-enforced constraint in a tree where none of them can fire**, since no workflow dispatches `harness-enforcer`. In its own words — "An approver who does not want to buy that should decline this finding rather than accept a rule they know cannot fire — that is a legitimate outcome and I would rather it be chosen deliberately than arrived at."

## A correction to yesterday's work

Assay 3 finding-3 falsifies a claim in the snapshot merged as #574 and in issue #573. Per-step conclusions, readable at the time:

```
run 29739302793 (07-20)   step 5 success  ·  step 8 FAILURE (release tags)
run 32015897112 (08-17)   step 5 success  ·  step 9 FAILURE (release tags)
run 32712709028 (08-24)   step 5 FAILURE  (snapshot staleness)
```

Five of six runs blocked at *Release tag completeness*, not *Snapshot staleness*. So refreshing the snapshot returns the next scheduled run to the older blocker rather than clearing the path: **reflection archival stays masked and the fifteen fragments stay unarchived**. #573's closing claim is wrong and the issue should be reopened.

The generalisation came from reading one run's conclusions and not the other five — which is the shape of the finding this PR proposes a rule against. Recorded rather than quietly amended.

## Also in the assay, not proposed here

- **finding-2** — *Release tag completeness* verifies a name exists, not that a release happened. The Assayer classified it `harness-loop` knowing it cites one assay and will be refused, rather than reaching for `script-validator` to clear the threshold — the move objection O3 named. It says the refusal record is the corroboration a fourth assay would need.
- **finding-3, finding-4** — `no-change`.
- Two proposals against a three-per-cycle cap, with assay 2's two P1 findings still unproposed and 23 objections undisposed. The Assayer raises the queue as an unresolved question rather than assuming its own findings go first.

## Exemption

`chore` label at creation. Records only; no plugin file changes, so no version bump.