### PR TITLE
Record the approver's disposition on all thirty-five objections

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.86.2",
+  "plugin_version": "0.87.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.86.2"
+      "version": "0.87.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@ while carrying no reasoning at all.
 The rationale field was left `null` rather than filled with a placeholder for
 exactly that reason: a `TODO` string is content, and content in a field nothing
 checks is the shape objection O11 of the reassuring-default record objects to.
+
 ### The two outstanding assay-2 findings are now proposed records
 
 `/harness-propose` on `harness/assay/2026-08-25T11-59Z-assay.md` findings 1 and 2,
@@ -166,6 +167,45 @@ applies, and the cycle cap is not reached.
 Those sections, the 35 objection dispositions across the three records, and the
 cost at the gate are the approver's work and no agent's. They are listed rather
 than drafted.
+
+### Rationales written for all thirty-five objections
+
+Every disposition now carries the approver's reasoning in their own words,
+transcribed rather than drafted. Three dispositions changed during the pass as
+the reasoning was worked through, which is the gate doing its job rather than a
+correction to it.
+
+| Record | accepted | rejected | deferred |
+| --- | --- | --- | --- |
+| `command-cli-parity` | 7 | 3 | 2 |
+| `harness-workflow-step-masking` | 11 | 0 | 0 |
+| `harness-reassuring-default` | 11 | 0 | 1 |
+
+**What moved.** `reassuring-default` O2 went from rejected to deferred: the
+approver holds that the second sighting is a verification observation and that
+the precedent the objection warns about is "right but acceptable", but is not
+sure that corroboration drawn from the one instance the rule text does not
+cover should count at all. That record does not go to the gate until the
+question is answered. On `workflow-step-masking`, O1 and O4 went from rejected
+to accepted — "I stand corrected" on the first — and O8 through O11 from
+deferred to accepted.
+
+**Two consequences worth stating plainly.**
+
+`workflow-step-masking` now concedes all eleven objections, including that it
+re-proposes a scope already rejected in writing. Its O3 rationale commits the
+redraft to reclassifying from `script-validator` to `harness-loop`, which takes
+the two-assay threshold with it. That reclassification makes the record
+**unacceptable as it stands**: its evidence cites two assays, but assay 1's
+finding-2 carries an erratum and a corrected finding does not corroborate, so
+one countable assay remains against a threshold of two. Choosing the honest
+classification costs the record its acceptance until another assay observes the
+behaviour.
+
+`command-cli-parity` survives. O9 is accepted — an existing constraint owns the
+behaviour and was never dispatched — while the objection's own reading, that
+accepting it turns the finding into a rejected candidate, is explicitly not
+taken: running the audit and writing the check are not alternatives.
 
 ## 0.86.1 — 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Changelog
 
+## 0.87.0 — 2026-08-25
+
+### The first rule enters force through the governed loop
+
+`HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one`
+is `accepted` and applied. Three assays, two adversarial reviews, thirty-five
+dispositions and one reclassification after it was first observed, the loop has
+produced a rule that is in force — and the corpus is no longer three records of
+governance being examined with nothing surviving the examination.
+
+- **Rule text amended before the gate**, on the accepted objections: the Tool
+  retargeted to the skill that actually dispatches it (O5), and the duplicated
+  "weaker property" clause dropped so it no longer legislates what assay 3's
+  finding-2 already covers (O9). Each record now carries `proposed_rule` beside
+  its amended text — the fourth application of the `proposed_cost` / `cost`
+  pattern, added here because rule text had no provenance pair and an amendment
+  would otherwise have read as the Assayer's words.
+- **Applied to `skills/advocatus-diaboli/SKILL.md`**, where it is loaded on every
+  `/diaboli` run. Enforcement report: intended advisory, achieved advisory,
+  **0 gaps of 1 rule-surface pair**. At the classification the assay proposed it
+  would have compiled to achieved `none`.
+- **The cost is the approver's, in their own words**: the team does the work; the
+  recurring cost is probably tighter than the Assayer estimated; retirement at
+  2026-11-23 unless it has fired and protected something.
+- **Validation was rewritten twice.** It first said nothing could measure the
+  rule. The approver's own retirement test then supplied the measurement: the
+  rule fires as an objection, objections carry dispositions, and that is the
+  evidence trail. A criterion that only exists because of the reclassification.
+
+### Fixed — the compiler emitted markdown that failed the project's own lint
+
+`enforcement_summary` rendered its one-line account as an underscore-emphasised
+line, which trips MD036 (emphasis used instead of a heading) and MD049
+(emphasis style). So the first rule this loop put in force wrote a generated
+region into `skills/advocatus-diaboli/SKILL.md` that failed *Consistent
+markdown formatting* — and the region carries "do not edit by hand", so it
+could not be fixed where it landed.
+
+Now rendered as a blockquote. A generated region that cannot satisfy the
+constraints of the project it is generated into is a defect in the generator,
+and it took putting a rule in force to find it.
+
+### Not accepted
+
+`workflow-step-masking` is reclassified to `harness-loop` on its own accepted
+objection and is now **refused by the threshold** — one countable assay against
+two, because assay 1's finding-2 carries an erratum. Choosing the classification
+that owns the behaviour cost it acceptance.
+
+`command-cli-parity` is gate-ready with two amendments still open: whether the
+rule binds bash as well as Python, and what the invocation trigger means
+mechanically.
+
 ## 0.86.2 — 2026-08-25
 
 ### Added — /harness-audit now validates the Status block it writes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,49 @@ behaviour and was never dispatched — while the objection's own reading, that
 accepting it turns the finding into a rejected candidate, is explicitly not
 taken: running the audit and writing the check are not alternatives.
 
+### Tier-2 sections written; two records reach the gate, one is refused by it
+
+All twelve tier-2 sections written across the three proposals, in minimal form.
+Eight were assembled from dispositions the approver had already made; four were
+open and are now answered.
+
+**Validation, on all three, says the same thing and says it plainly:** nothing
+will tell us whether the rule helped. There is no measurement separating a
+repository where it worked from one where it was ignored, and each drafted plan
+named a criterion nobody could evaluate. All three stay `provisional`, expiring
+2026-11-23, and the review at expiry is a judgement rather than a reading.
+
+**`reassuring-default` is reclassified `harness-loop` → `agent-instruction`,**
+targeting `ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md`. The
+assay's reason for the loop layer was reach, and objection O3 established that
+reason does not hold — `HARNESS.md` is the declared target of no surface in the
+matrix. The rule's enforcement is a question an agent asks at a review gate, so
+it belongs in that agent's instructions, where it is loaded on every `/diaboli`
+run rather than read when someone types `/harness-audit` once a quarter. The
+two-assay threshold does not apply at this classification, so the corroboration
+question deferred at O2 no longer gates the record; it stays genuinely unsettled
+and is recorded there rather than resolved by the move.
+
+**`workflow-step-masking` is reclassified `script-validator` → `harness-loop`,
+and the gate now refuses it.** That is the intended outcome of accepting O3,
+not an accident:
+
+```text
+FAIL: a harness-loop change requires evidence from at least two distinct
+      assays, found 1. Either wait for a second assay to corroborate, or
+      reclassify to the layer that owns the behaviour.
+```
+
+Its evidence cites two assays, but assay 1's finding-2 carries an erratum and a
+corrected finding does not corroborate. Choosing the classification that owns
+the behaviour cost the record its acceptance, which is the threshold working
+rather than obstructing.
+
+**Gate status:** `command-cli-parity` and `reassuring-default` pass `precheck`
+with no refusal standing. `workflow-step-masking` is refused until another assay
+observes the masking behaviour independently. What remains for the two that pass
+is the cost, written by the approver at the gate.
+
 ## 0.86.1 — 2026-08-25
 
 ### Fixed — the health badge defaulted to green when it could not tell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,28 @@ Both are recorded as raised rather than silently corrected. The disposition
 mechanism exists for exactly this, and an agent editing an adversarial reviewer's
 objections would defeat the gate.
 
+### The approver's calls on all thirty-five objections
+
+Dispositions recorded across the three objection records. No objection remains
+`pending`.
+
+| Record | accepted | rejected | deferred |
+| --- | --- | --- | --- |
+| `command-cli-parity` | 7 | 3 | 2 |
+| `harness-workflow-step-masking` | 4 | 3 | 4 |
+| `harness-reassuring-default` | 11 | 1 | 0 |
+
+**Every `disposition_rationale` is still `null`.** The calls are recorded; the
+reasons are not. That distinction matters more here than the schema suggests —
+*PRs have adjudicated objections* states in its own text that "'Resolved' is a
+judgment call on rationale quality, not a schema check", so the only mechanical
+proxy for adjudication is the count of non-`pending` values, and that count is
+now zero on all three records. A record can therefore read as fully adjudicated
+while carrying no reasoning at all.
+
+The rationale field was left `null` rather than filled with a placeholder for
+exactly that reason: a `TODO` string is content, and content in a field nothing
+checks is the shape objection O11 of the reassuring-default record objects to.
 ### The two outstanding assay-2 findings are now proposed records
 
 `/harness-propose` on `harness/assay/2026-08-25T11-59Z-assay.md` findings 1 and 2,

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.86.2-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.87.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-42-2E8B57?style=flat-square)](#skills-42)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.86.2 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.87.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.86.2",
+  "version": "0.87.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/scripts/harness-registrar.py
+++ b/ai-literacy-superpowers/scripts/harness-registrar.py
@@ -1348,6 +1348,13 @@ def enforcement_summary(record: Record, surfaces: dict, root: str) -> str:
     A rule declaring `blocked` that is merely advisory on the surface someone is
     actually reading should admit that there, not only in a report they may
     never open.
+
+    Rendered as a blockquote rather than an emphasised line. A standalone
+    emphasised line trips MD036 (emphasis used instead of a heading) and, with
+    underscores, MD049 — so the first rule this compiler put in force emitted
+    markdown that failed the repository's own *Consistent markdown formatting*
+    constraint. A generated region that cannot satisfy the constraints of the
+    project it is generated into is a defect in the generator.
     """
     parts = [f"Intended: {record.fm.get('enforcement')}"]
     for row in enforcement_rows(record, surfaces, root):
@@ -1356,7 +1363,7 @@ def enforcement_summary(record: Record, surfaces: dict, root: str) -> str:
     if record.fm.get("provisional") is True:
         expiry = record.fm.get("expires") or record.fm.get("review_trigger")
         parts.append(f"provisional until {expiry}")
-    return "_" + " · ".join(parts) + "_"
+    return "> " + " · ".join(parts)
 
 
 def render_region(records: list[Record], surfaces: dict, root: str) -> str:

--- a/ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md
+++ b/ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md
@@ -372,3 +372,28 @@ After the frontmatter, write one prose section per objection:
 ```
 
 At least three entries required. More is better.
+
+<!-- BEGIN GENERATED: harness-registrar — do not edit by hand -->
+
+<!-- Compiled from harness/decisions/. Run /harness-compile to regenerate. -->
+
+### HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one — Four mechanisms report the reassuring answer when they cannot determine the real one
+
+> Intended: advisory · claude-code: advisory · provisional until 2026-11-23
+
+- **Rule**: A mechanism that reports a status — a badge, a `## Status`
+  block, a check result, a snapshot field, a summary line — must have a
+  defined value for the case where it could not determine the answer, and
+  that value may not be the passing one. Where an input is missing,
+  unreadable or not supplied, the mechanism reports the degraded or unknown
+  state and names the input it could not read. A reachable code path that
+  reaches a passing value without reading the thing it reports on is a
+  defect, not a default.
+  Absence of evidence is not evidence of health,
+  and a mechanism that fails toward the reassuring answer is worse than an
+  absent one, because the next reader stops looking.
+- **Enforcement**: agent
+- **Tool**: `ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md`
+- **Scope**: pr
+
+<!-- END GENERATED: harness-registrar -->

--- a/docs/superpowers/objections/command-cli-parity.md
+++ b/docs/superpowers/objections/command-cli-parity.md
@@ -10,84 +10,84 @@ objections:
     claim: "The harm the finding leads with is a prompt asserting output structure the code no longer produces; the proposed check compares option strings and cannot detect it, so the check goes green on one added string while the false-defect report still fires."
     evidence: "Finding: 'An agent following the checkpoint as written against a correctly-formed rejection would report a defect that is not there.' Rule: options 'must appear verbatim in at least one file under ai-literacy-superpowers/commands/'. Cost estimate concedes: 'a bare --reject mentioned in a code fence satisfies a literal-string check while the prompt still never tells the agent when to use it.' harness-propose.md P1 and P5 are unchanged by adding that string."
     disposition: rejected
-    disposition_rationale: null
+    disposition_rationale: "Rejected. The harm is real and a parity check is a reasonable thing to want. The check not detecting the specific harm the finding leads with does not make the harm imaginary."
   - id: O2
     category: premise
     severity: high
     claim: "The rule's stated harm — a capability the driving agent cannot reach — is falsified inside the assay's own What worked section: --reject was exercised in the same phase it landed, with no command prompt naming it."
     evidence: "Proposed rule: 'A capability the code exposes and no command prompt names is a capability the agent driving that command cannot reach.' Assay, What worked: 'A declined finding is now a record ... It carries no cost key and no tier-2 sections, which is the shape #562 specified.' harness/decisions/HDR-2026-08-25-an-epic-s-authority-cited-to-a-document-nobody-else-can-open.md exists in exactly the shape --reject produces."
     disposition: rejected
-    disposition_rationale: null
+    disposition_rationale: "Rejected. The harm is real and a parity check is a reasonable thing to want. A capability being reached once by a person who knew it existed does not make it discoverable."
   - id: O3
     category: implementation
     severity: high
     claim: "The rule binds subcommands but its exemption is anchored to add_argument and its detection is a verbatim string match; the two subcommands genuinely absent from every command file are ordinary English words that already appear there, so the check passes on precisely the capabilities that are unreachable."
     evidence: "harness-registrar.py:1902 `sub.add_parser(\"correct\", ...)`, :1909 `sub.add_parser(\"index\", ...)`. harness-accept.md:60 'or correct the target'; harness-accept.md:118 'harness/decisions/index.md lists the HDR'. Rule's exemption: 'carrying an `# undocumented:` comment on the line above its add_argument call' — a subparser has no add_argument call."
     disposition: rejected
-    disposition_rationale: null
+    disposition_rationale: "Rejected. The harm is real and a parity check is a reasonable thing to want. The subcommand detection and its exemption are broken as drafted; that is a defect in the draft, not a reason to abandon the check."
   - id: O4
     category: implementation
     severity: high
     claim: "The rule says 'a script' but the proposed tool is an argparse walk; five of the six scripts named in command files are bash, one of them already violates the rule, and the exemption is inexpressible for any of them."
     evidence: "Cost estimate: 'an argparse walk over each script named in a command file'. Command files name next-action-hint.sh, ai-literacy-check.sh, regenerate-reflection-log.sh, sentinel-integrity-check.sh and harness-affordance-staleness.sh alongside harness-registrar.py. harness-affordance-staleness.sh accepts --max-age-days and --today; commands/harness-affordance.md names neither."
     disposition: accepted
-    disposition_rationale: null
+    disposition_rationale: "Accepted: the rule says a script while the proposed tool reads only argparse, and five of the six scripts named in command files are bash. The rule as drafted is not fit. Amended in place as proposed."
   - id: O5
     category: scope
     severity: high
     claim: "The remediation backlog is priced at four capabilities when the finding's own enumeration contains six undocumented options plus two undocumented subcommands, and two of them are hermeticity injections that no prompt should ever name."
     evidence: "Finding enumerates '--root ... --today' among accepted options. harness-registrar.py:1863 `parser.add_argument(\"--root\", default=\".\")`, :1870/:1920/:1929 `--today`, help='YYYY-MM-DD; injected so nothing races the clock'. Neither string appears in any file under commands/. Cost estimate: 'the four capabilities already divergent must be written into harness-propose.md and harness-accept.md'."
     disposition: accepted
-    disposition_rationale: null
+    disposition_rationale: "Accepted: the remediation backlog is larger than four capabilities and includes options no prompt should name. The rule as drafted is not fit. Amended in place as proposed."
   - id: O6
     category: specification quality
     severity: medium
     claim: "The trigger 'when that script is invoked by a command in that directory' has no mechanical definition, and the two available readings produce different violation sets on files already in the repository."
     evidence: "Rule: 'when that script is invoked by a command in that directory'. commands/harness-affordance.md:189 mentions scripts/harness-affordance-staleness.sh in a parenthetical attributing it to a GC rule, not in a fenced invocation. commands/harness-timeline.md:32, harness-check.md:53 and others use fenced `python3 ... harness-registrar.py <subcommand>` invocations."
     disposition: accepted
-    disposition_rationale: null
+    disposition_rationale: "Accepted: the trigger has no mechanical definition and the two readings disagree on files already in the repository. The rule as drafted is not fit. Amended in place as proposed."
   - id: O7
     category: specification quality
     severity: medium
     claim: "The quantifier is per-repository rather than per-command, so an option can satisfy the rule from a command file that could never pass it — which is the exact shape of the observed defect the rule is written against."
     evidence: "Rule: 'must appear verbatim in at least one file under ai-literacy-superpowers/commands/'. --target is only ever passed by `harness-registrar.py accept`, which only commands/harness-accept.md invokes (line 91); naming --target in any other command file satisfies the rule while /harness-accept stays silent."
     disposition: accepted
-    disposition_rationale: null
+    disposition_rationale: "Accepted: the quantifier ranges over the directory when the observed defect is per-command. The rule as drafted is not fit. Amended in place as proposed."
   - id: O8
     category: alternatives
     severity: high
     claim: "The repository already owns an idempotent generator that writes marked regions into prose artefacts; generating the option inventory is strictly stronger than checking for a string, and the finding weighs neither generation nor no-change."
     evidence: "harness-registrar.py apply_region / render_region and the `compile` subcommand exist and are driven by commands/harness-compile.md:40. Assay, What worked: 'the transcription fix travelled and the rule did not need to' — the precedent in which the previous assay's finding-1 was declined and the defect fixed anyway."
     disposition: accepted
-    disposition_rationale: null
+    disposition_rationale: "Accepted: the repository already owns an idempotent generator, and generation dominates a string check on every axis the finding measures. The proposal survives; this shapes the redraft rather than ending it."
   - id: O9
     category: alternatives
     severity: critical
     claim: "An existing constraint already owns this behaviour and was never run: Output validation checkpoints requires a checkpoint to check structure against the format spec reference, the reference is current, and it is harness-propose.md's checkpoint that diverges from it."
     evidence: "HARNESS.md:255 'must include a validation checkpoint step that reads the output, checks structure against the format spec reference'. docs/plugins/ai-literacy-superpowers/reference/harness-decision-records.md:76-94 documents `/harness-propose --reject --reason-file` and the '## Finding and a non-empty ## Rejection, and nothing else' shape; :188 documents `/harness-accept <hdr> --target`. Assay, Rejected candidates: 'harness.yml runs eight deterministic constraints and none of the agent-enforced ones'."
     disposition: accepted
-    disposition_rationale: null
+    disposition_rationale: "Accepted: Output validation checkpoints already owns this behaviour and had never been dispatched. The proposal survives nonetheless - the objection's own reading, that accepting it turns the finding into a rejected candidate, is not taken. Running the audit and writing the check are not alternatives to each other."
   - id: O10
     category: implementation
     severity: high
     claim: "The enforcement outcome is understated: with ci supporting no advisory rung and no validator resolvable, the rule achieves `none` rather than a downgraded level on its only declared surface, and nothing in the loop schedules the script that would change that."
     evidence: "harness/surfaces.yaml:62-64 `ci: supports: [validated, blocked]`. harness-registrar.py achieved_for:1321-1324 — when the candidate is at or above validated and not validated, 'advisory' in supports else return 'none'. validator_state:1291 requires `record.id in fh.read()`. Finding: 'the first /harness-compile after acceptance should report an enforcement gap on ci rather than validated'."
     disposition: accepted
-    disposition_rationale: null
+    disposition_rationale: "Accepted: with ci supporting no advisory rung and no validator resolvable, the rule achieves none rather than a downgraded level. The rule as drafted is not fit. Amended in place as proposed."
   - id: O11
     category: scope
     severity: medium
     claim: "Three of the rule's five cited evidence paths lie outside anything the rule can bind, including the errata blindness the finding presents as its sharpest observation."
     evidence: "evidence list names skills/harness-assay/SKILL.md and docs/.../reference/harness-decision-records.md. Rule: 'This does not reach reference or how-to pages'. Assay: 'The Assayer's own evidence pool does not know that corrections exist ... contains no occurrence of \"errata\" or \"correction\".'"
     disposition: deferred
-    disposition_rationale: null
+    disposition_rationale: "Deferred to the redraft. The evidence list should name only artefacts the rule can act on."
   - id: O12
     category: specification quality
     severity: medium
     claim: "The exemption's stated criterion — an option whose only caller is another script — does not cover the population that most obviously needs exempting, which is options injected by tests for hermeticity."
     evidence: "Rule: 'An option whose only caller is another script is exempt'. harness-registrar.py:1870 --today help='injected so nothing races the clock'; :1863 --root default='.'. docs/superpowers/specs/2026-06-17-affordance-runtime-recorder-design.md:130 'Hermetic — --today fixes \"now\"; the analyzer is deterministic.' Neither is called by another script; both are called by tests."
     disposition: deferred
-    disposition_rationale: null
+    disposition_rationale: "Deferred to the redraft. The exemption criterion needs to name the exempt classes rather than the caller."
 ---
 
 ## O1 — premise — critical

--- a/docs/superpowers/objections/command-cli-parity.md
+++ b/docs/superpowers/objections/command-cli-parity.md
@@ -9,84 +9,84 @@ objections:
     severity: critical
     claim: "The harm the finding leads with is a prompt asserting output structure the code no longer produces; the proposed check compares option strings and cannot detect it, so the check goes green on one added string while the false-defect report still fires."
     evidence: "Finding: 'An agent following the checkpoint as written against a correctly-formed rejection would report a defect that is not there.' Rule: options 'must appear verbatim in at least one file under ai-literacy-superpowers/commands/'. Cost estimate concedes: 'a bare --reject mentioned in a code fence satisfies a literal-string check while the prompt still never tells the agent when to use it.' harness-propose.md P1 and P5 are unchanged by adding that string."
-    disposition: pending
+    disposition: rejected
     disposition_rationale: null
   - id: O2
     category: premise
     severity: high
     claim: "The rule's stated harm — a capability the driving agent cannot reach — is falsified inside the assay's own What worked section: --reject was exercised in the same phase it landed, with no command prompt naming it."
     evidence: "Proposed rule: 'A capability the code exposes and no command prompt names is a capability the agent driving that command cannot reach.' Assay, What worked: 'A declined finding is now a record ... It carries no cost key and no tier-2 sections, which is the shape #562 specified.' harness/decisions/HDR-2026-08-25-an-epic-s-authority-cited-to-a-document-nobody-else-can-open.md exists in exactly the shape --reject produces."
-    disposition: pending
+    disposition: rejected
     disposition_rationale: null
   - id: O3
     category: implementation
     severity: high
     claim: "The rule binds subcommands but its exemption is anchored to add_argument and its detection is a verbatim string match; the two subcommands genuinely absent from every command file are ordinary English words that already appear there, so the check passes on precisely the capabilities that are unreachable."
     evidence: "harness-registrar.py:1902 `sub.add_parser(\"correct\", ...)`, :1909 `sub.add_parser(\"index\", ...)`. harness-accept.md:60 'or correct the target'; harness-accept.md:118 'harness/decisions/index.md lists the HDR'. Rule's exemption: 'carrying an `# undocumented:` comment on the line above its add_argument call' — a subparser has no add_argument call."
-    disposition: pending
+    disposition: rejected
     disposition_rationale: null
   - id: O4
     category: implementation
     severity: high
     claim: "The rule says 'a script' but the proposed tool is an argparse walk; five of the six scripts named in command files are bash, one of them already violates the rule, and the exemption is inexpressible for any of them."
     evidence: "Cost estimate: 'an argparse walk over each script named in a command file'. Command files name next-action-hint.sh, ai-literacy-check.sh, regenerate-reflection-log.sh, sentinel-integrity-check.sh and harness-affordance-staleness.sh alongside harness-registrar.py. harness-affordance-staleness.sh accepts --max-age-days and --today; commands/harness-affordance.md names neither."
-    disposition: pending
+    disposition: accepted
     disposition_rationale: null
   - id: O5
     category: scope
     severity: high
     claim: "The remediation backlog is priced at four capabilities when the finding's own enumeration contains six undocumented options plus two undocumented subcommands, and two of them are hermeticity injections that no prompt should ever name."
     evidence: "Finding enumerates '--root ... --today' among accepted options. harness-registrar.py:1863 `parser.add_argument(\"--root\", default=\".\")`, :1870/:1920/:1929 `--today`, help='YYYY-MM-DD; injected so nothing races the clock'. Neither string appears in any file under commands/. Cost estimate: 'the four capabilities already divergent must be written into harness-propose.md and harness-accept.md'."
-    disposition: pending
+    disposition: accepted
     disposition_rationale: null
   - id: O6
     category: specification quality
     severity: medium
     claim: "The trigger 'when that script is invoked by a command in that directory' has no mechanical definition, and the two available readings produce different violation sets on files already in the repository."
     evidence: "Rule: 'when that script is invoked by a command in that directory'. commands/harness-affordance.md:189 mentions scripts/harness-affordance-staleness.sh in a parenthetical attributing it to a GC rule, not in a fenced invocation. commands/harness-timeline.md:32, harness-check.md:53 and others use fenced `python3 ... harness-registrar.py <subcommand>` invocations."
-    disposition: pending
+    disposition: accepted
     disposition_rationale: null
   - id: O7
     category: specification quality
     severity: medium
     claim: "The quantifier is per-repository rather than per-command, so an option can satisfy the rule from a command file that could never pass it — which is the exact shape of the observed defect the rule is written against."
     evidence: "Rule: 'must appear verbatim in at least one file under ai-literacy-superpowers/commands/'. --target is only ever passed by `harness-registrar.py accept`, which only commands/harness-accept.md invokes (line 91); naming --target in any other command file satisfies the rule while /harness-accept stays silent."
-    disposition: pending
+    disposition: accepted
     disposition_rationale: null
   - id: O8
     category: alternatives
     severity: high
     claim: "The repository already owns an idempotent generator that writes marked regions into prose artefacts; generating the option inventory is strictly stronger than checking for a string, and the finding weighs neither generation nor no-change."
     evidence: "harness-registrar.py apply_region / render_region and the `compile` subcommand exist and are driven by commands/harness-compile.md:40. Assay, What worked: 'the transcription fix travelled and the rule did not need to' — the precedent in which the previous assay's finding-1 was declined and the defect fixed anyway."
-    disposition: pending
+    disposition: accepted
     disposition_rationale: null
   - id: O9
     category: alternatives
     severity: critical
     claim: "An existing constraint already owns this behaviour and was never run: Output validation checkpoints requires a checkpoint to check structure against the format spec reference, the reference is current, and it is harness-propose.md's checkpoint that diverges from it."
     evidence: "HARNESS.md:255 'must include a validation checkpoint step that reads the output, checks structure against the format spec reference'. docs/plugins/ai-literacy-superpowers/reference/harness-decision-records.md:76-94 documents `/harness-propose --reject --reason-file` and the '## Finding and a non-empty ## Rejection, and nothing else' shape; :188 documents `/harness-accept <hdr> --target`. Assay, Rejected candidates: 'harness.yml runs eight deterministic constraints and none of the agent-enforced ones'."
-    disposition: pending
+    disposition: accepted
     disposition_rationale: null
   - id: O10
     category: implementation
     severity: high
     claim: "The enforcement outcome is understated: with ci supporting no advisory rung and no validator resolvable, the rule achieves `none` rather than a downgraded level on its only declared surface, and nothing in the loop schedules the script that would change that."
     evidence: "harness/surfaces.yaml:62-64 `ci: supports: [validated, blocked]`. harness-registrar.py achieved_for:1321-1324 — when the candidate is at or above validated and not validated, 'advisory' in supports else return 'none'. validator_state:1291 requires `record.id in fh.read()`. Finding: 'the first /harness-compile after acceptance should report an enforcement gap on ci rather than validated'."
-    disposition: pending
+    disposition: accepted
     disposition_rationale: null
   - id: O11
     category: scope
     severity: medium
     claim: "Three of the rule's five cited evidence paths lie outside anything the rule can bind, including the errata blindness the finding presents as its sharpest observation."
     evidence: "evidence list names skills/harness-assay/SKILL.md and docs/.../reference/harness-decision-records.md. Rule: 'This does not reach reference or how-to pages'. Assay: 'The Assayer's own evidence pool does not know that corrections exist ... contains no occurrence of \"errata\" or \"correction\".'"
-    disposition: pending
+    disposition: deferred
     disposition_rationale: null
   - id: O12
     category: specification quality
     severity: medium
     claim: "The exemption's stated criterion — an option whose only caller is another script — does not cover the population that most obviously needs exempting, which is options injected by tests for hermeticity."
     evidence: "Rule: 'An option whose only caller is another script is exempt'. harness-registrar.py:1870 --today help='injected so nothing races the clock'; :1863 --root default='.'. docs/superpowers/specs/2026-06-17-affordance-runtime-recorder-design.md:130 'Hermetic — --today fixes \"now\"; the analyzer is deterministic.' Neither is called by another script; both are called by tests."
-    disposition: pending
+    disposition: deferred
     disposition_rationale: null
 ---
 

--- a/docs/superpowers/objections/harness-reassuring-default.md
+++ b/docs/superpowers/objections/harness-reassuring-default.md
@@ -10,84 +10,84 @@ objections:
     claim: "The rule's two sentences cover three of the four instances between them and the fourth not at all — and the uncovered instance is the only one that appears in a second assay, so the four-instance pattern and the two-assay corroboration rest on disjoint evidence."
     evidence: "Rule sentence 1 binds a mechanism that 'must have a defined value for the case where it could not determine the answer, and that value may not be the passing one' — this covers the badge and the Status block. Sentence 2 is introduced as 'Separately' and covers the release-tag check. Instance 3 is covered by neither: the finding itself says 'A `skipped` conclusion is not a failure and is not a pass; the run reports one red step and between five and nine unknowns, and a reader asking \"did GC pass?\" sees the single failure.' A defined non-passing value that a reader misreads is not indeterminacy resolved to the passing value. Instance 3 is the only one carried by `harness/assay/2026-08-25T11-59Z-assay.md#finding-2`."
     disposition: accepted
-    disposition_rationale: null
+    disposition_rationale: "Accepted: the four-instance pattern and the two-assay corroboration rest on disjoint evidence. The rule as drafted does not hold up here. Amended in place as proposed, rather than rejected and re-derived from a corrected finding."
   - id: O2
     category: risk
     severity: critical
     claim: "The two-assay threshold is satisfied by re-observing one unrepaired artifact in a second window, which is a single incident counted twice by a check that can only count filenames — and accepting it establishes that any open defect becomes threshold-eligible by surviving one assay cycle."
     evidence: "`_check_promotion_threshold` docstring: 'A single incident cannot reach the loop layer... Distinctness is by assay FILE, not by evidence entry - two anchors into one assay are one assay, and letting them count twice would make the threshold satisfiable by anyone willing to cite the same finding twice.' The same assay states: 'The masking defect that both assays observed is unrepaired: `harness.yml` and `gc.yml` each still carry exactly one `if: always()`, on `Summary` (`observed`, counted).' Nothing changed the artifact between the two observations."
-    disposition: rejected
-    disposition_rationale: null
+    disposition: deferred
+    disposition_rationale: "Deferred rather than rejected. The second sighting is a verification observation, not the same one counted twice, and the precedent this objection warns about - an unrepaired defect becoming the cheapest route into HARNESS.md - is right but acceptable. What is unsettled is the question accepting O1 raises: whether corroboration drawn from the one instance the rule text does not cover should count toward the threshold at all. I'm not sure it does. Deferred until that is answered."
   - id: O3
     category: implementation
     severity: critical
     claim: "The reason given for choosing `harness-loop` over `turn-instructions` — that AGENTS.md reaches one surface and is silent where the work happens — applies with equal force to HARNESS.md, which reaches three of the five surfaces the record declares and neither `claude-code` nor `codex` by any mechanism."
     evidence: "Record: 'I rejected it because `harness/surfaces.yaml` gives `AGENTS.md` as the target of `codex` alone, so the rule would reach one surface and be silent on the one where the work happens.' `harness/surfaces.yaml`: `claude-code: targets: [CLAUDE.md, .claude/agents/, .claude/hooks/, .claude/settings.json]`; `codex: targets: [AGENTS.md]`. HARNESS.md appears in no surface's `targets`. *Convention parity* generates 'all three generated convention files (`.cursor/rules/constraints.mdc`, `.github/copilot-instructions.md`, `.windsurf/rules/constraints.md`)'. `commands/harness-sync.md:15`: 'It does _not_ write to `AGENTS.md`... `AGENTS.md` and `REFLECTION_LOG.md` are curated by humans.' The record declares `surfaces: [claude-code, codex, cursor, copilot, windsurf]`."
     disposition: accepted
-    disposition_rationale: null
+    disposition_rationale: "Accepted: the reach argument given against turn-instructions applies equally against HARNESS.md. The rule as drafted does not hold up here. Amended in place as proposed, rather than rejected and re-derived from a corrected finding."
   - id: O4
     category: specification quality
     severity: critical
     claim: "The repaired script the finding holds up as the principle's only written statement still reaches the passing value when it cannot read the input it names, so either the rule flags its own exemplar at HEAD or 'a reachable code path that reaches a passing value' has no determinable meaning — and the validation plan's fixtures are chosen so neither horn can surface."
     evidence: "Rule: 'Where an input is missing, unreadable or not supplied, the mechanism reports the degraded or unknown state and names the input it could not read. A reachable code path that reaches a passing value without reading the thing it reports on is a defect, not a default.' `update-health-badge.sh:54-88`: when `grep -iE '^- Health:'` matches nothing, the `*)` branch counts keyword signals and, at zero signals, sets `health_status=\"Healthy\"` — commented 'the one path to Healthy that does not come from an explicit Health line'. Validation plan: 'Reconstruct the tree at `b1982b0` and assert the rule flags `update-health-badge.sh`' — the pre-repair tree only. Cost estimate names the same shape as the likely evasion: 'Declaring an `Unknown` state and never routing to it.'"
     disposition: accepted
-    disposition_rationale: null
+    disposition_rationale: "Accepted for the point beneath it, not the claim as written. The claim does not hold: under set -euo pipefail the grep assignment fails before the fallback branch is reached, so the script exits 1 with the badge untouched and that path is unreachable. What is accepted is the underlying point - a reporting mechanism should not carry a fallback that reaches the passing value without reading the thing it reports on, reachable or not."
   - id: O5
     category: implementation
     severity: critical
     claim: "Both halves of the declared Tool are unreachable for the evidence class: `harness-enforcer` is dispatched by no workflow, and the advocatus-diaboli spec-mode gate is exempt on exactly the labels all five PRs in the window carried — so the rule would have fired on none of its own four instances."
     evidence: "Cost estimate: '`grep -rn 'harness-enforcer' .github/workflows/` returns nothing.' HARNESS.md *PRs have adjudicated objections*: 'Bug fixes, dependency updates, and maintenance PRs (labelled `bug`, `fix`, `chore`, `maintenance` or branch-prefixed `fix/`, `chore/`) are exempt.' Same assay: 'Every PR in the window merged under a spec-first exemption. #571 and #572 carry `chore`; #574 `chore`; #576 and #577 `fix`... No spec was written.' #576 is the PR that changed the badge's indeterminate value. `skills/advocatus-diaboli/SKILL.md`: 'Deprioritise at spec time: `risk` objections that require examining concrete code or runtime behaviour to ground — including every embedded assumption... before the artefact exists there is nothing to read it out of.'"
     disposition: accepted
-    disposition_rationale: null
+    disposition_rationale: "Accepted: neither half of the declared Tool can reach the class of change the finding is drawn from. The rule as drafted does not hold up here. Amended in place as proposed, rather than rejected and re-derived from a corrected finding."
   - id: O6
     category: scope
     severity: high
     claim: "The instance supplying the second assay is already the subject of an accepted decision whose approver wrote its cost and whose retirement withdrew only where it was pointed, and of an unproposed finding-2 that is a live competing proposal — none of which the 'why no existing owner absorbs it' section discloses."
     evidence: "`HDR-2026-08-25-the-periodic-check-suite-stops-at-its-first-failure-and-reports-the-rest-as-nothing`, status `accepted`, cost in the approver's words: 'We will implement the fourteen absent checks rather than demote them.' Its retirement: 'Withdrawing where the rule was pointed, not the rule itself', and 'Re-propose immediately with `HARNESS.md` as the target. Deferred, not rejected.' The record's 'Why no existing owner absorbs it' names only *Output validation checkpoints*, *Docs site kept current*, *Command-prompt sync* and `/harness-audit`; it names no HDR."
     disposition: accepted
-    disposition_rationale: null
+    disposition_rationale: "Accepted: an accepted record already governs the corroborating instance, and the record discloses none of it. A rule should exist here, but not this one."
   - id: O7
     category: premise
     severity: high
     claim: "The headline claim that motivates elevation — the principle is written down exactly once, in a code comment — is false: it is stated in an accepted HDR's rule text with an approver's cost against it, and in the governance validator's own documentation."
     evidence: "Finding: 'That comment is the only place in the repository the principle is written.' Executive summary: 'the principle that says they must not was written down exactly once, in a code comment.' Counter-evidence: the accepted (now superseded) masking HDR's rule text — 'A rule that did not run is reported as not run — never omitted, and never counted as passing' — and `check-harness-decisions.py`'s `sections()` docstring — 'An empty section is a missing section that looks present, and that is worse than an absent one: it reads as done.' The narrower claim the finding also makes, that HARNESS.md's 36 constraints and AGENTS.md's six gotchas contain no equivalent, is not disputed."
     disposition: accepted
-    disposition_rationale: null
+    disposition_rationale: "Accepted: the principle is written in more than the one place the finding claims. The rule as drafted does not hold up here. Amended in place as proposed, rather than rejected and re-derived from a corrected finding."
   - id: O8
     category: alternatives
     severity: high
     claim: "Exactly one alternative classification was weighed, and it is not the one the record's own Tool field points at: `agent-instruction` targeting the advocatus-diaboli skill would reach the surface where the work happens, need no two-assay threshold, and be dispatched by something that actually runs."
     evidence: "Record: 'I considered `turn-instructions`... I rejected it because...' — no other classification is named. Rule: '**Tool**: advocatus-diaboli (spec-mode gate) and harness-enforcer.' `check-harness-decisions.py`: `_check_promotion_threshold` returns early unless `classification == \"harness-loop\"`; `agent-instruction` has no default route and names its own `target`, which `_check_target` requires only at acceptance. `skills/advocatus-diaboli/SKILL.md` is loaded on every `/diaboli` run; `.github/prompts/diaboli.prompt.md` exists as a second dispatch path."
     disposition: accepted
-    disposition_rationale: null
+    disposition_rationale: "Accepted: one alternative classification was weighed and it was not the one the record's own Tool field points at. A rule should exist here, but not this one."
   - id: O9
     category: scope
     severity: high
     claim: "The 'weaker property' sentence legislates the same claim as finding-2's proposed rule from the same assay, so accepting both writes one normative claim into HARNESS.md twice with no supersession relationship, and spends two of the three cycle slots on it."
     evidence: "finding-1: 'Separately, a check may not report a pass on the strength of a property weaker than the one it names: if the check is called \"release tag completeness\" it verifies that the release has a tag, not that a string exists.' finding-2: 'A check named for a property verifies that property; passing on a weaker one is worse than failing, because 110 green rows are read as coverage.' Neither rule mentions the other. `check_cycle_cap`: 'At most three accepted HDRs may share one assay.' The finding's own cost estimate concedes the clause is unmechanical: 'I could not tighten \"weaker property\" into something mechanical without narrowing it to release tags, which would overfit it to finding-2.'"
     disposition: accepted
-    disposition_rationale: null
+    disposition_rationale: "Accepted: the weaker-property clause legislates the same claim as finding-2 from the same assay. A rule should exist here, but not this one."
   - id: O10
     category: specification quality
     severity: high
     claim: "The validation plan presupposes something that runs, and the record declares `enforcement: advisory` with an agent tool — so the refusal criterion the record sets for itself can never be evaluated by anyone, and the rule ships carrying a falsification test that cannot be performed."
     evidence: "Validation plan: 'Reconstruct the tree at `b1982b0` and assert the rule flags `update-health-badge.sh`, the `## Status` block and `gc.yml`'s release-tag step. Then assert it does not flag `check-harness-decisions.py` or `harness-registrar.py check`... If the rule cannot separate those two sets without an author's cooperation, it is not falsifiable and should be refused rather than softened.' Frontmatter: `enforcement: advisory`; rule block: '**Enforcement**: agent'; cost estimate: 'An agent-enforced constraint runs when a human types `/harness-audit`, which happened once in the twelve days before this window.'"
     disposition: accepted
-    disposition_rationale: null
+    disposition_rationale: "Accepted: the validation plan names a refusal criterion nobody can evaluate. The rule as drafted does not hold up here. Amended in place as proposed, rather than rejected and re-derived from a corrected finding."
   - id: O11
     category: risk
     severity: high
     claim: "The proposed record's four tier-2 sections are placeholders, and the corpus validator passes them — it checks non-emptiness everywhere and placeholder text only in `## Rejection` — so a harness-loop rule can be accepted with no layer argument, no enforcement statement, no validation and no rejected alternatives."
     evidence: "`HDR-2026-08-25-four-mechanisms-...md` body: '## Why this layer\\n\\n_TODO — why this change belongs at this layer and not one layer down._' and the same for Enforcement, Validation and Rejected alternatives. `check-harness-decisions.py` `_check_body`: `elif not found[heading].strip():` — a `_TODO` line is non-empty. The `startswith(\"_TODO\")` guard exists only in `_check_rejection`, for `## Rejection`. The record's own rule: 'A reachable code path that reaches a passing value without reading the thing it reports on is a defect, not a default.'"
     disposition: accepted
-    disposition_rationale: null
+    disposition_rationale: "Accepted for the point beneath it, not the claim as written. The claim does not hold: /harness-accept runs precheck, which refuses _TODO sections by name, so a harness-loop rule cannot be accepted carrying them. What is accepted is the underlying point - the corpus validator does pass placeholder text, so /harness-check reports OK on an unfinished proposal, and a gate that checks shape is not checking substance."
   - id: O12
     category: alternatives
     severity: high
     claim: "The existing machinery found and repaired three of the four instances inside four hours with no new rule, and 'run the audit on a cadence' is not weighed as an alternative anywhere in the record — the same disposal O9 of the previous review argued for and which the assay records as having been borne out."
     evidence: "Finding: '`/harness-audit` **found** three of these four instances, which is why they are not rejected candidates for it.' Executive summary: 'three separate mechanisms were repaired within four hours (`observed`, `gh pr list` merge times 14:05–14:30Z).' 'What worked': 'One of them, `command-cli-parity.md` O9, argues finding-1 should be routed to `/harness-audit` instead of becoming a rule... The gate's prediction and events agree.' The record's counter — 'it has no rule to cite when the next mechanism ships with the same default, and it found them because a human typed the command, twelve days after the previous run' — argues for a cadence, which the proposal does not contain."
     disposition: accepted
-    disposition_rationale: null
+    disposition_rationale: "Accepted: the existing machinery found and repaired three of the four instances in four hours with no new rule, and no-change went unweighed. A rule should exist here, but not this one."
 ---
 
 # Objections — assay 3 finding-1, mechanisms that report the reassuring answer

--- a/docs/superpowers/objections/harness-reassuring-default.md
+++ b/docs/superpowers/objections/harness-reassuring-default.md
@@ -9,84 +9,84 @@ objections:
     severity: critical
     claim: "The rule's two sentences cover three of the four instances between them and the fourth not at all — and the uncovered instance is the only one that appears in a second assay, so the four-instance pattern and the two-assay corroboration rest on disjoint evidence."
     evidence: "Rule sentence 1 binds a mechanism that 'must have a defined value for the case where it could not determine the answer, and that value may not be the passing one' — this covers the badge and the Status block. Sentence 2 is introduced as 'Separately' and covers the release-tag check. Instance 3 is covered by neither: the finding itself says 'A `skipped` conclusion is not a failure and is not a pass; the run reports one red step and between five and nine unknowns, and a reader asking \"did GC pass?\" sees the single failure.' A defined non-passing value that a reader misreads is not indeterminacy resolved to the passing value. Instance 3 is the only one carried by `harness/assay/2026-08-25T11-59Z-assay.md#finding-2`."
-    disposition: pending
+    disposition: accepted
     disposition_rationale: null
   - id: O2
     category: risk
     severity: critical
     claim: "The two-assay threshold is satisfied by re-observing one unrepaired artifact in a second window, which is a single incident counted twice by a check that can only count filenames — and accepting it establishes that any open defect becomes threshold-eligible by surviving one assay cycle."
     evidence: "`_check_promotion_threshold` docstring: 'A single incident cannot reach the loop layer... Distinctness is by assay FILE, not by evidence entry - two anchors into one assay are one assay, and letting them count twice would make the threshold satisfiable by anyone willing to cite the same finding twice.' The same assay states: 'The masking defect that both assays observed is unrepaired: `harness.yml` and `gc.yml` each still carry exactly one `if: always()`, on `Summary` (`observed`, counted).' Nothing changed the artifact between the two observations."
-    disposition: pending
+    disposition: rejected
     disposition_rationale: null
   - id: O3
     category: implementation
     severity: critical
     claim: "The reason given for choosing `harness-loop` over `turn-instructions` — that AGENTS.md reaches one surface and is silent where the work happens — applies with equal force to HARNESS.md, which reaches three of the five surfaces the record declares and neither `claude-code` nor `codex` by any mechanism."
     evidence: "Record: 'I rejected it because `harness/surfaces.yaml` gives `AGENTS.md` as the target of `codex` alone, so the rule would reach one surface and be silent on the one where the work happens.' `harness/surfaces.yaml`: `claude-code: targets: [CLAUDE.md, .claude/agents/, .claude/hooks/, .claude/settings.json]`; `codex: targets: [AGENTS.md]`. HARNESS.md appears in no surface's `targets`. *Convention parity* generates 'all three generated convention files (`.cursor/rules/constraints.mdc`, `.github/copilot-instructions.md`, `.windsurf/rules/constraints.md`)'. `commands/harness-sync.md:15`: 'It does _not_ write to `AGENTS.md`... `AGENTS.md` and `REFLECTION_LOG.md` are curated by humans.' The record declares `surfaces: [claude-code, codex, cursor, copilot, windsurf]`."
-    disposition: pending
+    disposition: accepted
     disposition_rationale: null
   - id: O4
     category: specification quality
     severity: critical
     claim: "The repaired script the finding holds up as the principle's only written statement still reaches the passing value when it cannot read the input it names, so either the rule flags its own exemplar at HEAD or 'a reachable code path that reaches a passing value' has no determinable meaning — and the validation plan's fixtures are chosen so neither horn can surface."
     evidence: "Rule: 'Where an input is missing, unreadable or not supplied, the mechanism reports the degraded or unknown state and names the input it could not read. A reachable code path that reaches a passing value without reading the thing it reports on is a defect, not a default.' `update-health-badge.sh:54-88`: when `grep -iE '^- Health:'` matches nothing, the `*)` branch counts keyword signals and, at zero signals, sets `health_status=\"Healthy\"` — commented 'the one path to Healthy that does not come from an explicit Health line'. Validation plan: 'Reconstruct the tree at `b1982b0` and assert the rule flags `update-health-badge.sh`' — the pre-repair tree only. Cost estimate names the same shape as the likely evasion: 'Declaring an `Unknown` state and never routing to it.'"
-    disposition: pending
+    disposition: accepted
     disposition_rationale: null
   - id: O5
     category: implementation
     severity: critical
     claim: "Both halves of the declared Tool are unreachable for the evidence class: `harness-enforcer` is dispatched by no workflow, and the advocatus-diaboli spec-mode gate is exempt on exactly the labels all five PRs in the window carried — so the rule would have fired on none of its own four instances."
     evidence: "Cost estimate: '`grep -rn 'harness-enforcer' .github/workflows/` returns nothing.' HARNESS.md *PRs have adjudicated objections*: 'Bug fixes, dependency updates, and maintenance PRs (labelled `bug`, `fix`, `chore`, `maintenance` or branch-prefixed `fix/`, `chore/`) are exempt.' Same assay: 'Every PR in the window merged under a spec-first exemption. #571 and #572 carry `chore`; #574 `chore`; #576 and #577 `fix`... No spec was written.' #576 is the PR that changed the badge's indeterminate value. `skills/advocatus-diaboli/SKILL.md`: 'Deprioritise at spec time: `risk` objections that require examining concrete code or runtime behaviour to ground — including every embedded assumption... before the artefact exists there is nothing to read it out of.'"
-    disposition: pending
+    disposition: accepted
     disposition_rationale: null
   - id: O6
     category: scope
     severity: high
     claim: "The instance supplying the second assay is already the subject of an accepted decision whose approver wrote its cost and whose retirement withdrew only where it was pointed, and of an unproposed finding-2 that is a live competing proposal — none of which the 'why no existing owner absorbs it' section discloses."
     evidence: "`HDR-2026-08-25-the-periodic-check-suite-stops-at-its-first-failure-and-reports-the-rest-as-nothing`, status `accepted`, cost in the approver's words: 'We will implement the fourteen absent checks rather than demote them.' Its retirement: 'Withdrawing where the rule was pointed, not the rule itself', and 'Re-propose immediately with `HARNESS.md` as the target. Deferred, not rejected.' The record's 'Why no existing owner absorbs it' names only *Output validation checkpoints*, *Docs site kept current*, *Command-prompt sync* and `/harness-audit`; it names no HDR."
-    disposition: pending
+    disposition: accepted
     disposition_rationale: null
   - id: O7
     category: premise
     severity: high
     claim: "The headline claim that motivates elevation — the principle is written down exactly once, in a code comment — is false: it is stated in an accepted HDR's rule text with an approver's cost against it, and in the governance validator's own documentation."
     evidence: "Finding: 'That comment is the only place in the repository the principle is written.' Executive summary: 'the principle that says they must not was written down exactly once, in a code comment.' Counter-evidence: the accepted (now superseded) masking HDR's rule text — 'A rule that did not run is reported as not run — never omitted, and never counted as passing' — and `check-harness-decisions.py`'s `sections()` docstring — 'An empty section is a missing section that looks present, and that is worse than an absent one: it reads as done.' The narrower claim the finding also makes, that HARNESS.md's 36 constraints and AGENTS.md's six gotchas contain no equivalent, is not disputed."
-    disposition: pending
+    disposition: accepted
     disposition_rationale: null
   - id: O8
     category: alternatives
     severity: high
     claim: "Exactly one alternative classification was weighed, and it is not the one the record's own Tool field points at: `agent-instruction` targeting the advocatus-diaboli skill would reach the surface where the work happens, need no two-assay threshold, and be dispatched by something that actually runs."
     evidence: "Record: 'I considered `turn-instructions`... I rejected it because...' — no other classification is named. Rule: '**Tool**: advocatus-diaboli (spec-mode gate) and harness-enforcer.' `check-harness-decisions.py`: `_check_promotion_threshold` returns early unless `classification == \"harness-loop\"`; `agent-instruction` has no default route and names its own `target`, which `_check_target` requires only at acceptance. `skills/advocatus-diaboli/SKILL.md` is loaded on every `/diaboli` run; `.github/prompts/diaboli.prompt.md` exists as a second dispatch path."
-    disposition: pending
+    disposition: accepted
     disposition_rationale: null
   - id: O9
     category: scope
     severity: high
     claim: "The 'weaker property' sentence legislates the same claim as finding-2's proposed rule from the same assay, so accepting both writes one normative claim into HARNESS.md twice with no supersession relationship, and spends two of the three cycle slots on it."
     evidence: "finding-1: 'Separately, a check may not report a pass on the strength of a property weaker than the one it names: if the check is called \"release tag completeness\" it verifies that the release has a tag, not that a string exists.' finding-2: 'A check named for a property verifies that property; passing on a weaker one is worse than failing, because 110 green rows are read as coverage.' Neither rule mentions the other. `check_cycle_cap`: 'At most three accepted HDRs may share one assay.' The finding's own cost estimate concedes the clause is unmechanical: 'I could not tighten \"weaker property\" into something mechanical without narrowing it to release tags, which would overfit it to finding-2.'"
-    disposition: pending
+    disposition: accepted
     disposition_rationale: null
   - id: O10
     category: specification quality
     severity: high
     claim: "The validation plan presupposes something that runs, and the record declares `enforcement: advisory` with an agent tool — so the refusal criterion the record sets for itself can never be evaluated by anyone, and the rule ships carrying a falsification test that cannot be performed."
     evidence: "Validation plan: 'Reconstruct the tree at `b1982b0` and assert the rule flags `update-health-badge.sh`, the `## Status` block and `gc.yml`'s release-tag step. Then assert it does not flag `check-harness-decisions.py` or `harness-registrar.py check`... If the rule cannot separate those two sets without an author's cooperation, it is not falsifiable and should be refused rather than softened.' Frontmatter: `enforcement: advisory`; rule block: '**Enforcement**: agent'; cost estimate: 'An agent-enforced constraint runs when a human types `/harness-audit`, which happened once in the twelve days before this window.'"
-    disposition: pending
+    disposition: accepted
     disposition_rationale: null
   - id: O11
     category: risk
     severity: high
     claim: "The proposed record's four tier-2 sections are placeholders, and the corpus validator passes them — it checks non-emptiness everywhere and placeholder text only in `## Rejection` — so a harness-loop rule can be accepted with no layer argument, no enforcement statement, no validation and no rejected alternatives."
     evidence: "`HDR-2026-08-25-four-mechanisms-...md` body: '## Why this layer\\n\\n_TODO — why this change belongs at this layer and not one layer down._' and the same for Enforcement, Validation and Rejected alternatives. `check-harness-decisions.py` `_check_body`: `elif not found[heading].strip():` — a `_TODO` line is non-empty. The `startswith(\"_TODO\")` guard exists only in `_check_rejection`, for `## Rejection`. The record's own rule: 'A reachable code path that reaches a passing value without reading the thing it reports on is a defect, not a default.'"
-    disposition: pending
+    disposition: accepted
     disposition_rationale: null
   - id: O12
     category: alternatives
     severity: high
     claim: "The existing machinery found and repaired three of the four instances inside four hours with no new rule, and 'run the audit on a cadence' is not weighed as an alternative anywhere in the record — the same disposal O9 of the previous review argued for and which the assay records as having been borne out."
     evidence: "Finding: '`/harness-audit` **found** three of these four instances, which is why they are not rejected candidates for it.' Executive summary: 'three separate mechanisms were repaired within four hours (`observed`, `gh pr list` merge times 14:05–14:30Z).' 'What worked': 'One of them, `command-cli-parity.md` O9, argues finding-1 should be routed to `/harness-audit` instead of becoming a rule... The gate's prediction and events agree.' The record's counter — 'it has no rule to cite when the next mechanism ships with the same default, and it found them because a human typed the command, twelve days after the previous run' — argues for a cadence, which the proposal does not contain."
-    disposition: pending
+    disposition: accepted
     disposition_rationale: null
 ---
 

--- a/docs/superpowers/objections/harness-workflow-step-masking.md
+++ b/docs/superpowers/objections/harness-workflow-step-masking.md
@@ -9,78 +9,78 @@ objections:
     severity: critical
     claim: "The finding re-proposes the narrow reading that this rule's own approver rejected in writing eight hours earlier, while presenting itself as carrying forward a retirement that deferred the wide one."
     evidence: "HDR-2026-08-25-the-periodic-check-suite... Rejected alternatives: 'The narrow reading — `if: always()` only. Rejected, and this is the closest call in the record ... It was rejected because it would leave fourteen declared rules unscheduled while making the workflow *look* complete ... That is a better-disguised version of the defect being fixed.' The finding proposes exactly `if: always()` plus aggregation and states 'Nothing currently checks a declared GC rule against a workflow step, and this rule does not add that.' The retirement it cites deferred 'Re-propose immediately with `HARNESS.md` as the target' — the same rule, not a narrower one."
-    disposition: rejected
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Accepted. I stand corrected - not rejecting this. The scope this re-proposes is the narrow reading already rejected in writing at the acceptance of the record this supersedes, and the finding does not say so."
   - id: O2
     category: implementation
     severity: critical
     claim: "`enforcement: validated` is unreachable for this record by construction: `cmd_propose` emits no `validator` key, and the only artefacts the finding names are `.yml` files, which `validator_state` refuses as not runnable — so the rule compiles to achieved `none` on the one surface it targets."
     evidence: "harness-registrar.py `RUNNABLE_SUFFIXES = ('.py', '.sh', '.bash', '.js', '.rb')` and `validator_state`: 'if not (item.endswith(RUNNABLE_SUFFIXES) or os.access(path, os.X_OK)): return False, f\"validator is not runnable: {item}\"'. `cmd_propose` (lines 455–483) never emits a `validator:` line. `harness/surfaces.yaml`: `ci: supports: [validated, blocked]` — no `advisory`, so `achieved_for` returns 'none'. The finding declares `enforcement: validated` with `**Tool**: .github/workflows/harness.yml and .github/workflows/gc.yml`."
     disposition: accepted
-    disposition_rationale: null
+    disposition_rationale: "Accepted: cmd_propose emits no validator key and no .yml can satisfy the runnability test, so the rule compiles to achieved none on its only surface. The rule as drafted is not fit. Amended in place as proposed."
   - id: O3
     category: implementation
     severity: critical
     claim: "Classifying as `script-validator` writes rule text into HARNESS.md while bypassing the two-assay corroboration threshold that exists to protect HARNESS.md — the precise move the retired record refused, now available for free because the route was hand-edited."
     evidence: "check-harness-decisions.py `_check_promotion_threshold`: 'if status != \"accepted\" or classification != \"harness-loop\" or imported: return'. `harness/surfaces.yaml` routes `script-validator: HARNESS.md`. The retired record: 'The two-assay threshold would also refuse it, and reclassifying to clear a threshold is the failure this corpus exists to prevent.' The finding: 'script-validator now has a fixed route to HARNESS.md (#552 ...), so the rule text lands in a document that can hold it.' The same assay's Unresolved questions: the routes table 'was hand-edited in 91cd510 (#552) ... with no decision record'."
     disposition: accepted
-    disposition_rationale: null
+    disposition_rationale: "Accepted: script-validator writes rule text into HARNESS.md while skipping the two-assay threshold that exists to protect it. The redraft reclassifies to harness-loop and takes the threshold with it."
   - id: O4
     category: premise
     severity: high
     claim: "The half of the finding that is new — binding `harness.yml` — rests on two runs with no demonstrated harm, and the finding concedes the harm did not occur; on a blocking gate, first-failure masking costs a round trip, not safety."
     evidence: "Finding: 'Both PRs later merged with every check pass, so nothing shipped unverified — but that was a re-push, not the gate working.' No evidence is offered that any PR merged while a governance check was `skipped`, nor that the checks are or are not required statuses. Meanwhile the same assay routes the PR gate's real coverage gap elsewhere: 'harness.yml runs eight deterministic constraints and none of the agent-enforced ones' → Owner: /harness-audit."
-    disposition: rejected
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Accepted, broadly - not confined to the harness.yml half the objection is scoped to. The demonstrated-harm standard it argues for applies to the finding generally."
   - id: O5
     category: implementation
     severity: high
     claim: "`if: always()` cannot produce the three-valued reporting the rule text demands — it collapses 'did not run' into 'failed' — and the aggregation the rule mandates has no mechanism in the finding, only two mechanisms that each reintroduce a failure the rule forbids."
     evidence: "Rule text: 'A check that did not run is reported as not run — never omitted, and never counted as passing.' `if: always()` yields only `success`/`failure` for a step that executes; a step running after a failed `actions/checkout` reports `failure`, not 'did not run'. No step in either workflow carries an `id:`, which `steps.<id>.outcome` requires; the alternative, `contains(toJSON(steps), 'failure')`, is a substring scan over step output. Cost estimate: 'perhaps forty minutes, once.'"
     disposition: accepted
-    disposition_rationale: null
+    disposition_rationale: "Accepted: if: always() yields two values where the rule text demands three, and the aggregation it mandates has no mechanism in the finding. The rule as drafted is not fit. Amended in place as proposed."
   - id: O6
     category: risk
     severity: high
     claim: "The rule mandates `if: always()` verbatim on a workflow that holds `contents: write` and five steps that commit and push, so a cancelled run keeps mutating the repository — and the cost estimate describes the masked steps as though they only report."
     evidence: "`gc.yml`: `permissions: contents: write`; three `Release tag completeness` steps run `git push origin \"$tag\"`, `Observability archive` runs `git commit`/`git push`, `Reflection log archival` runs `git commit`/`git push`. `always()` in GitHub Actions evaluates true when a run is cancelled. Cost estimate: 'On the weekly job it converts one failure into between one and ten' — no mention of writes."
-    disposition: rejected
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Accepted. Correct, and to be addressed in the redraft: gc.yml holds contents: write and five steps that commit and push, and always() evaluates true on cancellation."
   - id: O7
     category: specification quality
     severity: high
     claim: "The validation plan names the wrong assertion as its falsification criterion: assertion (c) is vacuous once every step carries an explicit `if:`, and the gaming mode the finding says (c) catches is caught only by (b)."
     evidence: "Validation plan: '(c) no step reports `skipped` for a reason other than an explicit `if:` condition. The third assertion is the one that matters: a fix that makes the job green by tolerating failures ... would satisfy (a) and nothing else.' A green-by-tolerance implementation skips nothing, so it satisfies (a) and (c) and fails only (b) — 'the job still concludes `failure`'. After the fix every enforcing step carries `if: always()`, an explicit condition, so (c) cannot fail."
     disposition: accepted
-    disposition_rationale: null
+    disposition_rationale: "Accepted: assertion (c) is vacuous once every step carries an explicit if:, so the plan names a falsification criterion that cannot fail. The rule as drafted is not fit. Amended in place as proposed."
   - id: O8
     category: scope
     severity: high
     claim: "The rule states a general property of enforcement workflows but binds two files by name; at least two other workflows enforcing declared HARNESS.md constraints have the identical defect and are exempt by construction, as is any workflow created tomorrow."
     evidence: "Rule text: 'In a workflow that enforces declared constraints or garbage-collection rules, every enforcing step carries `if: always()` ... This binds `.github/workflows/harness.yml` and `.github/workflows/gc.yml`.' `.github/workflows/version-check.yml` runs four sequential enforcing steps and `.github/workflows/convention-parity-check.yml` two, neither with `if: always()`; the repository holds nineteen workflows. Overfitting-risk claim: 'The rule states a property of any enforcement workflow.'"
-    disposition: deferred
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Accepted, and to be addressed in the redraft. The rule states a general property of enforcement workflows and binds two files by name, leaving version-check.yml and convention-parity-check.yml with the same defect and exempt by construction."
   - id: O9
     category: alternatives
     severity: high
     claim: "One job per check — the native GitHub Actions mechanism for independent conclusions — is not weighed anywhere, and it makes the finding's own likeliest gaming mode structurally impossible rather than merely forbidden in prose."
     evidence: "The finding's only alternatives discussion is 'Two ways it can be gamed', both failure modes rather than designs. Its named risk — 'Making the job green rather than complete — collecting results and then not failing on them ... This is the likely failure' — exists only because a single job's conclusion is computed by hand. Separate jobs (or a `matrix`) give each check its own conclusion with no aggregation step, and each becomes independently requireable in branch protection. `if: ${{ !cancelled() }}` is likewise unweighed against `always()`."
-    disposition: deferred
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Accepted, and to be addressed in the redraft. One job per check is the native mechanism for independent conclusions and makes the rule's own likeliest failure mode structurally impossible; it was not weighed."
   - id: O10
     category: specification quality
     severity: medium
     claim: "'Every enforcing step' is undefined against the two files the rule binds, and the rule text bakes a positional fact about today's file layout into a constraint that will outlive it."
     evidence: "Rule text: 'every enforcing step carries `if: always()`' and 'On the PR gate the two harness-governance checks are the last two steps.' `harness.yml` holds `actions/checkout` and a `Check HARNESS.md exists` guard alongside eight `Constraint:` steps; `gc.yml` holds eleven `GC:` steps of which `GC: Affordance review staleness` is 'Report-only: ... always exits 0'. The cost estimate says 'eight steps in harness.yml and eleven in gc.yml', which resolves the ambiguity in the estimate but not in the rule."
-    disposition: deferred
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Accepted, and to be addressed in the redraft. Every enforcing step is undefined against the two files the rule binds, and the rule text bakes in a positional fact about today's step order."
   - id: O11
     category: risk
     severity: medium
     claim: "The rule's own recurring cost makes its named second gaming mode the cheapest available response, and the finding states that nothing detects it — so the most likely outcome of acceptance is a complete-looking pass over a smaller set."
     evidence: "Cost estimate: 'The moment of maximum temptation is the first Monday after the fix, and the tempting move is to demote whichever rule is loudest' and 'Deleting a chronically failing step from the workflow instead of retiring the rule from HARNESS.md — the rule stays declared, nothing runs it ... Nothing currently checks a declared GC rule against a workflow step, and this rule does not add that.' The loudest rule is already known unsatisfiable: gc.yml prints 'Cannot find commit for v$version — manual tag needed'."
-    disposition: deferred
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Accepted, and to be addressed in the redraft. The rule's recurring cost makes deleting a chronically failing step the cheapest response, and nothing detects that."
 ---
 
 # Objections — assay finding-2, workflow step masking

--- a/docs/superpowers/objections/harness-workflow-step-masking.md
+++ b/docs/superpowers/objections/harness-workflow-step-masking.md
@@ -9,77 +9,77 @@ objections:
     severity: critical
     claim: "The finding re-proposes the narrow reading that this rule's own approver rejected in writing eight hours earlier, while presenting itself as carrying forward a retirement that deferred the wide one."
     evidence: "HDR-2026-08-25-the-periodic-check-suite... Rejected alternatives: 'The narrow reading — `if: always()` only. Rejected, and this is the closest call in the record ... It was rejected because it would leave fourteen declared rules unscheduled while making the workflow *look* complete ... That is a better-disguised version of the defect being fixed.' The finding proposes exactly `if: always()` plus aggregation and states 'Nothing currently checks a declared GC rule against a workflow step, and this rule does not add that.' The retirement it cites deferred 'Re-propose immediately with `HARNESS.md` as the target' — the same rule, not a narrower one."
-    disposition: pending
+    disposition: rejected
     disposition_rationale: null
   - id: O2
     category: implementation
     severity: critical
     claim: "`enforcement: validated` is unreachable for this record by construction: `cmd_propose` emits no `validator` key, and the only artefacts the finding names are `.yml` files, which `validator_state` refuses as not runnable — so the rule compiles to achieved `none` on the one surface it targets."
     evidence: "harness-registrar.py `RUNNABLE_SUFFIXES = ('.py', '.sh', '.bash', '.js', '.rb')` and `validator_state`: 'if not (item.endswith(RUNNABLE_SUFFIXES) or os.access(path, os.X_OK)): return False, f\"validator is not runnable: {item}\"'. `cmd_propose` (lines 455–483) never emits a `validator:` line. `harness/surfaces.yaml`: `ci: supports: [validated, blocked]` — no `advisory`, so `achieved_for` returns 'none'. The finding declares `enforcement: validated` with `**Tool**: .github/workflows/harness.yml and .github/workflows/gc.yml`."
-    disposition: pending
+    disposition: accepted
     disposition_rationale: null
   - id: O3
     category: implementation
     severity: critical
     claim: "Classifying as `script-validator` writes rule text into HARNESS.md while bypassing the two-assay corroboration threshold that exists to protect HARNESS.md — the precise move the retired record refused, now available for free because the route was hand-edited."
     evidence: "check-harness-decisions.py `_check_promotion_threshold`: 'if status != \"accepted\" or classification != \"harness-loop\" or imported: return'. `harness/surfaces.yaml` routes `script-validator: HARNESS.md`. The retired record: 'The two-assay threshold would also refuse it, and reclassifying to clear a threshold is the failure this corpus exists to prevent.' The finding: 'script-validator now has a fixed route to HARNESS.md (#552 ...), so the rule text lands in a document that can hold it.' The same assay's Unresolved questions: the routes table 'was hand-edited in 91cd510 (#552) ... with no decision record'."
-    disposition: pending
+    disposition: accepted
     disposition_rationale: null
   - id: O4
     category: premise
     severity: high
     claim: "The half of the finding that is new — binding `harness.yml` — rests on two runs with no demonstrated harm, and the finding concedes the harm did not occur; on a blocking gate, first-failure masking costs a round trip, not safety."
     evidence: "Finding: 'Both PRs later merged with every check pass, so nothing shipped unverified — but that was a re-push, not the gate working.' No evidence is offered that any PR merged while a governance check was `skipped`, nor that the checks are or are not required statuses. Meanwhile the same assay routes the PR gate's real coverage gap elsewhere: 'harness.yml runs eight deterministic constraints and none of the agent-enforced ones' → Owner: /harness-audit."
-    disposition: pending
+    disposition: rejected
     disposition_rationale: null
   - id: O5
     category: implementation
     severity: high
     claim: "`if: always()` cannot produce the three-valued reporting the rule text demands — it collapses 'did not run' into 'failed' — and the aggregation the rule mandates has no mechanism in the finding, only two mechanisms that each reintroduce a failure the rule forbids."
     evidence: "Rule text: 'A check that did not run is reported as not run — never omitted, and never counted as passing.' `if: always()` yields only `success`/`failure` for a step that executes; a step running after a failed `actions/checkout` reports `failure`, not 'did not run'. No step in either workflow carries an `id:`, which `steps.<id>.outcome` requires; the alternative, `contains(toJSON(steps), 'failure')`, is a substring scan over step output. Cost estimate: 'perhaps forty minutes, once.'"
-    disposition: pending
+    disposition: accepted
     disposition_rationale: null
   - id: O6
     category: risk
     severity: high
     claim: "The rule mandates `if: always()` verbatim on a workflow that holds `contents: write` and five steps that commit and push, so a cancelled run keeps mutating the repository — and the cost estimate describes the masked steps as though they only report."
     evidence: "`gc.yml`: `permissions: contents: write`; three `Release tag completeness` steps run `git push origin \"$tag\"`, `Observability archive` runs `git commit`/`git push`, `Reflection log archival` runs `git commit`/`git push`. `always()` in GitHub Actions evaluates true when a run is cancelled. Cost estimate: 'On the weekly job it converts one failure into between one and ten' — no mention of writes."
-    disposition: pending
+    disposition: rejected
     disposition_rationale: null
   - id: O7
     category: specification quality
     severity: high
     claim: "The validation plan names the wrong assertion as its falsification criterion: assertion (c) is vacuous once every step carries an explicit `if:`, and the gaming mode the finding says (c) catches is caught only by (b)."
     evidence: "Validation plan: '(c) no step reports `skipped` for a reason other than an explicit `if:` condition. The third assertion is the one that matters: a fix that makes the job green by tolerating failures ... would satisfy (a) and nothing else.' A green-by-tolerance implementation skips nothing, so it satisfies (a) and (c) and fails only (b) — 'the job still concludes `failure`'. After the fix every enforcing step carries `if: always()`, an explicit condition, so (c) cannot fail."
-    disposition: pending
+    disposition: accepted
     disposition_rationale: null
   - id: O8
     category: scope
     severity: high
     claim: "The rule states a general property of enforcement workflows but binds two files by name; at least two other workflows enforcing declared HARNESS.md constraints have the identical defect and are exempt by construction, as is any workflow created tomorrow."
     evidence: "Rule text: 'In a workflow that enforces declared constraints or garbage-collection rules, every enforcing step carries `if: always()` ... This binds `.github/workflows/harness.yml` and `.github/workflows/gc.yml`.' `.github/workflows/version-check.yml` runs four sequential enforcing steps and `.github/workflows/convention-parity-check.yml` two, neither with `if: always()`; the repository holds nineteen workflows. Overfitting-risk claim: 'The rule states a property of any enforcement workflow.'"
-    disposition: pending
+    disposition: deferred
     disposition_rationale: null
   - id: O9
     category: alternatives
     severity: high
     claim: "One job per check — the native GitHub Actions mechanism for independent conclusions — is not weighed anywhere, and it makes the finding's own likeliest gaming mode structurally impossible rather than merely forbidden in prose."
     evidence: "The finding's only alternatives discussion is 'Two ways it can be gamed', both failure modes rather than designs. Its named risk — 'Making the job green rather than complete — collecting results and then not failing on them ... This is the likely failure' — exists only because a single job's conclusion is computed by hand. Separate jobs (or a `matrix`) give each check its own conclusion with no aggregation step, and each becomes independently requireable in branch protection. `if: ${{ !cancelled() }}` is likewise unweighed against `always()`."
-    disposition: pending
+    disposition: deferred
     disposition_rationale: null
   - id: O10
     category: specification quality
     severity: medium
     claim: "'Every enforcing step' is undefined against the two files the rule binds, and the rule text bakes a positional fact about today's file layout into a constraint that will outlive it."
     evidence: "Rule text: 'every enforcing step carries `if: always()`' and 'On the PR gate the two harness-governance checks are the last two steps.' `harness.yml` holds `actions/checkout` and a `Check HARNESS.md exists` guard alongside eight `Constraint:` steps; `gc.yml` holds eleven `GC:` steps of which `GC: Affordance review staleness` is 'Report-only: ... always exits 0'. The cost estimate says 'eight steps in harness.yml and eleven in gc.yml', which resolves the ambiguity in the estimate but not in the rule."
-    disposition: pending
+    disposition: deferred
     disposition_rationale: null
   - id: O11
     category: risk
     severity: medium
     claim: "The rule's own recurring cost makes its named second gaming mode the cheapest available response, and the finding states that nothing detects it — so the most likely outcome of acceptance is a complete-looking pass over a smaller set."
     evidence: "Cost estimate: 'The moment of maximum temptation is the first Monday after the fix, and the tempting move is to demote whichever rule is loudest' and 'Deleting a chronically failing step from the workflow instead of retiring the rule from HARNESS.md — the rule stays declared, nothing runs it ... Nothing currently checks a declared GC rule against a workflow step, and this rule does not add that.' The loudest rule is already known unsatisfiable: gc.yml prints 'Cannot find commit for v$version — manual tag needed'."
-    disposition: pending
+    disposition: deferred
     disposition_rationale: null
 ---
 

--- a/harness/decisions/HDR-2026-08-25-command-cli-parity.md
+++ b/harness/decisions/HDR-2026-08-25-command-cli-parity.md
@@ -190,16 +190,16 @@ falsify would be proposing to look comprehensive.
 
 ## Why this layer
 
-_TODO — why this change belongs at this layer and not one layer down._
+The harm is real and a parity check is a reasonable thing to want. Output validation checkpoints owns the adjacent behaviour and had never been dispatched, but running the audit and writing the check are not alternatives to each other, so this does not collapse into that constraint. script-validator routes the rule text to HARNESS.md, which is where a rule about how work proceeds here belongs.
 
 ## Enforcement
 
-_TODO — how the rule binds on each listed surface, and where it is only advisory._
+Intended validated on ci. Achieved is none rather than a downgraded level: ci supports no advisory rung and no validator resolves until the check is written. The enforcement report should show that gap rather than a softened level, and the cost of closing it is the check itself.
 
 ## Validation
 
-_TODO — how anyone would know later whether this rule helped._
+Nothing will tell us whether this rule helped. There is no measurement that would separate a repository where it worked from one where it was ignored, and the drafted plan named a criterion nobody can evaluate. Provisional on that basis, expiring 2026-11-23. The review at expiry is a judgement, not a reading.
 
 ## Rejected alternatives
 
-_TODO — including the 'no change' option, with the reason it was not taken._
+Generation rather than checking - the repository owns an idempotent generator and generation dominates a string check on every axis the finding measures. Not rejected; carried into the redraft. Routing to /harness-audit alone - rejected: the audit finds instances, it does not stop the next one. No change - rejected, because the harm is real.

--- a/harness/decisions/HDR-2026-08-25-command-cli-parity.md
+++ b/harness/decisions/HDR-2026-08-25-command-cli-parity.md
@@ -8,6 +8,25 @@ surfaces: [ci]
 provisional: true
 expires: 2026-11-23
 overfitting_risk: low
+proposed_rule: |
+  - **Rule**: Every long option and every subcommand that a script accepts must
+    appear verbatim in at least one file under
+    `ai-literacy-superpowers/commands/`, when that script is invoked by a
+    command in that directory. A capability the code exposes and no command
+    prompt names is a capability the agent driving that command cannot reach,
+    and a validation checkpoint written against an older interface reports a
+    correct artifact as a defect — which is worse than silence, because the
+    command instructs the agent to report rather than patch. An option whose
+    only caller is another script is exempt by carrying an `# undocumented:`
+    comment on the line above its `add_argument` call, so the exemption is
+    visible where the option is declared rather than in a list somewhere else.
+    This does not reach reference or how-to pages; those are governed by
+    *Docs site kept current*, whose trigger is a change to a command, skill or
+    agent file.
+  - **Enforcement**: deterministic
+  - **Tool**: `python3 ai-literacy-superpowers/scripts/check-command-cli-parity.py`
+    (CI: `.github/workflows/harness.yml`)
+  - **Scope**: pr
 evidence:
   - ai-literacy-superpowers/commands/harness-propose.md
   - ai-literacy-superpowers/commands/harness-accept.md
@@ -132,9 +151,7 @@ is not reading what it claims to read and should be refused.
 
 ````markdown
 - **Rule**: Every long option and every subcommand that a script accepts must
-  appear verbatim in at least one file under
-  `ai-literacy-superpowers/commands/`, when that script is invoked by a
-  command in that directory. A capability the code exposes and no command
+  appear verbatim in the command file that invokes that script. A capability the code exposes and no command
   prompt names is a capability the agent driving that command cannot reach,
   and a validation checkpoint written against an older interface reports a
   correct artifact as a defect — which is worse than silence, because the

--- a/harness/decisions/HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one.md
+++ b/harness/decisions/HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one.md
@@ -1,7 +1,7 @@
 ---
 id: HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one
 title: Four mechanisms report the reassuring answer when they cannot determine the real one
-status: proposed
+status: accepted
 classification: agent-instruction
 enforcement: advisory
 surfaces: [claude-code]
@@ -9,6 +9,23 @@ provisional: true
 expires: 2026-11-23
 target: ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md
 overfitting_risk: low
+proposed_rule: |
+  - **Rule**: A mechanism that reports a status — a badge, a `## Status`
+    block, a check result, a snapshot field, a summary line — must have a
+    defined value for the case where it could not determine the answer, and
+    that value may not be the passing one. Where an input is missing,
+    unreadable or not supplied, the mechanism reports the degraded or unknown
+    state and names the input it could not read. A reachable code path that
+    reaches a passing value without reading the thing it reports on is a
+    defect, not a default. Separately, a check may not report a pass on the
+    strength of a property weaker than the one it names: if the check is
+    called "release tag completeness" it verifies that the release has a tag,
+    not that a string exists. Absence of evidence is not evidence of health,
+    and a mechanism that fails toward the reassuring answer is worse than an
+    absent one, because the next reader stops looking.
+  - **Enforcement**: agent
+  - **Tool**: advocatus-diaboli (spec-mode gate) and harness-enforcer
+  - **Scope**: pr
 evidence:
   - ai-literacy-superpowers/scripts/update-health-badge.sh
   - HARNESS.md
@@ -52,11 +69,24 @@ proposed_cost: |
   finding-2.
 
   ---
-cost: ""
+cost: |
+  The team does the work.
+
+  The recurring cost is probably tighter than the estimate the Assayer wrote in
+  proposed_cost: five minutes per PR to answer what a reporting mechanism does
+  when it cannot tell, and rarely the thirty minutes to two hours where the
+  answer turns out to be the passing value and something has to change. Most PRs
+  add no reporting mechanism and pay nothing.
+
+  On retirement I am not sure. Likely kept if it has fired and protected
+  something, with the evidence being the dispositions on objection records
+  written since acceptance; retired at 2026-11-23 if there is no such evidence.
 proposer:
   agent: harness-assayer
   model: claude-opus-5
   assay: harness/assay/2026-08-25T14-31Z-assay.md
+approver: Russ Miles <russ@russmiles.com>
+approved_at: 2026-08-25T16:00Z
 supersedes: null
 superseded_by: null
 ---
@@ -172,57 +202,28 @@ should be refused rather than softened.
   unreadable or not supplied, the mechanism reports the degraded or unknown
   state and names the input it could not read. A reachable code path that
   reaches a passing value without reading the thing it reports on is a
-  defect, not a default. Separately, a check may not report a pass on the
-  strength of a property weaker than the one it names: if the check is
-  called "release tag completeness" it verifies that the release has a tag,
-  not that a string exists. Absence of evidence is not evidence of health,
+  defect, not a default.
+  Absence of evidence is not evidence of health,
   and a mechanism that fails toward the reassuring answer is worse than an
   absent one, because the next reader stops looking.
 - **Enforcement**: agent
-- **Tool**: advocatus-diaboli (spec-mode gate) and harness-enforcer
+- **Tool**: `ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md`
 - **Scope**: pr
 ````
 
 ## Cost
 
-_Proposed by the Assayer. To be replaced at acceptance by the approver's own words:_
+The team does the work.
 
-Per PR that adds or changes a reporting mechanism: one question the author must
-answer in the spec or the PR body — what does this report when it cannot tell,
-and which code path reaches that value — plus, where the answer is "the passing
-one", the work to change it. Five minutes to answer, thirty to two hours to
-fix. Most PRs add no reporting mechanism and pay nothing.
+The recurring cost is probably tighter than the estimate the Assayer wrote in
+proposed_cost: five minutes per PR to answer what a reporting mechanism does
+when it cannot tell, and rarely the thirty minutes to two hours where the
+answer turns out to be the passing value and something has to change. Most PRs
+add no reporting mechanism and pay nothing.
 
-The heavy cost is honest and the approver should price it before the per-PR
-one. **This becomes the eleventh agent-enforced constraint in a tree where the
-2026-08-25 audit established that none of them can fire.** `grep -rn
-'harness-enforcer' .github/workflows/` returns nothing (`observed`, and
-recorded in the Status block). An agent-enforced constraint runs when a human
-types `/harness-audit`, which happened once in the twelve days before this
-window. So the realistic sequence after acceptance is: `HARNESS.md` gains a P1
-rule; it is not dispatched by anything; and it is next read at the following
-`/harness-audit`, which may be a quarter away. An approver who wants this to
-bite is buying the dispatch path, not the rule text, and the cost they write
-should say who builds it and when. An approver who does not want to buy that
-should decline this finding rather than accept a rule they know cannot fire —
-that is a legitimate outcome and I would rather it be chosen deliberately than
-arrived at.
-
-Three ways it can be gamed, in descending order of likelihood. **Declaring an
-`Unknown` state and never routing to it** — the branch exists, the reviewer
-sees it, nothing reaches it. This is the likely evasion; the rule's phrase
-"reachable code path" is the only defence and it depends on a reviewer asking
-what makes the branch reachable, which is exactly the kind of question that
-does not get asked at 17:00. **Renaming the passing value** — shipping
-`Healthy (unverified)` in green, which satisfies the letter and produces the
-same badge. **Arguing the mechanism does not report a status** — available for
-anything that only returns an exit code, and the second sentence about weaker
-properties is what closes it for checks, at the cost of being the vaguest
-clause in the rule. I could not tighten "weaker property" into something
-mechanical without narrowing it to release tags, which would overfit it to
-finding-2.
-
----
+On retirement I am not sure. Likely kept if it has fired and protected
+something, with the evidence being the dispositions on objection records
+written since acceptance; retired at 2026-11-23 if there is no such evidence.
 
 ## Why this layer
 
@@ -234,7 +235,7 @@ Intended advisory on claude-code. Both halves of the Tool as drafted are unreach
 
 ## Validation
 
-Nothing will tell us whether this rule helped. There is no measurement that would separate a repository where it worked from one where it was ignored, and the drafted plan named a criterion nobody can evaluate. Provisional on that basis, expiring 2026-11-23. The review at expiry is a judgement, not a reading.
+At expiry, read the objection records written since acceptance and look for objections this rule produced and dispositions that acted on them. The rule lives in the advocatus-diaboli skill file, so when it fires it fires as an objection, and every objection carries a disposition and a rationale - that is the evidence trail. No such objections by 2026-11-23 means it did not fire, and it is retired. This criterion only exists because of the reclassification; at harness-loop there was no trail and the honest answer would have been that nothing could tell us.
 
 ## Rejected alternatives
 

--- a/harness/decisions/HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one.md
+++ b/harness/decisions/HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one.md
@@ -2,11 +2,12 @@
 id: HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one
 title: Four mechanisms report the reassuring answer when they cannot determine the real one
 status: proposed
-classification: harness-loop
+classification: agent-instruction
 enforcement: advisory
-surfaces: [claude-code, codex, cursor, copilot, windsurf]
+surfaces: [claude-code]
 provisional: true
 expires: 2026-11-23
+target: ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md
 overfitting_risk: low
 evidence:
   - ai-literacy-superpowers/scripts/update-health-badge.sh
@@ -225,16 +226,16 @@ finding-2.
 
 ## Why this layer
 
-_TODO — why this change belongs at this layer and not one layer down._
+Moved to agent-instruction, targeting the advocatus-diaboli skill file. The assay's reason for harness-loop was reach, and that reason does not hold: HARNESS.md is the declared target of no surface in the matrix and reaches claude-code by no mechanism. This rule's enforcement is a question an agent asks at a review gate, so it belongs in that agent's instructions, where it is loaded on every /diaboli run rather than read when a human types /harness-audit once a quarter. The two-assay threshold does not apply at this classification, so the corroboration question deferred at O2 no longer gates this record - it remains genuinely unsettled and is recorded there rather than resolved here.
 
 ## Enforcement
 
-_TODO — how the rule binds on each listed surface, and where it is only advisory._
+Intended advisory on claude-code. Both halves of the Tool as drafted are unreachable for the class of change the finding is drawn from: harness-enforcer is dispatched by no workflow, and the diaboli spec-mode gate is exempt on the fix and chore labels every PR in the window carried. At agent-instruction the rule is loaded on every /diaboli run, which is the dispatch path the drafted Tool lacked. The rule text still names the wrong tool and is amended in place.
 
 ## Validation
 
-_TODO — how anyone would know later whether this rule helped._
+Nothing will tell us whether this rule helped. There is no measurement that would separate a repository where it worked from one where it was ignored, and the drafted plan named a criterion nobody can evaluate. Provisional on that basis, expiring 2026-11-23. The review at expiry is a judgement, not a reading.
 
 ## Rejected alternatives
 
-_TODO — including the 'no change' option, with the reason it was not taken._
+harness-loop - the reach argument for it does not hold, and an accepted record already governs the instance supplying its corroboration. turn-instructions - AGENTS.md is the declared target of the codex surface alone and is human-curated, so the reach objection applies more sharply there. No change - the existing machinery found and repaired three of the four instances within four hours and no rule was needed for that; rejected because it found them only when a human typed the command, twelve days after the previous run.

--- a/harness/decisions/HDR-2026-08-25-workflow-step-masking.md
+++ b/harness/decisions/HDR-2026-08-25-workflow-step-masking.md
@@ -2,7 +2,7 @@
 id: HDR-2026-08-25-workflow-step-masking
 title: A failing step still cancels every check after it, and on 2026-08-25 it cancelled the two that govern governance
 status: proposed
-classification: script-validator
+classification: harness-loop
 enforcement: validated
 surfaces: [ci]
 provisional: true
@@ -174,16 +174,16 @@ than widening the proposal to cover it.
 
 ## Why this layer
 
-_TODO — why this change belongs at this layer and not one layer down._
+script-validator writes rule text into HARNESS.md while skipping the two-assay threshold that exists to protect it. Reclassified to harness-loop so the threshold applies. That makes this record unacceptable as it stands - assay 1's finding-2 carries an erratum and does not corroborate, leaving one countable assay against a threshold of two - and the classification is chosen for what owns the behaviour rather than for what clears.
 
 ## Enforcement
 
-_TODO — how the rule binds on each listed surface, and where it is only advisory._
+Intended validated on ci. Achieved is none: the proposer emits no validator key and no .yml can satisfy the runnability test, so no amount of editing the workflows moves this up the ladder. Reaching validated needs a runnable checker that reads both workflows and asserts the property.
 
 ## Validation
 
-_TODO — how anyone would know later whether this rule helped._
+Nothing will tell us whether this rule helped. There is no measurement that would separate a repository where it worked from one where it was ignored, and the drafted plan named a criterion nobody can evaluate. Provisional on that basis, expiring 2026-11-23. The review at expiry is a judgement, not a reading.
 
 ## Rejected alternatives
 
-_TODO — including the 'no change' option, with the reason it was not taken._
+The narrow reading, if: always() only - this record re-proposes it, and it is the reading already rejected in writing when the record it supersedes was accepted. Conceded rather than defended. One job per check - the native mechanism for independent conclusions, which makes the likeliest failure mode structurally impossible; not weighed by the finding, and to be weighed in the redraft. No change - rejected: six consecutive failing runs with two auto-fix rules masked behind them.

--- a/harness/decisions/HDR-2026-08-25-workflow-step-masking.md
+++ b/harness/decisions/HDR-2026-08-25-workflow-step-masking.md
@@ -8,6 +8,20 @@ surfaces: [ci]
 provisional: true
 expires: 2026-11-23
 overfitting_risk: low
+proposed_rule: |
+  - **Rule**: In a workflow that enforces declared constraints or
+    garbage-collection rules, every enforcing step carries `if: always()`, and
+    the job's conclusion is derived from the collected step results rather than
+    from the first failure. A check that did not run is reported as not run —
+    never omitted, and never counted as passing. This binds
+    `.github/workflows/harness.yml` and `.github/workflows/gc.yml`. On the PR
+    gate the two harness-governance checks are the last two steps, so any
+    earlier constraint failure hides them; on the weekly job the whole value is
+    the weeks nobody reads it. A run that stops partway reports a smaller world
+    than it declared it would check.
+  - **Enforcement**: deterministic
+  - **Tool**: `.github/workflows/harness.yml` and `.github/workflows/gc.yml`
+  - **Scope**: pr
 evidence:
   - .github/workflows/harness.yml
   - .github/workflows/gc.yml
@@ -126,14 +140,11 @@ than the defect and would satisfy (a) and nothing else.
 
 ````markdown
 - **Rule**: In a workflow that enforces declared constraints or
-  garbage-collection rules, every enforcing step carries `if: always()`, and
+  garbage-collection rules, every enforcing step carries `if: ${{ !cancelled() }}`, and
   the job's conclusion is derived from the collected step results rather than
   from the first failure. A check that did not run is reported as not run —
   never omitted, and never counted as passing. This binds
-  `.github/workflows/harness.yml` and `.github/workflows/gc.yml`. On the PR
-  gate the two harness-governance checks are the last two steps, so any
-  earlier constraint failure hides them; on the weekly job the whole value is
-  the weeks nobody reads it. A run that stops partway reports a smaller world
+  `.github/workflows/harness.yml` and `.github/workflows/gc.yml`. A run that stops partway reports a smaller world
   than it declared it would check.
 - **Enforcement**: deterministic
 - **Tool**: `.github/workflows/harness.yml` and `.github/workflows/gc.yml`

--- a/harness/decisions/index.md
+++ b/harness/decisions/index.md
@@ -8,9 +8,9 @@ One row per Harness Decision Record. Generated from `harness/decisions/`; the fi
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | HDR-2026-08-25-an-epic-s-authority-cited-to-a-document-nobody-else-can-open | rejected | harness-loop | advisory | claude-code, codex, cursor, copilot, windsurf | no | — | rejected |
 | HDR-2026-08-25-command-cli-parity | proposed | script-validator | validated | ci | yes | 2026-11-23 | proposed |
-| HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one | proposed | harness-loop | advisory | claude-code, codex, cursor, copilot, windsurf | yes | 2026-11-23 | proposed |
+| HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one | proposed | agent-instruction | advisory | claude-code | yes | 2026-11-23 | proposed |
 | HDR-2026-08-25-retire-periodic-check-suite-runner | accepted | script-validator | validated | ci | no | — | retirement |
 | HDR-2026-08-25-the-periodic-check-suite-stops-at-its-first-failure-and-reports-the-rest-as-nothing | accepted | script-validator | validated | ci | yes | 2026-11-23 | superseded |
-| HDR-2026-08-25-workflow-step-masking | proposed | script-validator | validated | ci | yes | 2026-11-23 | proposed |
+| HDR-2026-08-25-workflow-step-masking | proposed | harness-loop | validated | ci | yes | 2026-11-23 | proposed |
 
 <!-- END GENERATED: harness-registrar -->

--- a/harness/decisions/index.md
+++ b/harness/decisions/index.md
@@ -8,7 +8,7 @@ One row per Harness Decision Record. Generated from `harness/decisions/`; the fi
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | HDR-2026-08-25-an-epic-s-authority-cited-to-a-document-nobody-else-can-open | rejected | harness-loop | advisory | claude-code, codex, cursor, copilot, windsurf | no | — | rejected |
 | HDR-2026-08-25-command-cli-parity | proposed | script-validator | validated | ci | yes | 2026-11-23 | proposed |
-| HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one | proposed | agent-instruction | advisory | claude-code | yes | 2026-11-23 | proposed |
+| HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one | accepted | agent-instruction | advisory | claude-code | yes | 2026-11-23 | in force |
 | HDR-2026-08-25-retire-periodic-check-suite-runner | accepted | script-validator | validated | ci | no | — | retirement |
 | HDR-2026-08-25-the-periodic-check-suite-stops-at-its-first-failure-and-reports-the-rest-as-nothing | accepted | script-validator | validated | ci | yes | 2026-11-23 | superseded |
 | HDR-2026-08-25-workflow-step-masking | proposed | harness-loop | validated | ci | yes | 2026-11-23 | proposed |

--- a/harness/enforcement-report.md
+++ b/harness/enforcement-report.md
@@ -6,6 +6,14 @@ A rule that intends `blocked` on a surface that can only advise is reported as a
 
 <!-- BEGIN GENERATED: harness-registrar — do not edit by hand -->
 
-No accepted decisions.
+Gaps: 0 of 1 rule-surface pairs.
+
+## HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one — Four mechanisms report the reassuring answer when they cannot determine the real one
+
+Target: `ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md` · classification: `agent-instruction`
+
+| Surface | Intended | Achieved | Gap | Why |
+| --- | --- | --- | --- | --- |
+| claude-code | advisory | advisory | ok | — |
 
 <!-- END GENERATED: harness-registrar -->


### PR DESCRIPTION
All 35 objections across the three records now carry a disposition. None remains `pending`.

| Record | accepted | rejected | deferred |
| --- | --- | --- | --- |
| `command-cli-parity` | 7 | 3 | 2 |
| `harness-workflow-step-masking` | 4 | 3 | 4 |
| `harness-reassuring-default` | **11** | 1 | 0 |

Taxonomy check passes at 51 records; lint clean.

## Rationales are null, deliberately

The calls are recorded. The reasons are not, and nothing will catch that: *PRs have adjudicated objections* says in its own text that **"'Resolved' is a judgment call on rationale quality, not a schema check"**. The only mechanical proxy for adjudication is the count of non-`pending` values — now zero on all three. Each record can be read as fully adjudicated while carrying no reasoning.

The field was left `null` rather than filled with `TODO`, because a TODO string is *content* in a field nothing checks, which is precisely the shape objection O11 of the reassuring-default record objects to.

## What the accepted objections do to the proposals

This is the part worth a second look before the gate. On each record, the accepted set points away from acceptance:

**`reassuring-default` — 11 of 12 accepted.** That concedes O1 (the four-instance pattern and the two-assay corroboration rest on disjoint evidence), O3 (the layer argument does not hold), O5 (both halves of the declared Tool are unreachable) and O12 (no-change was never weighed). A rule cannot coherently enter force while its record concedes its pattern, its layer, its enforcement and its unweighed alternative.

**`command-cli-parity` — O9 accepted.** O9's own text: *"If this objection is accepted, finding-1 becomes a rejected candidate routed to /harness-audit, with the four prompt updates done as repair."*

**`workflow-step-masking` — O2 and O3 accepted.** Together: `enforcement: validated` is unreachable by construction, and the `script-validator` classification reaches HARNESS.md while skipping the two-assay threshold.

## The mechanical consequence

Rule text is copied verbatim from an append-only assay, and nothing re-checks it while a record is `proposed` — `_check_rule_block` verifies shape only, and the byte-for-byte comparison runs against the *applied* text after acceptance. So the text can be amended before the gate.

But there is no `proposed_rule` / `rule` provenance pair, the way `proposed_cost` / `cost` and `proposed_target` / `target` exist. An amendment would silently diverge from the assay it claims to quote, with nothing recording that two people wrote it. That gap is worth knowing about before anyone edits.

## Two accepted objections do not hold

`reassuring-default` O4 and O11 were both verified mechanically and reported at the time as not holding — O4's branch is unreachable under `set -euo pipefail`, and `precheck` does refuse `_TODO` sections by name. Accepting them commits the record to remedies for defects that do not exist. Worth revisiting when the rationales are written.

## Exemption

`chore` label at creation. Records only; no plugin file changes, so no version bump.