### PR TITLE
Draft the two outstanding assay-2 findings into proposed records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,30 @@ Both are recorded as raised rather than silently corrected. The disposition
 mechanism exists for exactly this, and an agent editing an adversarial reviewer's
 objections would defeat the gate.
 
+### The two outstanding assay-2 findings are now proposed records
+
+`/harness-propose` on `harness/assay/2026-08-25T11-59Z-assay.md` findings 1 and 2,
+which had objection records but had never been drafted into the corpus.
+
+- **`HDR-2026-08-25-command-cli-parity`** — `script-validator`, routed to
+  `HARNESS.md`, naming no target.
+- **`HDR-2026-08-25-workflow-step-masking`** — `script-validator`, same routing.
+  This is the re-proposal the retirement record deferred: "Re-propose immediately
+  with `HARNESS.md` as the target. Deferred, not rejected." The route now carries
+  the target, so the deadlock that retired the original does not recur.
+
+The corpus holds six records — three historical, three `proposed` — and
+`/harness-check` reports OK.
+
+All three proposals fail `precheck` on exactly one thing, and it is the same
+thing for each: the four tier-2 sections are placeholders. Nothing else stands
+in the way — routing resolves, the two-assay threshold is satisfied where it
+applies, and the cycle cap is not reached.
+
+Those sections, the 35 objection dispositions across the three records, and the
+cost at the gate are the approver's work and no agent's. They are listed rather
+than drafted.
+
 ## 0.86.1 — 2026-08-25
 
 ### Fixed — the health badge defaulted to green when it could not tell

--- a/harness/decisions/HDR-2026-08-25-command-cli-parity.md
+++ b/harness/decisions/HDR-2026-08-25-command-cli-parity.md
@@ -1,0 +1,205 @@
+---
+id: HDR-2026-08-25-command-cli-parity
+title: The prose that drives the loop is never checked against the loop's code
+status: proposed
+classification: script-validator
+enforcement: validated
+surfaces: [ci]
+provisional: true
+expires: 2026-11-23
+overfitting_risk: low
+evidence:
+  - ai-literacy-superpowers/commands/harness-propose.md
+  - ai-literacy-superpowers/commands/harness-accept.md
+  - ai-literacy-superpowers/skills/harness-assay/SKILL.md
+  - ai-literacy-superpowers/scripts/harness-registrar.py
+  - docs/plugins/ai-literacy-superpowers/reference/harness-decision-records.md
+  - HARNESS.md
+  - harness/assay/2026-08-25T11-59Z-assay.md#finding-1
+proposed_cost: |
+  One-off: writing the parity check — an argparse walk over each script named in
+  a command file, matched against that file's text — perhaps an hour, plus the
+  Layer-0 suite. Then a backlog: the four capabilities already divergent must be
+  written into `harness-propose.md` and `harness-accept.md` before the check can
+  go green, which is thirty to sixty minutes of prose someone has to actually
+  think about, because `--reject` changes what step 5's checkpoint should assert.
+
+  Recurring: one line of prose per new option, paid by whoever adds the option,
+  in the same PR. For a repository that added four in a day that is not nothing;
+  for a repository that adds one a month it is invisible. The honest description
+  is that it makes adding a flag slightly more expensive and makes an unusable
+  flag impossible.
+
+  Three ways it can be gamed, in descending order of likelihood. **Naming the
+  flag and not explaining it** — a bare `--reject` mentioned in a code fence
+  satisfies a literal-string check while the prompt still never tells the agent
+  when to use it. This is the likely evasion and the check cannot see it; the
+  mitigation is that the flag at least becomes discoverable, which is strictly
+  better than today. **`# undocumented:` as a default** — the exemption is one
+  comment away and an author in a hurry will reach for it; it is deliberately
+  placed at the `add_argument` line so it shows up in the diff beside the option,
+  where a reviewer is already looking. **Splitting the parser** — moving options
+  into a wrapper script that no command file names. That would be conspicuous and
+  costs more than writing the line.
+
+  What the rule does **not** catch is the friction that motivated half its
+  evidence: a reference page or a docstring asserting behaviour the code lacks,
+  as in #567 and #568. I could not state a mechanical test for that class whose
+  false-positive rate I could predict, and proposing an advisory rule I cannot
+  falsify would be proposing to look comprehensive.
+
+  ---
+cost: ""
+proposer:
+  agent: harness-assayer
+  model: claude-opus-5
+  assay: harness/assay/2026-08-25T11-59Z-assay.md
+supersedes: null
+superseded_by: null
+---
+
+## Finding
+
+`harness-registrar.py` accepts the long options `--acknowledge-correction`,
+`--approver`, `--assay`, `--correction-file`, `--cost-file`, `--finding`,
+`--hdr`, `--now`, `--reason-file`, `--reject`, `--root`, `--slug`, `--target`,
+`--today`, and the subcommands `accept`, `check`, `compile`, `correct`,
+`index`, `lint-assay`, `precheck`, `propose`, `review`.
+
+`ai-literacy-superpowers/commands/harness-propose.md` names `--assay`,
+`--finding`, `--slug`. `commands/harness-accept.md` names `--hdr`,
+`--cost-file`, `--approver`, `--now`. A `grep -rln` across
+`ai-literacy-superpowers/commands/`, `agents/` and `skills/` for
+`--reject`, `--acknowledge-correction`, `--correction-file`,
+`harness-registrar.py correct` and `accept … --target` returns **no files**.
+Both command files were last modified on 2026-08-23; the four capabilities
+landed on 2026-08-25 in #562, #566 and #568.
+
+The divergence is not only omission. `harness-propose.md`'s step-5 validation
+checkpoint requires, as **P1**, that the written record's frontmatter carries
+`proposed_cost` and `cost`, and as **P5** that a tier-2 classification carries
+all four extra sections. The rejection record shipped by #562 and written by
+#563 carries neither key and none of those sections, by design. An agent
+following the checkpoint as written against a correctly-formed rejection would
+report a defect that is not there — and the command's own instruction for that
+case is "Report the deviation as a defect … Report, do not patch."
+
+The same divergence reaches the reference layer: the errata mechanism is
+documented in `docs/.../reference/assay-finding-format.md` and in the
+`harness-registrar.py` source, and nowhere in the agent-facing prose that
+`/harness-assay` and `/harness-propose` actually load.
+
+## Assayer's reasoning
+
+_Written by the Assayer, carried verbatim. Not the approver's words, and not a substitute for the sections below._
+
+**Why this layer, and why no existing owner absorbs it.** Three constraints sit
+nearby and none of them fires here. *Docs site kept current* is triggered by a
+PR that "adds, removes, or substantially changes a skill, agent, or command" —
+and no file under `ai-literacy-superpowers/commands/`, `agents/` or `skills/`
+changed in this entire phase (`observed`, `git diff --name-only`), so its
+trigger condition is precisely what went missing. *Docs propagation when
+shipping new commands* is scoped to a PR that adds a **new** command. The GC
+rule *Command-prompt sync* compares `commands/` against `.github/prompts/` —
+two prose surfaces against each other, never against the code. `/harness-audit`
+would correctly report all three compliant, which is why this is a finding and
+not a rejected candidate.
+
+I am deliberately **not** proposing "update the command prompt". Four
+capabilities diverged in a single day across three PRs, each written carefully
+and each reviewed; the failure is not carelessness but the absence of anything
+that reads a parser and a prompt in the same breath. That is a check, so the
+classification is `script-validator`, which routes to `HARNESS.md`. I name no
+`target` for that reason: the route wins in `target_of`, and since #568 a
+routed classification refuses one.
+
+`enforcement: validated` states the intent. No such check exists today, so the
+first `/harness-compile` after acceptance should report an enforcement **gap**
+on `ci` rather than `validated`. That is the enforcement report doing its job
+and is not a reason to declare `advisory` instead.
+
+**Overfitting risk: low.** The rule states a property of any command that
+delegates to a script and encodes none of the four options that happen to have
+diverged. It would have fired on all four independently.
+
+**Validation plan.** Reconstruct the tree at `b1982b0^` for #562, #566 and #568
+and assert the check fails on each. Assert it passes at `2e2d1fa`, where the
+prompts and the parser agreed. Then assert it passes at `b1982b0` **only after**
+the prompts are updated — if it passes on the current tree unchanged, the check
+is not reading what it claims to read and should be refused.
+
+## Rule
+
+````markdown
+- **Rule**: Every long option and every subcommand that a script accepts must
+  appear verbatim in at least one file under
+  `ai-literacy-superpowers/commands/`, when that script is invoked by a
+  command in that directory. A capability the code exposes and no command
+  prompt names is a capability the agent driving that command cannot reach,
+  and a validation checkpoint written against an older interface reports a
+  correct artifact as a defect — which is worse than silence, because the
+  command instructs the agent to report rather than patch. An option whose
+  only caller is another script is exempt by carrying an `# undocumented:`
+  comment on the line above its `add_argument` call, so the exemption is
+  visible where the option is declared rather than in a list somewhere else.
+  This does not reach reference or how-to pages; those are governed by
+  *Docs site kept current*, whose trigger is a change to a command, skill or
+  agent file.
+- **Enforcement**: deterministic
+- **Tool**: `python3 ai-literacy-superpowers/scripts/check-command-cli-parity.py`
+  (CI: `.github/workflows/harness.yml`)
+- **Scope**: pr
+````
+
+## Cost
+
+_Proposed by the Assayer. To be replaced at acceptance by the approver's own words:_
+
+One-off: writing the parity check — an argparse walk over each script named in
+a command file, matched against that file's text — perhaps an hour, plus the
+Layer-0 suite. Then a backlog: the four capabilities already divergent must be
+written into `harness-propose.md` and `harness-accept.md` before the check can
+go green, which is thirty to sixty minutes of prose someone has to actually
+think about, because `--reject` changes what step 5's checkpoint should assert.
+
+Recurring: one line of prose per new option, paid by whoever adds the option,
+in the same PR. For a repository that added four in a day that is not nothing;
+for a repository that adds one a month it is invisible. The honest description
+is that it makes adding a flag slightly more expensive and makes an unusable
+flag impossible.
+
+Three ways it can be gamed, in descending order of likelihood. **Naming the
+flag and not explaining it** — a bare `--reject` mentioned in a code fence
+satisfies a literal-string check while the prompt still never tells the agent
+when to use it. This is the likely evasion and the check cannot see it; the
+mitigation is that the flag at least becomes discoverable, which is strictly
+better than today. **`# undocumented:` as a default** — the exemption is one
+comment away and an author in a hurry will reach for it; it is deliberately
+placed at the `add_argument` line so it shows up in the diff beside the option,
+where a reviewer is already looking. **Splitting the parser** — moving options
+into a wrapper script that no command file names. That would be conspicuous and
+costs more than writing the line.
+
+What the rule does **not** catch is the friction that motivated half its
+evidence: a reference page or a docstring asserting behaviour the code lacks,
+as in #567 and #568. I could not state a mechanical test for that class whose
+false-positive rate I could predict, and proposing an advisory rule I cannot
+falsify would be proposing to look comprehensive.
+
+---
+
+## Why this layer
+
+_TODO — why this change belongs at this layer and not one layer down._
+
+## Enforcement
+
+_TODO — how the rule binds on each listed surface, and where it is only advisory._
+
+## Validation
+
+_TODO — how anyone would know later whether this rule helped._
+
+## Rejected alternatives
+
+_TODO — including the 'no change' option, with the reason it was not taken._

--- a/harness/decisions/HDR-2026-08-25-workflow-step-masking.md
+++ b/harness/decisions/HDR-2026-08-25-workflow-step-masking.md
@@ -1,0 +1,189 @@
+---
+id: HDR-2026-08-25-workflow-step-masking
+title: A failing step still cancels every check after it, and on 2026-08-25 it cancelled the two that govern governance
+status: proposed
+classification: script-validator
+enforcement: validated
+surfaces: [ci]
+provisional: true
+expires: 2026-11-23
+overfitting_risk: low
+evidence:
+  - .github/workflows/harness.yml
+  - .github/workflows/gc.yml
+  - harness/decisions/HDR-2026-08-25-retire-periodic-check-suite-runner.md
+  - harness/assay/2026-08-25T08-08Z-assay.md#finding-2
+  - HARNESS.md
+  - harness/assay/2026-08-25T11-59Z-assay.md#finding-2
+proposed_cost: |
+  One-off: `if: always()` on eight steps in `harness.yml` and eleven in
+  `gc.yml`, plus an aggregation step in each that fails the job when any
+  collected result failed. Perhaps forty minutes, once.
+
+  The recurring cost is the honest one and it is not zero, and it differs by
+  workflow. On the **PR gate** it makes red PRs noisier: a branch with a
+  ShellCheck error will now show three failures instead of one, and the temptation
+  is to read the extra two as noise rather than as two governance checks that were
+  never going to pass either. On the **weekly job** it converts one failure into
+  between one and ten. The six weeks of *Garbage Collection* failures already
+  hide an unknown number of results; whoever holds the cadence inherits a backlog
+  that was always there. The moment of maximum temptation is the first Monday
+  after the fix, and the tempting move is to demote whichever rule is loudest.
+
+  Two ways it can be gamed. **Making the job green rather than complete** —
+  collecting results and then not failing on them satisfies "a result for every
+  step" while deleting the signal entirely. This is the likely failure, and it is
+  why the rule names the job conclusion explicitly rather than only the steps.
+  **Deleting a chronically failing step from the workflow instead of retiring the
+  rule from `HARNESS.md`** — the rule stays declared, nothing runs it, and the run
+  reports a complete pass over a smaller set. *Convention parity* does not catch
+  this; it compares `HARNESS.md` against its three prose mirrors, not against the
+  workflows. Nothing currently checks a declared GC rule against a workflow step,
+  and this rule does not add that. It is a real hole and I am naming it rather
+  than widening the proposal to cover it.
+
+  ---
+cost: ""
+proposer:
+  agent: harness-assayer
+  model: claude-opus-5
+  assay: harness/assay/2026-08-25T11-59Z-assay.md
+supersedes: null
+superseded_by: null
+---
+
+## Finding
+
+`.github/workflows/harness.yml` — the PR gate — runs eight constraint steps
+sequentially. Only the final `Summary` step carries `if: always()` (`observed`,
+lines 25–81). The last two constraint steps, in order, are
+*Harness decision records are well-formed* and
+*Harness governance is applied and undrifted*: the two validators that hold the
+identifier grammar, the required fields, the two-assay promotion threshold, the
+three-per-cycle cap, the frozen-record check and the expiry check.
+
+Being last, they are the most maskable steps in the file. That is not
+hypothetical. On run `32836457544` (branch `harness-write-path-integrity`,
+PR #552) and again on run `32839441437` (branch `harness-validator-binding`,
+PR #561), step 8 *Constraint: ShellCheck compliance* is recorded `failure` and
+steps 9, 10 and 11 — *Sentinel integrity*, *Harness decision records are
+well-formed*, *Harness governance is applied and undrifted* — are all recorded
+`skipped` (`observed`, `gh api .../actions/runs/<id>/jobs`, per-step
+conclusions). Both of those PRs were changing
+`ai-literacy-superpowers/scripts/check-harness-decisions.py` and
+`harness-registrar.py`. The two checks that exist to catch a governance
+regression did not run on two of the PRs that rewrote the governance code. Both
+PRs later merged with every check `pass`, so nothing shipped unverified — but
+that was a re-push, not the gate working.
+
+`.github/workflows/gc.yml` is unchanged in this phase and has the same shape:
+eleven `GC:` steps, one `if: always()`, on `Summary` (`observed`). The
+*Garbage Collection* schedule has failed six consecutive runs, 2026-07-20
+through 2026-08-24 (`observed`, `gh run list`). It has not run since, so I make
+no claim about a seventh.
+
+Assay 1's finding-2 observed this on `gc.yml`. Its errata narrowed the count of
+declared rules the workflow covers and states that "The masking observation - a
+failing step silencing every later step - is unaffected and stands"
+(`observed`). Its record was accepted, corrupted its target, and was retired;
+the retirement's `## Rejected alternatives` closes with "**Re-propose
+immediately with `HARNESS.md` as the target.** Deferred, not rejected"
+(`observed`). Every fact above was re-read at `b1982b0` rather than carried
+forward, and the corrected count forms no part of this claim — I counted the
+steps in both files directly.
+
+## Assayer's reasoning
+
+_Written by the Assayer, carried verbatim. Not the approver's words, and not a substitute for the sections below._
+
+**Why this layer, and what is different from the retired record.** The retired
+record pointed at `.github/workflows/gc.yml` as its `target` and the compiler
+appended markdown to YAML. `script-validator` now has a fixed route to
+`HARNESS.md` (#552, and pinned in `harness/surfaces.yaml`), so the rule text
+lands in a document that can hold it and the workflows are named in **Tool**,
+which is where the retirement record says they always belonged. I name no
+`target` in the metadata: the route wins, and since #568 a routed
+classification refuses one.
+
+`/harness-gc` still cannot own this. It runs the rules on demand and reports
+each individually; what it cannot observe is the behaviour of a runner nobody
+invoked. And `/harness-gc` has no visibility into `harness.yml` at all, which
+is the half of this finding that is new.
+
+**Overfitting risk: low.** The rule states a property of any enforcement
+workflow and encodes neither ShellCheck, nor release-tag completeness, nor
+snapshot staleness — the three rules that happened to fail. It would have
+applied identically to all eight observed runs.
+
+**Validation plan.** Push a branch with a deliberately failing early step in
+`harness.yml` and assert that (a) every later step produces a conclusion, (b)
+the job still concludes `failure`, and (c) no step reports `skipped` for a
+reason other than an explicit `if:` condition. The third assertion is the one
+that matters: a fix that makes the job green by tolerating failures is worse
+than the defect and would satisfy (a) and nothing else.
+
+## Rule
+
+````markdown
+- **Rule**: In a workflow that enforces declared constraints or
+  garbage-collection rules, every enforcing step carries `if: always()`, and
+  the job's conclusion is derived from the collected step results rather than
+  from the first failure. A check that did not run is reported as not run —
+  never omitted, and never counted as passing. This binds
+  `.github/workflows/harness.yml` and `.github/workflows/gc.yml`. On the PR
+  gate the two harness-governance checks are the last two steps, so any
+  earlier constraint failure hides them; on the weekly job the whole value is
+  the weeks nobody reads it. A run that stops partway reports a smaller world
+  than it declared it would check.
+- **Enforcement**: deterministic
+- **Tool**: `.github/workflows/harness.yml` and `.github/workflows/gc.yml`
+- **Scope**: pr
+````
+
+## Cost
+
+_Proposed by the Assayer. To be replaced at acceptance by the approver's own words:_
+
+One-off: `if: always()` on eight steps in `harness.yml` and eleven in
+`gc.yml`, plus an aggregation step in each that fails the job when any
+collected result failed. Perhaps forty minutes, once.
+
+The recurring cost is the honest one and it is not zero, and it differs by
+workflow. On the **PR gate** it makes red PRs noisier: a branch with a
+ShellCheck error will now show three failures instead of one, and the temptation
+is to read the extra two as noise rather than as two governance checks that were
+never going to pass either. On the **weekly job** it converts one failure into
+between one and ten. The six weeks of *Garbage Collection* failures already
+hide an unknown number of results; whoever holds the cadence inherits a backlog
+that was always there. The moment of maximum temptation is the first Monday
+after the fix, and the tempting move is to demote whichever rule is loudest.
+
+Two ways it can be gamed. **Making the job green rather than complete** —
+collecting results and then not failing on them satisfies "a result for every
+step" while deleting the signal entirely. This is the likely failure, and it is
+why the rule names the job conclusion explicitly rather than only the steps.
+**Deleting a chronically failing step from the workflow instead of retiring the
+rule from `HARNESS.md`** — the rule stays declared, nothing runs it, and the run
+reports a complete pass over a smaller set. *Convention parity* does not catch
+this; it compares `HARNESS.md` against its three prose mirrors, not against the
+workflows. Nothing currently checks a declared GC rule against a workflow step,
+and this rule does not add that. It is a real hole and I am naming it rather
+than widening the proposal to cover it.
+
+---
+
+## Why this layer
+
+_TODO — why this change belongs at this layer and not one layer down._
+
+## Enforcement
+
+_TODO — how the rule binds on each listed surface, and where it is only advisory._
+
+## Validation
+
+_TODO — how anyone would know later whether this rule helped._
+
+## Rejected alternatives
+
+_TODO — including the 'no change' option, with the reason it was not taken._

--- a/harness/decisions/index.md
+++ b/harness/decisions/index.md
@@ -7,8 +7,10 @@ One row per Harness Decision Record. Generated from `harness/decisions/`; the fi
 | ID | Status | Classification | Enforcement | Surfaces | Provisional | Expires | State |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | HDR-2026-08-25-an-epic-s-authority-cited-to-a-document-nobody-else-can-open | rejected | harness-loop | advisory | claude-code, codex, cursor, copilot, windsurf | no | — | rejected |
+| HDR-2026-08-25-command-cli-parity | proposed | script-validator | validated | ci | yes | 2026-11-23 | proposed |
 | HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one | proposed | harness-loop | advisory | claude-code, codex, cursor, copilot, windsurf | yes | 2026-11-23 | proposed |
 | HDR-2026-08-25-retire-periodic-check-suite-runner | accepted | script-validator | validated | ci | no | — | retirement |
 | HDR-2026-08-25-the-periodic-check-suite-stops-at-its-first-failure-and-reports-the-rest-as-nothing | accepted | script-validator | validated | ci | yes | 2026-11-23 | superseded |
+| HDR-2026-08-25-workflow-step-masking | proposed | script-validator | validated | ci | yes | 2026-11-23 | proposed |
 
 <!-- END GENERATED: harness-registrar -->


### PR DESCRIPTION
Both assay-2 findings had adversarial reviews and neither had ever been drafted into the corpus. This puts all three live candidates at `proposed` so they can be worked through together.

| Record | Classification | Routing | Precheck |
| --- | --- | --- | --- |
| `HDR-2026-08-25-command-cli-parity` | `script-validator` | → `HARNESS.md`, no target named | tier-2 sections only |
| `HDR-2026-08-25-workflow-step-masking` | `script-validator` | → `HARNESS.md`, no target named | tier-2 sections only |
| `HDR-2026-08-25-four-mechanisms-...` | `harness-loop` | → `HARNESS.md`, no target named | tier-2 sections only |

**The masking record is the re-proposal the retirement deferred.** That record closed with "Re-propose immediately with `HARNESS.md` as the target. Deferred, not rejected" — deferred because the target was copied verbatim from an append-only assay and could not be corrected. Since #552 routed `script-validator` to `HARNESS.md` and #568 made a routed classification refuse an explicit target, the route supplies it and the deadlock does not recur.

## What blocks acceptance

All three fail `precheck` on the same single item — the four tier-2 sections are placeholders. Nothing else: routing resolves, the two-assay threshold is satisfied where it applies (`harness-loop` only), and the cycle cap is nowhere near.

`check-harness-decisions.py` passes at 6 records and `/harness-check` reports OK.

## What is deliberately not in this PR

The four tier-2 sections per record, the **35 pending objection dispositions** across the three objection records, and the cost at the gate. `precheck` names them as "must be written by a human", and drafting them for a human to approve would defeat the gate they exist to be.

## Exemption

`chore` label at creation. Records only; no plugin file changes, so no version bump.