### PR TITLE
Repair three GC tools that could not report a failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,58 @@ advisories were published against a package this repository has been rendering
 untrusted Markdown through on every pull request, and the first thing that ever
 looked was a garbage-collection sweep someone ran by hand on 2026-08-25.
 
+### Fixed — three garbage-collection tools that could not report a failure
+
+`/harness-gc`'s first on-demand run found that three of the ten deterministic GC
+rules were structurally incapable of failing. Not stale, not misconfigured —
+counted among the active nineteen since April, running clean, examining nothing.
+See #587.
+
+**Release tag completeness** used `grep -oP`, a GNU extension. Under
+`/usr/bin/grep` on macOS it prints usage, extracts nothing, and **exits 0** — the
+loop body never runs and the rule reports a clean bill. Replaced with a POSIX
+`sed -n` extraction. Verified under `PATH=/usr/bin:/bin`: the old form extracts
+**0** version headings, the new one extracts **118**, and against a fixture
+carrying an untagged version the new form reports `MISSING: v9.9.9` where the old
+form reports nothing.
+
+This was the third recurrence of the BSD/GNU pattern, landing outside the fence
+built for it — *Layer 0 bash tests run on macOS and Linux* scopes to Layer 0 bash
+scripts, not to rule tools declared inline in `HARNESS.md`.
+
+**Objection record freshness** referenced an unbound `$f` with no enclosing loop.
+Run verbatim, `$f` expanded empty, the `-newer` operand became
+`docs/superpowers/objections/.md`, `find` errored into suppressed stderr, and
+`grep .` matched nothing — `rc=1`, always, regardless of state. Replaced with a
+loop that binds its variable and compares **git commit dates** rather than
+filesystem mtimes, which are identical on a fresh clone and would have made the
+comparison meaningless in CI. It now reports 12 records.
+
+**Docs-site strict-build sweep** declared `mkdocs build --strict`, and `mkdocs` is
+not on the ambient PATH — a bare `/harness-gc` got a shell "command not found"
+rather than a result. The tool now checks for the binary first and fails with a
+named reason and a remedy. Absence of the tool reads as failure, not as silence.
+
+### Repair, not a rule change
+
+**What it checks**, **Enforcement**, **Frequency** and **Auto-fix** are byte-identical
+for all three. Only the Tool implementation moved, and in every case because the
+declared implementation could not execute. This is treated as repair rather than
+a governed change on the grounds that the harness evolution loop exists to
+restrain rules *entering force*, not to gate a portability bug in an existing
+rule's implementation.
+
+### Known limitation, deliberately not fixed here
+
+*Objection record freshness* now reports 12 stale records, and most are
+metadata-only post-merge edits rather than design changes — seven are
+cadence-sentinels specs all last touched by `1133b9c` (#518), a provenance fix.
+The rule as declared compares timestamps and has no discriminator for "design
+content changed". Adding one would change what the rule checks, which is a
+governed decision rather than a repair, so the over-firing is recorded and left.
+Four objection records also have no date-prefixed spec and the rule is silent on
+them by construction.
+
 ## 0.86.2 — 2026-08-25
 
 ### Added — /harness-audit now validates the Status block it writes

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -733,7 +733,7 @@ Use /governance-constrain for guided authoring of governance constraints.
   has a corresponding `vX.Y.Z` git tag
 - **Frequency**: weekly
 - **Enforcement**: deterministic
-- **Tool**: for v in $(grep -oP '(?<=^## )\d+\.\d+\.\d+' CHANGELOG.md); do git tag -l "v$v" | grep -q "v$v" || echo "MISSING: v$v"; done
+- **Tool**: for v in $(sed -n 's/^## \([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' CHANGELOG.md); do git tag -l "v$v" | grep -q "v$v" || echo "MISSING: v$v"; done
 - **Auto-fix**: true (creates missing tags pointing at the merge
   commit that introduced the version heading)
 
@@ -839,7 +839,7 @@ Use /governance-constrain for guided authoring of governance constraints.
   changes after code-time review produce a stale code-mode record.
 - **Frequency**: weekly
 - **Enforcement**: deterministic
-- **Tool**: find docs/superpowers/specs -name "*.md" -newer docs/superpowers/objections/$(basename "$f" .md | sed 's/^[0-9-]*-//').md 2>/dev/null | grep .
+- **Tool**: for o in docs/superpowers/objections/*.md; do [ -f "$o" ] || continue; slug=$(basename "$o" .md); slug=${slug%-code}; spec=$(ls docs/superpowers/specs/*-"$slug".md 2>/dev/null | head -1); [ -n "$spec" ] || continue; so=$(git log -1 --format=%ct -- "$o"); ss=$(git log -1 --format=%ct -- "$spec"); [ -n "$so" ] && [ -n "$ss" ] && [ "$ss" -gt "$so" ] && echo "STALE: $o"; done; exit 0
 - **Auto-fix**: false
 
 <!-- Uncomment if governance constraints are declared above:
@@ -976,7 +976,7 @@ Run /governance-audit quarterly to keep governance constraints fresh.
   model-cards plugin already follows this.
 - **Frequency**: weekly
 - **Enforcement**: deterministic
-- **Tool**: `mkdocs build --strict --quiet --site-dir /tmp/mkdocs-gc-check 2>&1 >/dev/null; rc=$?; rm -rf /tmp/mkdocs-gc-check; exit $rc`
+- **Tool**: `command -v mkdocs >/dev/null 2>&1 || { echo "MISSING TOOL: mkdocs not on PATH — pip install -r requirements.txt"; exit 1; }; mkdocs build --strict --quiet --site-dir /tmp/mkdocs-gc-check >/dev/null 2>&1; rc=$?; rm -rf /tmp/mkdocs-gc-check; exit $rc`
 - **Auto-fix**: false
 
 ---


### PR DESCRIPTION
Closes #587.

Three of the ten deterministic GC rules were **structurally incapable of reporting a failure** — not stale, not misconfigured. Counted among the active nineteen since April, running clean, examining nothing.

## Release tag completeness

`grep -oP` is a GNU extension. Under `/usr/bin/grep` on macOS it prints usage, extracts nothing, and **exits 0** — the loop body never runs and the rule reports a clean bill.

```diff
-for v in $(grep -oP '(?<=^## )\d+\.\d+\.\d+' CHANGELOG.md); do ...
+for v in $(sed -n 's/^## \([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' CHANGELOG.md); do ...
```

Verified under `PATH=/usr/bin:/bin`:

| | old | new |
| --- | --- | --- |
| version headings extracted | **0** | **118** |
| against a fixture with an untagged version | reports nothing | `MISSING: v9.9.9` |

That second row is the point of the issue: the new tool was tested for its ability to **fail**, not just to run.

Third recurrence of the BSD/GNU pattern, landing outside the fence built for it — *Layer 0 bash tests run on macOS and Linux* scopes to Layer 0 bash scripts, not to rule tools declared inline in HARNESS.md.

## Objection record freshness

`$f` was unbound with no enclosing loop. Run verbatim, it expanded empty, the `-newer` operand became `docs/superpowers/objections/.md`, `find` errored into suppressed stderr, and `grep .` matched nothing — **`rc=1`, always, regardless of state.**

Replaced with a loop that binds its variable and compares **git commit dates** rather than filesystem mtimes. That second choice matters: mtimes are identical on a fresh clone, so an mtime comparison would be meaningless anywhere except the machine that authored the files. It now reports 12 records.

## Docs-site strict-build sweep

Declared `mkdocs build --strict`; `mkdocs` is not on the ambient PATH, so a bare `/harness-gc` got a shell "command not found" rather than a result. Now:

```bash
command -v mkdocs >/dev/null 2>&1 || { echo "MISSING TOOL: mkdocs not on PATH — pip install -r requirements.txt"; exit 1; }
```

Absence of the tool reads as failure with a named reason and a remedy, rather than as silence — which is the principle the rule currently in force is about.

## Repair, not a rule change

**What it checks**, **Enforcement**, **Frequency** and **Auto-fix** are byte-identical for all three. Only the Tool implementation moved, and in every case because the declared implementation could not execute.

Treated as repair rather than a governed change on the grounds that the harness evolution loop exists to restrain rules *entering force*, not to gate a portability bug in an existing rule's implementation. Say if you'd rather it went through `/harness-assay` → `/harness-propose` → `/harness-accept`; the argument the other way is real, and this is the kind of edit CLAUDE.md warns turns a governing document into the least governed thing in the repository.

## Known limitation, deliberately left

*Objection record freshness* now reports 12 stale records, and **most are metadata-only post-merge edits** — seven are cadence-sentinels specs all last touched by `1133b9c` (#518, a provenance fix). The rule as declared compares timestamps and has no discriminator for "design content changed".

Adding one would change *what the rule checks*, which is a governed decision rather than a repair. Recorded and left. Four objection records also have no date-prefixed spec and the rule is silent on them by construction — including the four written today, which follow a different naming convention.

## Verification

All three executed straight out of `HARNESS.md` under `PATH=/usr/bin:/bin`, by extracting the Tool field and running it verbatim. Convention parity 36/36, `harness check` OK, markdownlint clean.

## Exemption

`fix` label at creation, `fix/` branch prefix. No plugin file changes — `HARNESS.md` is at the repository root — so no version bump.
