### PR TITLE
Harness health: Degraded to Attention, ahead of Monday's scheduled run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -374,6 +374,50 @@ dispositions pending, and two merged specs cite it as their evidence base.
 That is the constraint working, and merging a knowingly-red gate is how a red
 check becomes normal. The adjudication comes first; the promotion follows it.
 
+### Harness health: Degraded → Attention, on work rather than arithmetic
+
+Re-run ahead of Monday's scheduled GC job. Each of the three reasons for
+refusing this upgrade at 16:00 has been answered:
+
+| Held at 16:00 because | Now |
+| --- | --- |
+| the investigative layer was never built out | masking repaired in both workflows; three GC tools that could not fail repaired and fixture-tested. **Partly** — 5 of 19 GC rules still have automation |
+| a manual run is not a cadence | still true, and now *testable*: Monday is the first unassisted run since 2026-07-13 |
+| an open CVE surfaced from a rule that had never run | closed — `pip-audit` reports no known vulnerabilities |
+
+And the enforcement figure stopped overstating: **30/36, every one able to fire**,
+where 35/36 counted ten constraints nothing could dispatch.
+
+**Why not Healthy**, named rather than felt: the scheduled run has not happened —
+every completed GC run today was hand-triggered — and two constraints remain
+`agent` with no dispatch path, blocked behind 12 pending dispositions in
+`harness-provenance-citation.md`.
+
+### The badge writer picked the wrong state, again
+
+Writing the revised Health line surfaced a second defect in
+`update-health-badge.sh`, four commits after #575 fixed the first. Its `case`
+substring-matches the whole line and tests `*Degraded*` first, so:
+
+```markdown
+- Health: **Attention** *(revised twice — held at Degraded at 16:00, upgraded…)*
+```
+
+produced a **`Degraded`** badge. The word appears in an annotation describing the
+*previous* state.
+
+It failed in the safe direction here. Reversed it would not: a line reading
+`- Health: **Degraded** *(was Healthy last month)*` produces a green badge on a
+degraded habitat, because the ordering that saved us is an accident rather than a
+safety property.
+
+Filed as #595. The matcher answers "does this line contain a state word?" rather
+than "what is this line's value?" — the same shape as the three GC tools in #587
+and the parity gate that compares headings but not values. **Fourth instance in a
+day, and the second in this one script.** The snapshot line was rewritten to avoid
+naming other states, which is a workaround in the data and will not survive the
+next person writing a natural sentence.
+
 ## 0.86.2 — 2026-08-25
 
 ### Added — /harness-audit now validates the Status block it writes

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Agents](https://img.shields.io/badge/Agents-22-2E8B57?style=flat-square)](#agents-22)
 [![Commands](https://img.shields.io/badge/Commands-39-2E8B57?style=flat-square)](#commands-39)
 [![Harness](https://img.shields.io/badge/Harness-35%2F36_enforced-B8860B?style=flat-square)](HARNESS.md)
-[![Harness Health](https://img.shields.io/badge/Harness_Health-Degraded-DC143C?style=flat-square)](observability/snapshots/2026-08-25-snapshot.md)
+[![Harness Health](https://img.shields.io/badge/Harness_Health-Attention-DAA520?style=flat-square)](observability/snapshots/2026-08-25-snapshot.md)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
 [![Copilot CLI](https://img.shields.io/badge/Copilot_CLI-Plugin-000000?style=flat-square&logo=githubcopilot&logoColor=white)](https://github.com/features/copilot)
 [![Agent Harness Enabled](https://img.shields.io/badge/Agent_Harness-Enabled-000000?style=flat-square)](HARNESS.md)

--- a/observability/snapshots/2026-08-25-snapshot.md
+++ b/observability/snapshots/2026-08-25-snapshot.md
@@ -1,9 +1,14 @@
 # Harness Health Snapshot — 2026-08-25
 
-> **Revised later the same day**, after the first on-demand `/harness-gc` run and
-> an `/assess`. Sections marked *(revised)* carry the end-of-day state; the rest
-> stand as first written. Two claims made in the morning were falsified by the
-> evening and are corrected in place with the correction shown, not silently.
+> **Revised twice the same day.** First after the on-demand `/harness-gc` run and
+> the `/assess`; again at end of day after the masking repair, the CVE fix, the GC
+> tool repairs and the enforcement-figure correction. Sections marked *(revised)*
+> carry the latest state; the rest stand as first written. Three claims made
+> earlier in the day were falsified later in it and are corrected in place with
+> the correction shown, not silently.
+>
+> **Health moved Degraded → Attention at the second revision.** The reasoning is
+> in `## Meta`, including what was refused at the first revision and what changed.
 
 Generated in quick mode, immediately after a full `/harness-audit` run
 (discovery + enforcement across all 36 constraints + audit). Where the audit
@@ -17,8 +22,8 @@ records that exist but are not yet merged.
 
 ## Enforcement
 
-- Constraints: 35/36 enforced (97%)
-- Deterministic: 25 | Agent: 10 | Unverified: 1
+- Constraints: 30/36 enforced (83%) *(revised)*
+- Deterministic: 26 | Agent: 4 | Unverified: 6
 - Drift detected: yes
 
 Read the ratio narrowly. It counts **declared** enforcement, which is the
@@ -272,9 +277,45 @@ directory has received nothing since the Cadence Sentinels epic.
   nothing because it stops
 - Trend alerts: GC job failing 6 consecutive runs; in-scope specs without an
   objection record rising to 37; without a choice story, 52
-- Health: **Degraded** *(revised — held, not upgraded)*
+- Health: **Attention** *(revised twice; see below for what was held and why)*
 
-### (revised) Why Degraded still holds at end of day
+### (revised, end of day) Why this is now Attention
+
+The hold recorded below was correct when written and is no longer. Each of the
+three reasons for refusing the upgrade has been answered by work, not by
+arithmetic:
+
+1. **"The investigative layer was never built out."** Partly answered. The
+   masking defect is repaired — `gc.yml` carries a guard on all 11 enforcing
+   steps under `!cancelled()`, `harness.yml` on all 9 under `always()`, and both
+   derive the job conclusion from collected outcomes with a third state for a
+   step that did not run. Three deterministic GC tools that were structurally
+   incapable of failing are repaired and tested against fixtures that make them
+   fail. **Not fully answered:** 5 of 19 GC rules still have automation; the
+   other 14 run only when a human types `/harness-gc`.
+2. **"A manual run is not a cadence."** Still true, and now testable. Monday's
+   scheduled cron is the first unassisted run since 2026-07-13, and it will run
+   against repaired tools and a job that reports per-step. That is the evidence
+   `Healthy` should wait for.
+3. **"An open CVE was found by a rule that had never run."** Closed. Two
+   `pymdown-extensions` advisories, remediated by relaxing the `mkdocs-material`
+   pin; `pip-audit` reports no known vulnerabilities.
+
+And the enforcement figure is no longer overstating: 35/36 counted ten
+constraints declared `agent` that nothing could dispatch. One was promoted to
+`deterministic` with a real check, five demoted to `unverified`. **30/36, and
+every one of the 30 can fire.**
+
+**Why not Healthy.** Two things, both named rather than felt. The scheduled run
+has not happened — every completed GC run today was hand-triggered. And two
+constraints (*PRs have adjudicated objections*, *PRs have adjudicated choice
+stories*) remain `agent` with no dispatch path, blocked behind 12 pending
+dispositions in `harness-provenance-citation.md`. A deterministic check for their
+schema half is written and verified, and was deliberately not shipped because it
+fails on that record — which is the constraint working, not a reason to merge it
+red.
+
+### (superseded, 16:00) Why Degraded was held at the first revision
 
 Two of the four grounds closed during the day: the snapshot cadence lapse (this
 file) and the outer-loop overdue on `/assess` (2026-08-25 assessment, Level 4).


### PR DESCRIPTION
`/harness-health` re-run ahead of Monday's scheduled GC job.

## Degraded → Attention

Each of the three reasons for refusing this upgrade at 16:00 has been answered by work, not by arithmetic:

| Held at 16:00 because | Now |
| --- | --- |
| the investigative layer was never built out | masking repaired in both workflows (11/11 and 9/9 steps guarded, three-state aggregation); three GC tools that could not fail repaired and fixture-tested. **Partly answered** — 5 of 19 GC rules still have automation |
| a manual run is not a cadence | still true, and now *testable*. Monday's cron is the first unassisted run since 2026-07-13, against repaired tools and a job that reports per-step |
| an open CVE surfaced from a rule that had never run | **closed** — `pip-audit` reports no known vulnerabilities |

And the enforcement figure stopped overstating:

```text
before   25 deterministic + 10 agent + 1 unverified   35/36
after    26 deterministic +  4 agent + 6 unverified   30/36   every one able to fire
```

## Why not Healthy

Named rather than felt:

1. **No scheduled run has happened.** Every completed GC run today was hand-triggered. Monday is the evidence `Healthy` should wait for.
2. **Two constraints remain `agent` with no dispatch path** — *PRs have adjudicated objections* and *PRs have adjudicated choice stories* — blocked behind 12 pending dispositions in `harness-provenance-citation.md`. A deterministic check for their schema half is written and verified, and deliberately unshipped because it fails on that record.

## The badge writer picked the wrong state, again

Writing the revised Health line surfaced a **second defect in `update-health-badge.sh`**, four commits after #575 fixed the first. Its `case` substring-matches the whole line and tests `*Degraded*` first, so:

```markdown
- Health: **Attention** *(revised twice — held at Degraded at 16:00, upgraded…)*
```

wrote a **`Degraded`** badge. The word appears only in an annotation describing the *previous* state.

It failed in the safe direction here. Reversed it does not: `- Health: **Degraded** *(was Healthy last month)*` produces a green badge on a degraded habitat, because the ordering that saved us is an accident rather than a safety property.

Filed as **#595**. The matcher answers *"does this line contain a state word?"* rather than *"what is this line's value?"* — the same shape as the three GC tools in #587 and the parity gate that compares headings but not values. **Fourth instance in a day, second in this one script.**

The snapshot's Health line was rewritten to avoid naming other states. That is a workaround in the data, not a fix in the tool, and it will not survive the next person writing a natural sentence.

## Verification

16 sections present and in order; no deprecated `observatory_metrics` block; health field reads `Attention`; badge regenerated from the snapshot and now matches; markdownlint clean.

## Exemption

`chore` label at creation. No plugin file changes, so no version bump — the CHANGELOG entry is appended under 0.87.0.
