### PR TITLE
Docs: catch up with the evolution loop's first full cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -374,6 +374,47 @@ dispositions pending, and two merged specs cite it as their evidence base.
 That is the constraint working, and merging a knowingly-red gate is how a red
 check becomes normal. The adjudication comes first; the promotion follows it.
 
+### Docs — the evolution loop ran a full cycle and the docs catch up
+
+Five gaps, closed. See #597.
+
+- **`proposed_rule` documented.** Added to the schema on 2026-08-25 and written
+  down nowhere. `reference/harness-decision-records.md` now carries it in the
+  fields table and in a new **`proposed_*` pair** section naming all three
+  instances — `proposed_cost`/`cost`, `proposed_target`/`target`,
+  `proposed_rule`/`## Rule` — with the reason they exist stated once: two people
+  contribute to a record and a reader should be able to tell which part came from
+  whom.
+- **The fields table listed one provenance key when there were three.** Fixed;
+  `proposed_target` was previously only in prose.
+- **The decline path is in the how-to.** `--reject --reason-file` produced 2 of
+  the 6 records in this corpus and appeared in no page a reader follows.
+  `record-a-governance-change.md` now has a step for it, including why the reason
+  is supplied up front and never as a placeholder, and why a rejection matters to
+  a *later* assay: without it, a recurring problem and an already-adjudicated one
+  are indistinguishable.
+- **The errata channel is in `assay-a-phase.md`.** Corrections go in a sibling
+  record, `/harness-propose` refuses on a corrected finding until acknowledged,
+  and a corrected finding stops counting toward the two-assay threshold. That
+  third point decided an outcome today and was documented only in reference.
+
+### And the thing the day actually taught
+
+`explanation/harness-evolution.md` gains a section on the incentive the two-assay
+threshold creates:
+
+> A repaired defect cannot be re-observed. So the cheapest route to promoting any
+> finding is: observe a defect, do not fix it, observe it again next cycle.
+
+Raised as an objection against one record on 2026-08-25 and decisive on a
+different one the same day. The section carries the worked example — a masking
+defect repaired directly and its rule declined, because fixing it foreclosed the
+only route to corroboration — and what to take from it: fix the defect, say in the
+record why the rule was declined, and let a rule earn its place when a repair
+*fails to hold* rather than when a defect is held open to satisfy a threshold.
+
+`mkdocs build --strict` passes.
+
 ### Harness health: Degraded → Attention, on work rather than arithmetic
 
 Re-run ahead of Monday's scheduled GC job. Each of the three reasons for

--- a/docs/plugins/ai-literacy-superpowers/explanation/harness-evolution.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/harness-evolution.md
@@ -92,6 +92,59 @@ cannot win a slot twice running probably was not worth a rule.
 resolves to `no-change` is a successful assay. Without this, the mechanism
 rewards finding something, and an agent that must find something will.
 
+## The incentive the threshold creates, and what to do about it
+
+The two-assay threshold makes a rule hard to add: a change to `HARNESS.md` needs
+evidence from two distinct assays, so a single incident cannot reach the layer
+that governs the loop. That is the right shape, and it has a consequence nobody
+designed.
+
+**A repaired defect cannot be re-observed.** So the cheapest route to promoting
+any finding is: observe a defect, *do not fix it*, observe it again next cycle,
+cite both assays. The threshold starts rewarding unrepaired defects over repaired
+ones — the exact inversion of what a harness is for.
+
+This is not hypothetical. It was raised as an objection against one record on
+2026-08-25 and decided the outcome of a different one the same day.
+
+### The worked example
+
+A defect in this repository's own CI made a failing step discard every step after
+it. Six consecutive weekly runs reported one failure and up to nine unknowns, and
+two auto-fix rules sat behind the failure for six weeks.
+
+An assay found it. A rule was proposed requiring every enforcing step to report,
+classified `harness-loop` because that is the layer that owns the behaviour. It
+held evidence from one countable assay against a threshold of two, because the
+other assay that had observed the same defect carried an erratum on that finding.
+
+The route to a second observation was a fourth assay finding the masking **still
+present**. Which meant: to get the rule, leave the defect standing.
+
+The defect was repaired instead, and the rule declined. The rejection record says
+why, and states the cost rather than hiding it — *there is no regression guard;
+nothing prevents a future workflow adding an unguarded step*.
+
+### What to take from it
+
+**Fixing the defect is almost always right.** A rule is a claim about the future;
+a repair is a change to the present. Trading a present repair for a future
+guarantee is a bad trade when the guarantee costs you the repair.
+
+**Say so in the record.** A finding declined because its defect was fixed is not
+the same as a finding declined because it was wrong, and a later assay reading the
+corpus needs to tell them apart. The rejection is where that distinction lives.
+
+**The precedent is older than the mechanism.** The first assay this repository ran
+declined its own finding-1 while the underlying defect was fixed anyway. The next
+assay recorded the outcome plainly: *"the transcription fix travelled and the rule
+did not need to."*
+
+**A rule earns its place when the defect recurs after a repair.** That is the
+honest corroboration — not a defect held open to satisfy a threshold, but a fix
+that did not hold. If the repair sticks, the rule was never needed. If it does
+not, the second assay has something real to say.
+
 ## The enforcement gap is the point
 
 `harness/enforcement-report.md` states, for every rule on every surface, the

--- a/docs/plugins/ai-literacy-superpowers/how-to/assay-a-phase.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/assay-a-phase.md
@@ -66,6 +66,45 @@ overfitting to this project. A finding killed here stays in the report as a
 rejected candidate, which is exactly where it belongs: the next assay can see
 that it was considered and why it lost.
 
+## 3b. Correcting an assay you have already written
+
+Assays are append-only and are never edited — they record what an agent observed
+at a moment, and editing one destroys the thing that makes it evidence. When a
+finding turns out to be wrong, the correction goes in a **sibling errata record**:
+
+```bash
+python3 ai-literacy-superpowers/scripts/harness-registrar.py correct \
+  --assay harness/assay/<timestamp>-assay.md \
+  --finding finding-N \
+  --correction-file <path>
+```
+
+That writes `harness/assay/<timestamp>-assay.errata.md`. One section per
+corrected finding; a later correction to the same finding is appended, never
+substituted. Neither file is edited.
+
+Three consequences worth knowing before you need them:
+
+1. **`/harness-propose` refuses on a corrected finding.** It quotes the
+   correction and proceeds only with `--acknowledge-correction`. That is a
+   refusal rather than a warning, because a warning from a command that just
+   succeeded is a warning nobody reads, and the record it produces is frozen.
+2. **A corrected finding stops counting toward the two-assay threshold.** The
+   threshold exists so a single incident cannot reach the loop layer, and
+   corroboration by an observation that was wrong is not corroboration.
+3. **The exclusion is per finding, not per assay.** An assay may hold six
+   findings and be wrong about one.
+
+Point 2 is load-bearing and has already decided an outcome in this repository: a
+`harness-loop` record could not clear the threshold because one of its two cited
+assays carried an erratum on the finding it cited.
+
+**There is deliberately no pointer inside the assay.** Adding one would require
+editing the record, and a mechanism that pressures anyone to edit an append-only
+document is worse than the gap it closes. Discovery is met by a sibling with a
+predictable name and by refusals at the two points where a correction changes what
+you should do.
+
 ## 4. Propose the ones you want
 
 ```bash

--- a/docs/plugins/ai-literacy-superpowers/how-to/record-a-governance-change.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/record-a-governance-change.md
@@ -51,6 +51,39 @@ bureaucracy: a change that reaches beyond a single agent has to argue why it
 belongs at that layer, and neither the Assayer nor the Registrar is entitled to
 make that argument for you.
 
+## 2b. Or decline it
+
+A finding does not have to become a rule. Declining is a first-class outcome
+with its own record, and it is the right one whenever the finding is real but the
+rule is not — pointed at the wrong problem, owned by a constraint that already
+exists, or aimed at a defect you are about to repair directly.
+
+```bash
+/harness-propose <assay-path> <finding-id> --reject --reason-file <path>
+```
+
+The reason is supplied **up front, in a file, and never as a placeholder**. A
+rejection has no later gate — it is written at `rejected` and never accepted — so
+a `TODO` would sit in the corpus permanently recording that someone said no and
+nothing about why.
+
+A rejection costs one section. It carries `## Finding` and a non-empty
+`## Rejection`, and nothing else: no `## Rule` because nothing enters force, no
+`cost` key because nothing is demanded, and no tier-2 sections because no layer
+is being argued for.
+
+It reaches no artifact, consumes no cycle slot, and stays out of
+`/harness-timeline`. It appears in `harness/decisions/index.md` with state
+`rejected`.
+
+**Why this matters more than tidiness.** A later assay reads prior assays and
+will re-find the same class of problem. Without a rejection record it cannot
+distinguish a recurring problem from one already adjudicated — which is the
+distinction the two-assay promotion threshold turns on. Corroboration by a
+finding that was already refused is not corroboration.
+
+Two of the six records in this repository's own corpus are rejections.
+
 ## 3. Accept
 
 ```bash

--- a/docs/plugins/ai-literacy-superpowers/reference/harness-decision-records.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/harness-decision-records.md
@@ -162,13 +162,35 @@ cohort: b                  # optional
 | `expires` **or** `review_trigger` | `provisional: true` | `provisional: true` |
 | `target` | when the classification has no route | `status: accepted` |
 | `validator` | optional | — |
-| `cohort`, `proposed_cost`, `imported` | optional | — |
+| `cohort`, `imported` | optional | — |
+| `proposed_cost`, `proposed_target`, `proposed_rule` | optional | — |
 | `overfitting_risk` | optional | — |
 
 **`target`** names the artifact the rule text is written into, and is required at
 **acceptance** for `agent-instruction`, `agent-reference`, `regression-test` and
 `new-agent`. `harness-loop`, `turn-instructions` and `script-validator` have
 fixed routes in `surfaces.yaml` and need no target of their own.
+
+### The `proposed_*` pair
+
+Three fields come in pairs, and they exist for one reason: **two people
+contribute to a record, and a reader should be able to tell which part came from
+whom.**
+
+| Assayer's value | Approver's value | Set at | Why the pair exists |
+| --- | --- | --- | --- |
+| `proposed_cost` | `cost` | acceptance | The Assayer estimates; the approver writes what they are taking on, in their own words. A rule enters force on a cost a person wrote |
+| `proposed_target` | `target` | acceptance, via `--target` | The Assayer frequently identifies a behaviour without knowing which artifact should own it. That is the approver's call, made at the gate beside the cost |
+| `proposed_rule` | the `## Rule` block | before acceptance | Rule text is copied verbatim from an append-only assay. Where an accepted objection requires the text to change, the original is preserved here so the amended rule does not read as the Assayer's words |
+
+`proposed_rule` was added on 2026-08-25, when accepted objections required rule
+text to be amended on three records before the gate. Without it an amendment
+diverges silently from the assay it claims to quote — every other place two
+people contribute to a record keeps them distinguishable, and rule text was the
+one that did not.
+
+Only fill a `proposed_*` field when the two values actually differ. A record
+where the Assayer's value stood unchanged carries the value once.
 
 **A target must be a markdown artifact (`.md`).** Rule text is markdown and is
 applied verbatim, so the artifact that *hosts* a rule has to be one that can hold


### PR DESCRIPTION
Closes #597. Five gaps, closed. `mkdocs build --strict` passes.

## 1–2. The schema debt, created today

`proposed_rule` was added to the record schema on 2026-08-25 — so an amended rule would not read as the Assayer's words — and written down nowhere. It exists in three records.

`reference/harness-decision-records.md` now carries it in the fields table, alongside a new **`proposed_*` pair** section that names all three instances and states the reason once:

| Assayer's value | Approver's value | Why the pair exists |
| --- | --- | --- |
| `proposed_cost` | `cost` | a rule enters force on a cost a person wrote |
| `proposed_target` | `target` | the Assayer often cannot know which artifact owns a behaviour |
| `proposed_rule` | the `## Rule` block | rule text is verbatim from an append-only assay; an amendment must not diverge silently |

`proposed_target` was previously only in prose, so the table listed one provenance key when there were three.

## 3. The decline path

`--reject --reason-file` produced **2 of the 6 records** in this corpus and appeared in no page a reader follows. `record-a-governance-change.md` now has a step for it, covering the record's shape (no `## Rule`, no `cost`, a mandatory `## Rejection`), why the reason is supplied up front and never as a placeholder, and the part that matters to a *later* assay:

> Without a rejection record it cannot distinguish a recurring problem from one already adjudicated — which is the distinction the two-assay threshold turns on.

## 4. The errata channel

`assay-a-phase.md` — the how-to for the command that *produces* assays — did not mention that assays can be corrected. It now covers the sibling record, the propose-time refusal, and the consequence that decided an outcome today:

> A corrected finding stops counting toward the two-assay threshold.

`workflow-step-masking` could not clear the threshold precisely because assay 1's finding-2 carries an erratum.

## 5. The thing the day actually taught

`explanation/harness-evolution.md` gains a section on the incentive the threshold creates:

> **A repaired defect cannot be re-observed.** So the cheapest route to promoting any finding is: observe a defect, *do not fix it*, observe it again next cycle. The threshold starts rewarding unrepaired defects over repaired ones — the exact inversion of what a harness is for.

Raised as objection **O2** against one record in the morning; decisive on a **different** record by evening. The section carries the worked example — the masking defect repaired directly and its rule declined, because fixing it foreclosed the only route to corroboration — and four conclusions:

- Fixing the defect is almost always right; trading a present repair for a future guarantee is a bad trade when the guarantee costs you the repair
- Say in the record *why* it was declined — a finding declined because its defect was fixed is not the same as one declined because it was wrong
- The precedent predates the mechanism: assay 1 declined its own finding-1 while the defect was fixed anyway
- **A rule earns its place when the defect recurs after a repair** — that is honest corroboration, not a defect held open to satisfy a threshold

This is the one I'd have most regretted losing. It was discovered by argument, confirmed by events four hours later, and lived only in a PR body and a rejection record.

## Not in scope

The tutorial's narrative arc. It walks propose → accept → *expect to be refused*, which is still pedagogically right and nothing today invalidated it.

## Exemption

`chore/` branch prefix. Docs only, outside the plugin directory, so no version bump — the CHANGELOG entry is appended under 0.87.0.
