### PR TITLE
Close two pymdown-extensions CVEs by relaxing the mkdocs-material pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,53 @@ Both corrections show the original and the correction rather than overwriting:
   fifteen fragments; *Release tag completeness* had six tags its own search could
   never have created; *Observability archive* had nothing until October.
 
+### Security — pymdown-extensions CVEs closed by relaxing the mkdocs-material pin
+
+`pymdown-extensions` 10.21.3 carried two known advisories, and the fixed version
+was unreachable at the old pin. See #586.
+
+- **PYSEC-2026-3609** — path traversal in `pymdownx/b64.py::repl_path`. A `src`
+  containing `../` or an absolute path escaped `base_path` with no containment
+  check, base64-inlining any readable file with an image extension into rendered
+  output.
+- **PYSEC-2026-3654** — exponential-backtracking ReDoS (CWE-1333, proposed CVSS
+  3.1 7.5 High) in four inline processors — `caret`, `tilde`, `betterem`,
+  `magiclink` — all reachable in **default** configuration. Both `pages.yml` and
+  `docs-build-check.yml` render this repository's Markdown through them, so on
+  the PR gate the input was any Markdown file in a contributor's branch.
+
+`pymdown-extensions` is transitive and unpinned; `mkdocs-material==9.5.42`
+constrained it to `~=10.2`, so no update to the transitive package alone could
+have reached the fix.
+
+```diff
+-mkdocs-material==9.5.42
++mkdocs-material==9.7.7
+-mkdocs-redirects==1.2.2
++mkdocs-redirects==1.2.3
+```
+
+**Verified rather than assumed**, in a clean venv:
+
+| Check | Before | After |
+| --- | --- | --- |
+| `pip-audit -r requirements.txt` | 2 vulnerabilities in 1 package | **No known vulnerabilities found** |
+| resolved `pymdown-extensions` | 10.21.3 | **11.0.2** |
+| `mkdocs build --strict` | exit 0, 312 pages | exit 0, 312 pages |
+
+The two-minor jump in mkdocs-material changes the rendered output not at all —
+identical page count, identical strict-build result. It does introduce one
+non-fatal MkDocs 2 deprecation notice, which `--strict` does not treat as an
+error and which is suppressible with `DISABLE_MKDOCS_2_WARNING=true` if it
+becomes noise.
+
+**How this was found is the part worth keeping.** *Dependency currency* is an
+agent-enforced GC rule with no workflow step, declared since April and never
+run. There is no `dependabot.yml` and no scheduled dependency scan. Both
+advisories were published against a package this repository has been rendering
+untrusted Markdown through on every pull request, and the first thing that ever
+looked was a garbage-collection sweep someone ran by hand on 2026-08-25.
+
 ## 0.86.2 — 2026-08-25
 
 ### Added — /harness-audit now validates the Status block it writes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mkdocs==1.6.1
-mkdocs-material==9.5.42
-mkdocs-redirects==1.2.2
+mkdocs-material==9.7.7
+mkdocs-redirects==1.2.3
 mkdocs-awesome-pages-plugin==2.10.1


### PR DESCRIPTION
Closes #586.

`pymdown-extensions` 10.21.3 carried two known advisories, and the fixed version was **unreachable at the old pin**.

- **PYSEC-2026-3609** — path traversal in `pymdownx/b64.py::repl_path`. A `src` containing `../` or an absolute path escaped `base_path` with no containment check, base64-inlining any readable file with an image extension into rendered output.
- **PYSEC-2026-3654** — exponential-backtracking ReDoS (CWE-1333, proposed CVSS 3.1 7.5 High) in `caret`, `tilde`, `betterem` and `magiclink` — all reachable in **default** configuration.

Both `pages.yml` and `docs-build-check.yml` render this repository's Markdown through those processors. On the PR gate, the input is any Markdown file in a contributor's branch.

## Why one line, and why that line

`pymdown-extensions` is transitive and unpinned. `mkdocs-material==9.5.42` constrains it to `~=10.2`, so **no update to the transitive package alone could have reached the fix**. `mkdocs-material==9.7.7` relaxes the constraint and admits 11.0.2.

```diff
-mkdocs-material==9.5.42
+mkdocs-material==9.7.7
-mkdocs-redirects==1.2.2
+mkdocs-redirects==1.2.3
```

## Verified in a clean venv, not assumed

| Check | Before | After |
| --- | --- | --- |
| `pip-audit -r requirements.txt` | 2 vulnerabilities in 1 package | **No known vulnerabilities found** |
| resolved `pymdown-extensions` | 10.21.3 | **11.0.2** |
| `mkdocs build --strict` | exit 0, 312 pages | exit 0, 312 pages |

I ran the baseline against the *current* `requirements.txt` first, to confirm the vulnerability actually reproduces here rather than trusting the advisory match — it does, both IDs, same versions.

The two-minor jump changes the rendered output not at all: identical page count, identical strict-build result. It introduces one non-fatal MkDocs 2 deprecation notice, which `--strict` does not treat as an error (exit 0 confirmed) and which is suppressible via `DISABLE_MKDOCS_2_WARNING=true` if it becomes noise.

## How this was found

*Dependency currency* is an agent-enforced GC rule **with no workflow step**, declared since April and never executed. There is no `dependabot.yml` and no scheduled dependency scan.

Both advisories were live against a package rendering repository Markdown on every pull request, and the first thing that ever looked was a garbage-collection sweep run by hand on 2026-08-25 — the first on-demand `/harness-gc` in the repository's history.

That is the argument for #587 and #588 in one sentence: the rule worked the first time it ran, four months after it was declared.

## Follow-up not in this PR

`actions/checkout` is SHA-pinned in 18 places and tag-pinned `@v6` in 2, alongside `setup-python@v6`, `upload-pages-artifact@v5`, `deploy-pages@v5` and `configure-pages@v6`. Outside the letter of *Dependency currency* but inside its intent, and this repository ships a `github-actions-supply-chain` skill. Worth its own decision.

## Exemption

`fix` label at creation, `fix/` branch prefix. No plugin file changes, so no version bump — the CHANGELOG entry is appended under 0.87.0.
