### PR TITLE
Hold harness health at Degraded, and record why

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,39 @@ The masking defect is real and its cost is narrower than the count of blocked
 rules implied. Recorded here rather than left standing, because the more
 dramatic version is the one already written down.
 
+### The health field had a reason to move, and was held
+
+The 2026-08-25 snapshot is revised in place with the end-of-day state. Two of the
+four grounds for `Degraded` closed during the day — the snapshot cadence lapse and
+the outer-loop overdue on `/assess` — and cadence compliance reached 5/5. On the
+format reference's own rule that arithmetic points at **Attention**.
+
+It is held at **Degraded**, on evidence gathered after the arithmetic:
+
+- **The investigative layer was not one degraded layer; it was largely unbuilt.**
+  5 of 19 declared rules have any automation, 14 ran for the first time on
+  2026-08-25, and 9 of those 14 produced findings. Three of the ten deterministic
+  rules cannot report a failure as declared (#587).
+- **A manual run is not a cadence.** It happened because someone typed a command
+  once, and the scheduled job will fail again at *Release tag completeness*.
+- **An open CVE surfaced from a rule that had never run** (#586). A habitat that
+  finds that on its first sweep should not improve its health the same day.
+
+Recording a refused upgrade is the point: this is the first time the health field
+has had a reason to move and been held.
+
+### Two morning claims falsified by the evening, corrected in place
+
+Both corrections show the original and the correction rather than overwriting:
+
+- *"No rule after step 5 has produced a result in 36 days"* — false, and
+  generalised from the 2026-08-24 run alone. Per-step conclusions show 07-20
+  failing at step 8 and 08-17 at step 9, both with steps 5–7 `success`. Five of
+  six blocked at *Release tag completeness*. Falsified by assay 3 finding-3.
+- *"Two auto-fix rules had work waiting"* — one did. Reflection archival had
+  fifteen fragments; *Release tag completeness* had six tags its own search could
+  never have created; *Observability archive* had nothing until October.
+
 ## 0.86.2 — 2026-08-25
 
 ### Added — /harness-audit now validates the Status block it writes

--- a/observability/snapshots/2026-08-25-snapshot.md
+++ b/observability/snapshots/2026-08-25-snapshot.md
@@ -1,5 +1,10 @@
 # Harness Health Snapshot — 2026-08-25
 
+> **Revised later the same day**, after the first on-demand `/harness-gc` run and
+> an `/assess`. Sections marked *(revised)* carry the end-of-day state; the rest
+> stand as first written. Two claims made in the morning were falsified by the
+> evening and are corrected in place with the correction shown, not silently.
+
 Generated in quick mode, immediately after a full `/harness-audit` run
 (discovery + enforcement across all 36 constraints + audit). Where the audit
 observed a value directly, this snapshot carries the observed value rather
@@ -42,10 +47,44 @@ design — no application suite). Two template blocks (`Spec conformance`,
 - Last run: 2026-08-24 (scheduled `gc.yml` — **failed**)
 - Cadence compliance: overdue in effect — the job has run weekly on schedule
   and failed on every run since 2026-07-20 (6 consecutive: 07-20, 07-27,
-  08-03, 08-10, 08-17, 08-24), so no rule after step 5 has produced a result
-  in 36 days
-- Findings since last snapshot: 2 confirmed, both discovered by the audit
-  rather than by the GC job itself
+  08-03, 08-10, 08-17, 08-24). *(Revised: the clause that followed — "no rule
+  after step 5 has produced a result in 36 days" — was false, and was
+  generalised from the 08-24 run alone. Per-step conclusions show 07-20 failing
+  at step 8 and 08-17 at step 9, both with steps 5–7 `success`. Five of the six
+  blocked at* Release tag completeness*, not* Snapshot staleness*. Falsified by
+  assay 3 finding-3.)*
+- Findings since last snapshot: **9 confirmed**, from the first on-demand run
+
+### (revised) The investigative layer was not dead — it was largely unbuilt
+
+The morning reading of this section was that a working weekly job had been
+broken for six weeks by step-masking. Running `/harness-gc` Mode 2 falsified
+that. The masking is real and its cost is recorded below, but it is the smaller
+half of the problem.
+
+```text
+19  rules declared active in HARNESS.md
+ 5  have any automation in gc.yml
+14  ran for the first time on 2026-08-25
+ 9  of those 14 produced findings
+```
+
+`gc.yml` carries 11 steps, but three enforce *Constraints* rather than GC rules,
+and one runs *Affordance review staleness*, whose declaring block sits inside an
+HTML comment and parses inactive. So the workflow was never covering the rule
+set even when it was green.
+
+Worse than uncovered: **three of the ten deterministic rules cannot report a
+failure as declared.** *Release tag completeness* uses `grep -oP`, a GNU
+extension; under `/usr/bin/grep` on macOS it prints usage, extracts nothing, and
+exits 0 — a silent pass from a rule that never ran. *Objection record freshness*
+references an unbound `$f` with no enclosing loop and can only ever return
+`rc=1`. *Docs-site strict-build sweep* declares `mkdocs`, which is not on the
+ambient PATH. Filed as #587.
+
+The distinction matters for what fixing this costs. A broken runner is a
+workflow change. A rule set that is 5/19 automated, with 3/10 of its
+deterministic tools structurally incapable of failing, is a body of work.
 
 The GC job fails at step 5 (*Snapshot staleness*) and records steps 6–14
 `skipped`. Only `Summary` carries `if: always()`. Verified on run
@@ -57,9 +96,13 @@ step 9   skipped   GC: Release tag completeness (ai-literacy-superpowers)
 step 13  skipped   GC: Reflection log archival of promoted entries (Path 1)
 ```
 
-Both skipped steps are `Auto-fix: true` rules, and both have unfixed work
-waiting: six untagged releases (`v0.28.1`–`v0.28.5`, `v0.29.1`, verified
-absent on the remote) and fifteen archivable reflection fragments. Those are
+Both skipped steps are `Auto-fix: true` rules. *(Revised: **one** of the three
+auto-fix rules had work waiting, not two. Reflection archival had fifteen
+fragments — since applied. Release tag completeness had six tags its own search
+could never have created, because it greps commit messages for a version string
+that appears only in the diff. Observability archive had nothing and will have
+nothing until October. The masking cost is real and narrower than the count of
+blocked rules implied.)* Those are
 this snapshot's two GC findings, and they are the same defect's bill rather
 than independent problems.
 
@@ -229,9 +272,43 @@ directory has received nothing since the Cadence Sentinels epic.
   nothing because it stops
 - Trend alerts: GC job failing 6 consecutive runs; in-scope specs without an
   objection record rising to 37; without a choice story, 52
-- Health: **Degraded**
+- Health: **Degraded** *(revised — held, not upgraded)*
 
-Health is Degraded rather than Attention because more than one layer is
+### (revised) Why Degraded still holds at end of day
+
+Two of the four grounds closed during the day: the snapshot cadence lapse (this
+file) and the outer-loop overdue on `/assess` (2026-08-25 assessment, Level 4).
+Cadence compliance is now 5/5. On the format reference's own rule — *Attention*
+if one layer is degraded, *Degraded* if multiple are — that arithmetic points at
+Attention.
+
+It is held at **Degraded** anyway, on evidence gathered after the arithmetic:
+
+1. **The investigative layer is not one degraded layer, it is a layer that was
+   never built out.** 5 of 19 rules automated; 3 of 10 deterministic tools
+   unable to fail. Upgrading on the strength of a manual run that surfaced nine
+   findings would be reading the run's *existence* as health rather than its
+   *results*.
+2. **The manual run is not a cadence.** It happened because a human typed a
+   command once. Nothing schedules it, and the scheduled job will fail again at
+   *Release tag completeness* — now for a different reason than in August, since
+   the six tags exist but the rule still verifies a name rather than a release
+   (#578).
+3. **An open CVE was found by a rule that had never run.** `pymdown-extensions`
+   10.21.3 carries a path traversal and a ReDoS reachable in default config,
+   rendered through two workflows on every PR (#586). A habitat that discovers
+   that on its first sweep is not one whose health should improve on the same
+   day.
+
+The upgrade to Attention is available and is deliberately not taken. It becomes
+correct when #586 and #587 close and a scheduled run completes — that is, when
+the layer reports rather than when someone reports for it. Recording the refused
+upgrade is the point: this is the first time the health field has had a reason
+to move and been held.
+
+The original morning reasoning follows, unchanged.
+
+Health was Degraded rather than Attention because more than one layer was
 affected: the investigative loop has not completed a run in 36 days, the
 snapshot cadence had lapsed, four constraints fail, and the outer loop is
 overdue on assessment. None of this is new damage — the audit found all of it


### PR DESCRIPTION
The 2026-08-25 snapshot revised in place with the end-of-day state, after the first on-demand `/harness-gc` run and an `/assess`. Sections marked *(revised)* carry the new state; the rest stand as first written.

## The health field had a reason to move, and was held

Two of the four grounds for `Degraded` closed during the day — the snapshot cadence lapse, and the outer-loop overdue on `/assess`. Cadence compliance reached 5/5. On the format reference's own rule — *Attention* if one layer is degraded, *Degraded* if multiple are — that arithmetic points at **Attention**.

Held at **Degraded** anyway, on evidence gathered after the arithmetic:

1. **The investigative layer was not one degraded layer. It was largely unbuilt.**

   ```text
   19  rules declared active in HARNESS.md
    5  have any automation in gc.yml
   14  ran for the first time on 2026-08-25
    9  of those 14 produced findings
   ```

   And three of the ten deterministic rules **cannot report a failure as declared** (#587): `grep -oP` false-passing under BSD grep with rc=0, an unbound `$f` that can only return `rc=1`, and a declared `mkdocs` that is not on the ambient PATH.

2. **A manual run is not a cadence.** It happened because someone typed a command once. Nothing schedules it, and the scheduled job will fail again at *Release tag completeness*.

3. **An open CVE surfaced from a rule that had never run** (#586). A habitat that discovers a path traversal and a ReDoS on its first sweep should not improve its health the same day.

The upgrade is available and deliberately not taken. It becomes correct when #586 and #587 close and a scheduled run completes — when the layer reports, rather than when someone reports for it.

**Recording a refused upgrade is the point.** This is the first time the health field has had a reason to move and been held.

## Two morning claims the evening falsified

Both corrected in place showing the original and the correction, rather than overwritten:

| Claim | Correction |
| --- | --- |
| "No rule after step 5 has produced a result in 36 days" | False, and generalised from the 08-24 run alone. Per-step conclusions show 07-20 failing at step 8 and 08-17 at step 9, both with steps 5–7 `success`. Five of six blocked at *Release tag completeness*. Falsified by assay 3 finding-3 |
| "Two auto-fix rules had work waiting" | One did. Reflection archival had 15 fragments; *Release tag completeness* had six tags its own search could never have created; *Observability archive* had nothing, and has nothing until October |

## Verification

- All 16 sections present and in order; no deprecated `observatory_metrics` block
- Health field reads `Degraded`; `update-health-badge.sh` run against the snapshot confirms the README badge is already correct and produces no diff
- markdownlint clean

## Exemption

`chore` label at creation. No plugin file changes, so no version bump — the CHANGELOG entry is appended under 0.87.0.
