### PR TITLE
Add /harness-board — render the loop as a queue with an unblock action per item

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.87.0",
+  "plugin_version": "0.88.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.87.0"
+      "version": "0.88.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,60 @@
 # Changelog
 
+## 0.88.0 — 2026-08-25
+
+### Added — `/harness-board`, because "what is blocked" took three commands to answer
+
+On 2026-08-25 the evolution loop ran end to end for the first time. Answering
+*"what is blocked, and on what"* took running `precheck` three times, reading two
+objection records, and hand-computing a two-assay threshold — while every one of
+those answers already existed in machine-readable form.
+
+The sharper failure was not the absence of an overview. It was that one could
+report **that** three proposals were stalled but not **why each differed**, and
+the three blockers turned out to be entirely different: missing tier-2 sections,
+a threshold refusal, and two undecided rule-text amendments.
+
+```text
+PROPOSALS
+  2026-08-25-command-cli-parity          precheck: clean
+      → gate-ready. Remaining: the cost, written at /harness-accept
+  2026-08-25-workflow-step-masking       precheck: REFUSED
+      → a harness-loop change requires evidence from at least two
+        distinct assays, found 1
+```
+
+Five sections ordered by closeness to a gate — assays, proposals, in force,
+accepted-but-not-binding, objections awaiting disposition — plus `--timeline` for
+interventions over time.
+
+### Three properties that are load-bearing, not incidental
+
+**It quotes `precheck` rather than reimplementing the refusal.** Two
+implementations diverge, and the divergence favours the board because the board is
+what someone reads — a record would be refused at the gate while the board called
+it ready.
+
+**It never omits what it cannot classify.** A record with no `status`, or an
+unrecognised one, appears under `UNCLASSIFIED` with its path. Verified
+adversarially against seeded malformed records. A board that drops what it cannot
+parse reports a smaller world than it checked, and a board is the worst place to
+reproduce that, because it is the thing you would use to notice.
+
+**It distinguishes in force from accepted.** The first implementation listed a
+superseded record under IN FORCE — `status: accepted` is not the same as binding,
+since a superseded rule and a retirement are both accepted and neither binds. Now
+read from the registrar's derived state rather than recomputed, which is the same
+principle as quoting `precheck`.
+
+### And it stores nothing
+
+There is deliberately no `BOARD.md`. A file that must be regenerated becomes a
+file that is stale, and the 2026-08-25 assessment found exactly that: two stored
+dashboards, 106 days old, read by nobody. A third with a fresher date would be the
+same mistake. `git status` is unchanged after a run, asserted rather than assumed.
+
+Ships with a spec, a Layer 1 structural scenario, a reference entry and a how-to.
+
 ## 0.87.0 — 2026-08-25
 
 ### The first rule enters force through the governed loop

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.87.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.88.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-42-2E8B57?style=flat-square)](#skills-42)
 [![Agents](https://img.shields.io/badge/Agents-22-2E8B57?style=flat-square)](#agents-22)
-[![Commands](https://img.shields.io/badge/Commands-39-2E8B57?style=flat-square)](#commands-39)
+[![Commands](https://img.shields.io/badge/Commands-40-2E8B57?style=flat-square)](#commands-40)
 [![Harness](https://img.shields.io/badge/Harness-35%2F36_enforced-B8860B?style=flat-square)](HARNESS.md)
 [![Harness Health](https://img.shields.io/badge/Harness_Health-Attention-DAA520?style=flat-square)](observability/snapshots/2026-08-25-snapshot.md)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.87.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 39 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.88.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **42 skills, 22 agents, 40 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 
@@ -296,7 +296,7 @@ sentinels** guard the shape of the work around those decisions: the
 | assessor | AI literacy assessment — scans repo, asks questions, applies fixes, recommends workflow changes | Read + Write |
 | governance-auditor | Governance specialist — semantic drift analysis, debt inventory, three-frame alignment | Read + limited Write |
 
-### Commands (39)
+### Commands (40)
 
 | Command | What it does |
 | ------- | ------------ |

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.87.0",
+  "version": "0.88.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/commands/harness-board.md
+++ b/ai-literacy-superpowers/commands/harness-board.md
@@ -1,0 +1,90 @@
+---
+name: harness-board
+description: Render the harness evolution loop as a queue — every assay, proposal, record and objection in flight, with the concrete next action for each. Read-only; writes nothing. Pass --timeline for interventions over time instead.
+---
+
+# /harness-board
+
+Show what is in flight in the evolution loop, and what unblocks each item.
+
+Read-only. It writes no file and exits non-zero only on its own failure, never on
+the state of the corpus. The board reports; it does not gate.
+
+## When to use
+
+- Before `/harness-accept`, to see which proposals are gate-ready and which are refused
+- After an assay, to see what the findings became
+- When picking up the loop after time away and the question is "where was I"
+- Any time the answer to "what is blocked" would otherwise take several commands
+
+## Process
+
+### 1. Run it
+
+```bash
+python3 ai-literacy-superpowers/scripts/harness-board.py
+```
+
+For interventions over time rather than the queue:
+
+```bash
+python3 ai-literacy-superpowers/scripts/harness-board.py --timeline
+```
+
+### 2. Read the queue
+
+Five sections, ordered by closeness to a gate:
+
+- **ASSAYS** — each assay, its finding count, how many propose a rule versus
+  resolve to `no-change`, and whether it carries an errata record
+- **PROPOSALS** — each `proposed` record with its `precheck` result. A refused
+  record shows **the exact refusal**, quoted from `precheck` rather than
+  recomputed. A clean record shows what remains: the cost, written at the gate
+- **IN FORCE** — records actually binding something, with provisional expiry.
+  This reads the registrar's derived state rather than `status`, because a
+  superseded rule and a retirement are both `accepted` and neither binds
+- **ACCEPTED BUT NOT BINDING** — superseded and retired records, so the
+  difference is visible rather than inferred
+- **OBJECTIONS AWAITING DISPOSITION** — records carrying `pending` dispositions,
+  which block the proposals that depend on them
+
+### 3. Act on the arrows
+
+Every blocked item carries a `→` line naming a **concrete next action**, not a
+state. "Blocked" is not an action; "a harness-loop change requires evidence from
+at least two distinct assays, found 1" is.
+
+## What it does not do
+
+**It does not act.** No proposing, accepting, or disposing. The loop's write path
+is gated deliberately, and a board that could act would collapse the gates it
+exists to make visible.
+
+**It does not store anything.** There is no `BOARD.md`. A file that must be
+regenerated becomes a file that is stale — this repository already carries two
+dashboards that went 106 days unread, and a third with a fresher date would be
+the same mistake. Run the command when you want the answer.
+
+**It does not reimplement `precheck`.** Where a blocker is computed by the
+registrar, the board shells out and quotes it. Two implementations of a refusal
+rule diverge, and the divergence favours the board, because the board is what
+someone reads.
+
+**It does not hide what it cannot parse.** A record with no `status`, or an
+unrecognised one, appears under `UNCLASSIFIED` with its path. A board that
+silently drops what it cannot classify reports a smaller world than it checked.
+
+## Note on disposition vocabulary
+
+The corpus contains both plural and singular disposition values — `accepted` and
+`accept`, `rejected` and `reject`, plus `amend`. The board normalises for counting
+and prints a note listing any non-canonical values it saw. It does not rewrite
+records, and it does not treat the divergence as an error:
+`check-objection-taxonomy.py` passes on all of them, so the schema permits it.
+
+## See also
+
+- `/harness-assay` — produce the assays this board reads
+- `/harness-propose`, `/harness-accept` — the write path the board reports on
+- `/harness-timeline` — the raw JSON feed behind `--timeline`
+- `/harness-check` — pass/fail over the corpus, which the board deliberately does not duplicate

--- a/ai-literacy-superpowers/scripts/harness-board.py
+++ b/ai-literacy-superpowers/scripts/harness-board.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Render the harness evolution loop as a queue, with the next action per item.
+
+Read-only by construction. It writes nothing, and it exits non-zero only on its
+own failure — never on the corpus's state. The board reports; it does not gate.
+
+Three properties matter more than the rendering, and each comes from an observed
+failure on 2026-08-25:
+
+**It quotes `precheck` rather than reimplementing it.** Two implementations of a
+refusal rule diverge, and the divergence favours the board, because the board is
+what someone reads.
+
+**It never omits what it cannot classify.** A record this script does not
+understand is rendered as `unclassified` with its path. A board that silently
+drops what it cannot parse reports a smaller world than it checked — the subject
+of the rule currently in force.
+
+**It writes nothing.** A file that must be regenerated becomes a file that is
+stale. This repository carries two stored dashboards that went 106 days unread.
+"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+DECISIONS = "harness/decisions"
+ASSAYS = "harness/assay"
+OBJECTIONS = "docs/superpowers/objections"
+REGISTRAR = "ai-literacy-superpowers/scripts/harness-registrar.py"
+
+# Older records use singular forms. Normalised for counting; the raw value is
+# preserved and shown where it differs, because the schema permits both and
+# check-objection-taxonomy.py passes on all of them.
+DISPOSITION_ALIASES = {"accept": "accepted", "amend": "amended", "reject": "rejected"}
+
+
+def frontmatter(path):
+    """The record's frontmatter as a flat dict of scalars. Never raises."""
+    try:
+        text = open(path, encoding="utf-8").read()
+    except OSError:
+        return {}
+    if not text.startswith("---"):
+        return {}
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return {}
+    out = {}
+    for line in parts[1].split("\n"):
+        m = re.match(r"^([a-z_]+):\s*(.*)$", line)
+        if m:
+            out[m.group(1)] = m.group(2).strip()
+    return out
+
+
+def run(cmd):
+    """(rc, combined output). A tool that is absent is a failure, not a pass."""
+    try:
+        p = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        return p.returncode, (p.stdout + p.stderr).strip()
+    except (OSError, subprocess.SubprocessError) as exc:
+        return 127, f"could not run {' '.join(cmd)}: {exc}"
+
+
+def blocker_for(path):
+    """The exact refusal standing between this record and acceptance.
+
+    Quoted from precheck, never recomputed here.
+    """
+    rc, out = run(["python3", REGISTRAR, "precheck", "--hdr", path])
+    if rc == 0:
+        return None
+    first = next((l for l in out.split("\n") if l.startswith("FAIL:")), out)
+    return re.sub(r"^FAIL: [^:]+: ", "", first).strip()
+
+
+def dispositions(path):
+    """(normalised counts, raw values that differed)."""
+    try:
+        text = open(path, encoding="utf-8").read()
+    except OSError:
+        return {}, set()
+    counts, raw_seen = {}, set()
+    for value in re.findall(r"^\s+disposition:\s*(\S+)\s*$", text, re.M):
+        norm = DISPOSITION_ALIASES.get(value, value)
+        if norm != value:
+            raw_seen.add(value)
+        counts[norm] = counts.get(norm, 0) + 1
+    return counts, raw_seen
+
+
+def findings(path):
+    """(finding id, title, classification) for each finding in an assay."""
+    try:
+        text = open(path, encoding="utf-8").read()
+    except OSError:
+        return []
+    out = []
+    for block in re.split(r"(?=^### finding-)", text, flags=re.M)[1:]:
+        head = block.split("\n")[0]
+        m = re.match(r"### (finding-\d+) — (.+)", head)
+        if not m:
+            continue
+        cls = re.search(r"^classification:\s*(\S+)", block, re.M)
+        out.append((m.group(1), m.group(2).strip(), cls.group(1) if cls else "?"))
+    return out
+
+
+def wrap(text, width, indent):
+    words, lines, cur = text.split(), [], ""
+    for w in words:
+        if len(cur) + len(w) + 1 > width:
+            lines.append(cur)
+            cur = w
+        else:
+            cur = f"{cur} {w}".strip()
+    if cur:
+        lines.append(cur)
+    return ("\n" + " " * indent).join(lines)
+
+
+def timeline_states(root):
+    """id -> derived state, read from the registrar rather than recomputed."""
+    rc, out = run(["python3", REGISTRAR, "timeline"])
+    if rc != 0:
+        return {}
+    states = {}
+    for line in out.split("\n"):
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            d = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if d.get("id"):
+            states[d["id"]] = d.get("state", "?")
+    return states
+
+
+def queue_view(root):
+    lines, unclassified = [], []
+
+    # ---- assays -----------------------------------------------------------
+    assays = sorted(
+        p for p in os.listdir(os.path.join(root, ASSAYS))
+        if p.endswith("-assay.md")
+    ) if os.path.isdir(os.path.join(root, ASSAYS)) else []
+    lines.append("ASSAYS")
+    if not assays:
+        lines.append("  none")
+    for a in assays:
+        fs = findings(os.path.join(root, ASSAYS, a))
+        nochange = sum(1 for _, _, c in fs if c == "no-change")
+        rule = len(fs) - nochange
+        errata = os.path.exists(os.path.join(root, ASSAYS, a.replace("-assay.md", "-assay.errata.md")))
+        note = "  (carries errata)" if errata else ""
+        lines.append(f"  {a[:-3]:<26} {len(fs)} findings   "
+                     f"{rule} proposing · {nochange} no-change{note}")
+
+    # ---- decision records -------------------------------------------------
+    recs = sorted(
+        p for p in os.listdir(os.path.join(root, DECISIONS))
+        if p.startswith("HDR-") and p.endswith(".md")
+    ) if os.path.isdir(os.path.join(root, DECISIONS)) else []
+
+    buckets = {"proposed": [], "accepted": [], "rejected": []}
+    for r in recs:
+        path = os.path.join(root, DECISIONS, r)
+        fm = frontmatter(path)
+        status = fm.get("status")
+        if status in buckets:
+            buckets[status].append((r, fm, path))
+        else:
+            unclassified.append((r, status or "no status field"))
+
+    lines.append("")
+    lines.append("PROPOSALS")
+    if not buckets["proposed"]:
+        lines.append("  none")
+    for r, fm, path in buckets["proposed"]:
+        slug = r[4:-3]
+        blocker = blocker_for(path)
+        state = "precheck: clean" if blocker is None else "precheck: REFUSED"
+        lines.append(f"  {slug[:52]:<54} {state}")
+        if blocker:
+            lines.append("      → " + wrap(blocker, 66, 8))
+        else:
+            lines.append("      → gate-ready. Remaining: the cost, written at "
+                         "/harness-accept")
+
+    # `status: accepted` is not the same as in force — a superseded rule and a
+    # retirement are both accepted and neither binds anything. The registrar's
+    # timeline already derives that state, so it is read rather than recomputed.
+    states = timeline_states(root)
+    lines.append("")
+    lines.append("IN FORCE")
+    live = [(r, fm) for r, fm, _ in buckets["accepted"]
+            if states.get(r[:-3]) == "in force"]
+    if not live:
+        lines.append("  none")
+    for r, fm in live:
+        slug = r[4:-3]
+        exp = fm.get("expires")
+        prov = " · provisional until " + exp if fm.get("provisional") == "true" and exp else ""
+        lines.append(f"  {slug[:52]:<54} {fm.get('classification','?')}{prov}")
+
+    closed = [(r, states.get(r[:-3], "?")) for r, _f, _p in buckets["accepted"]
+              if states.get(r[:-3]) != "in force"]
+    if closed:
+        lines.append("")
+        lines.append("ACCEPTED BUT NOT BINDING")
+        for r, st in closed:
+            lines.append(f"  {r[4:-3][:52]:<54} {st}")
+
+    if buckets["rejected"]:
+        lines.append("")
+        lines.append("DECLINED")
+        for r, _fm, _p in buckets["rejected"]:
+            lines.append(f"  {r[4:-3][:52]}")
+
+    # ---- objection records ------------------------------------------------
+    objs = sorted(
+        p for p in os.listdir(os.path.join(root, OBJECTIONS))
+        if p.endswith(".md") and p != "README.md"
+    ) if os.path.isdir(os.path.join(root, OBJECTIONS)) else []
+    stuck = []
+    raw_forms = set()
+    for o in objs:
+        counts, raw = dispositions(os.path.join(root, OBJECTIONS, o))
+        raw_forms |= raw
+        if counts.get("pending"):
+            stuck.append((o, counts["pending"], sum(counts.values())))
+    lines.append("")
+    lines.append("OBJECTIONS AWAITING DISPOSITION")
+    if not stuck:
+        lines.append(f"  none — all {len(objs)} records adjudicated")
+    for o, pending, total in stuck:
+        lines.append(f"  {o[:-3][:52]:<54} {pending}/{total} pending")
+        lines.append("      → dispose them, or record why they stand")
+
+    if raw_forms:
+        lines.append("")
+        lines.append("  note: non-canonical disposition values normalised for "
+                     "counting: " + ", ".join(sorted(raw_forms)))
+
+    if unclassified:
+        lines.append("")
+        lines.append("UNCLASSIFIED — shown because omitting them would report a "
+                     "smaller world than was checked")
+        for r, why in unclassified:
+            lines.append(f"  {DECISIONS}/{r}: {why}")
+
+    return "\n".join(lines)
+
+
+def timeline_view(root):
+    rc, out = run(["python3", REGISTRAR, "timeline"])
+    if rc != 0:
+        return f"timeline unavailable (registrar exited {rc}):\n{out}"
+    rows = []
+    for line in out.split("\n"):
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            d = json.loads(line)
+        except json.JSONDecodeError:
+            rows.append(("?", "?", "?", line[:60]))
+            continue
+        rows.append((d.get("date", "?"), d.get("direction", "?"),
+                     d.get("state", "?"), d.get("id", "?")))
+    if not rows:
+        return "no accepted records — the timeline is empty"
+    width = max(len(r[2]) for r in rows)
+    return "\n".join(
+        f"  {d}  {dirn:<8}  {state:<{width}}  {rid[:56]}"
+        for d, dirn, state, rid in sorted(rows))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--root", default=".", help="repository root")
+    ap.add_argument("--timeline", action="store_true",
+                    help="render interventions over time instead of the queue")
+    args = ap.parse_args()
+
+    root = args.root
+    if not os.path.isdir(os.path.join(root, DECISIONS)):
+        print(f"no decision corpus at {os.path.join(root, DECISIONS)} — "
+              "run /harness-propose first, or pass --root", file=sys.stderr)
+        return 1
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(root)
+        print(timeline_view(".") if args.timeline else queue_view("."))
+    finally:
+        os.chdir(cwd)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/plugins/ai-literacy-superpowers/how-to/see-what-is-blocked.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/see-what-is-blocked.md
@@ -1,0 +1,72 @@
+# See what is blocked in the evolution loop
+
+`/harness-board` renders every artefact in flight and the concrete next action
+for each. Read-only; it writes nothing.
+
+## Run it
+
+```bash
+python3 ai-literacy-superpowers/scripts/harness-board.py
+```
+
+```text
+ASSAYS
+  2026-08-25T14-31Z-assay    4 findings   2 proposing · 2 no-change
+
+PROPOSALS
+  2026-08-25-command-cli-parity                          precheck: clean
+      → gate-ready. Remaining: the cost, written at /harness-accept
+
+IN FORCE
+  2026-08-25-four-mechanisms-report-the-reassuring-ans   agent-instruction · provisional until 2026-11-23
+
+ACCEPTED BUT NOT BINDING
+  2026-08-25-the-periodic-check-suite-stops-at-its-fir   superseded
+
+OBJECTIONS AWAITING DISPOSITION
+  harness-provenance-citation                            12/12 pending
+      → dispose them, or record why they stand
+```
+
+## Read the arrows, not the states
+
+Every blocked item carries a `→` line naming something you can do. A refused
+proposal shows the refusal **quoted from `precheck`**, so the board and the gate
+cannot disagree:
+
+```text
+  2026-08-25-workflow-step-masking                       precheck: REFUSED
+      → a harness-loop change requires evidence from at least two
+        distinct assays, found 1
+```
+
+That is the difference between knowing a thing is blocked and knowing what to do
+about it — and the three proposals in flight on 2026-08-25 were blocked for three
+entirely different reasons.
+
+## Interventions over time
+
+```bash
+python3 ai-literacy-superpowers/scripts/harness-board.py --timeline
+```
+
+Direction, state and expiry per accepted record, from the same feed
+`/harness-timeline` emits.
+
+## What it will not do
+
+It does not propose, accept or dispose anything — the loop's write path is gated
+deliberately, and a board that could act would collapse the gates it exists to
+make visible.
+
+It does not store anything. There is no `BOARD.md`, because a file that must be
+regenerated becomes a file that is stale.
+
+It does not hide a record it cannot parse. Anything with a missing or
+unrecognised `status` appears under `UNCLASSIFIED` with its path.
+
+## See also
+
+- [Record a governance change](record-a-governance-change.md)
+- [Assay a phase](assay-a-phase.md)
+- [Harness decision records](../reference/harness-decision-records.md)

--- a/docs/plugins/ai-literacy-superpowers/reference/commands.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/commands.md
@@ -297,6 +297,41 @@ step, and a gate with no decision behind it is the shape of approval theatre.
 It does not commit, push, or open a pull request. Three gates exist — drafting,
 accepting, committing — and none is implied by another.
 
+### /harness-board
+
+Usage: `/harness-board` · `/harness-board --timeline`
+
+- **Skills read**: none
+- **Agents dispatched**: none
+
+Renders the evolution loop as a queue — every assay, proposal, accepted record
+and objection in flight, with the concrete next action for each. Read-only, and
+it writes nothing.
+
+Five sections, ordered by closeness to a gate: **ASSAYS**, **PROPOSALS**,
+**IN FORCE**, **ACCEPTED BUT NOT BINDING**, **OBJECTIONS AWAITING DISPOSITION**.
+`--timeline` renders interventions over time instead, from the same feed
+`/harness-timeline` emits.
+
+Three properties are load-bearing rather than incidental:
+
+- **It quotes `precheck`** for a proposed record's blocker instead of
+  reimplementing the refusal. Two implementations diverge, and the divergence
+  favours the board because the board is what someone reads.
+- **It never omits what it cannot classify.** A record with no `status`, or an
+  unrecognised one, appears under `UNCLASSIFIED` with its path — a board that
+  drops what it cannot parse reports a smaller world than it checked.
+- **It distinguishes in force from accepted.** A superseded rule and a retirement
+  are both `accepted` and neither binds anything, so the binding state is read
+  from the registrar's derived `state` rather than from `status`.
+
+There is deliberately no stored `BOARD.md`. A file that must be regenerated
+becomes a file that is stale, and this repository already carries two dashboards
+that went 106 days unread.
+
+It does not propose, accept or dispose anything, and it exits non-zero only on
+its own failure — never on the state of the corpus.
+
 ### /harness-timeline
 
 Usage: `/harness-timeline`

--- a/docs/superpowers/specs/2026-08-25-harness-board-design.md
+++ b/docs/superpowers/specs/2026-08-25-harness-board-design.md
@@ -1,0 +1,148 @@
+# The harness board — design
+
+**Status:** proposed
+**Date:** 2026-08-25
+**Issue:** #590
+**Provenance:** the 2026-08-25 session, in which the evolution loop completed its
+first full cycle. The evidence in §1 was gathered by running the loop, not by
+reasoning about it.
+**Scope:** a read-only command that renders the loop's in-flight artefacts and
+the next action for each.
+**Out of scope:** proposing, accepting or disposing anything; an HTML view; any
+stored artefact.
+
+## 1. Problem statement
+
+On 2026-08-25 the harness evolution loop ran end to end for the first time. By
+the end of the day the corpus held six decision records, four assays, four
+objection records and thirty-five dispositions.
+
+Answering *"what is blocked, and on what"* took running `precheck` three times,
+reading two objection records, and hand-computing a two-assay threshold.
+
+Every one of those answers already existed in machine-readable form. Nothing
+assembled them.
+
+The specific failure is sharper than "no overview". It was possible to report
+**that** three proposals were stalled, but not **why each one differed**, without
+three separate commands. The three blockers turned out to be entirely different —
+missing tier-2 sections, a threshold refusal, and two undecided rule-text
+amendments — and that distinction is exactly what a human needs in order to act.
+
+### What exists, and what it does not answer
+
+| Command | Gives | Does not give |
+| --- | --- | --- |
+| `/harness-timeline` | JSON lines per **accepted** record | anything about proposed, rejected or queued work |
+| `/harness-status` | enforcement ratio, drift, GC state | nothing about the loop's queues |
+| `/harness-check` | pass/fail over the whole corpus | which item, or what to do about it |
+| `precheck --hdr <one>` | **the exact blocker, per record** | one record at a time |
+
+`precheck` is the important row. It already computes the answer and already words
+it for a human. It simply has to be asked once per record, by someone who knows
+the records exist.
+
+## 2. Decision — `/harness-board`
+
+A read-only command rendering two views over the existing corpus.
+
+### 2.1 Queue view
+
+Every artefact in flight, its state, and the single next action. Grouped by kind,
+ordered by what is closest to a gate.
+
+Each blocked item names a **concrete next action**, not a state. "Blocked" is not
+an action; "two rule-text amendments undecided" is.
+
+### 2.2 Timeline view
+
+Interventions over time with direction and expiry horizon.
+`harness-registrar.py timeline` already emits `direction`, `state`,
+`provisional`, `expires`, `supersedes` and `superseded_by` per accepted record —
+enough to render without new analysis.
+
+Selected with `--timeline`; the queue view is the default because it is the half
+that answers a question nobody can otherwise answer cheaply.
+
+### 2.3 Three constraints that follow from the day's evidence
+
+**Render on demand, write nothing.** `/harness-timeline` sets the precedent — it
+is "deliberately not a stored artifact, and it writes nothing". A file that must
+be regenerated becomes a file that is stale, and the 2026-08-25 assessment found
+exactly that: two dashboards, 106 days old, read by nobody. A command that renders
+current state cannot go stale. This also keeps the board clear of **INV-1**.
+
+**Quote `precheck`, never reimplement it.** Two implementations of a refusal rule
+will diverge, and the divergence will favour the board, because the board is what
+someone reads. Where a blocker is computed by `precheck`, the board shells out and
+quotes the result.
+
+**Never omit what it cannot classify.** A record the board does not understand is
+rendered as unclassified, with its path. A board that silently drops what it
+cannot parse reports a smaller world than it checked — which is the subject of the
+rule this repository currently has in force.
+
+## 3. Data sources
+
+All read-only, all existing:
+
+| Source | Gives |
+| --- | --- |
+| `harness/decisions/HDR-*.md` | `status`, `classification`, `enforcement`, `provisional`, `expires` |
+| `harness-registrar.py precheck --hdr` | the exact refusal, per proposed record |
+| `harness-registrar.py timeline` | direction and state per accepted record |
+| `harness/assay/*.md` | findings, their classification and `no-change` status |
+| `docs/superpowers/objections/*.md` | disposition counts per record |
+
+### 3.1 One known wrinkle
+
+The disposition vocabulary is not consistent across the corpus. A sweep on
+2026-08-25 returns `accepted` (309), `amend` (71), `rejected` (24) and `accept`
+(24) — the singular forms appear in older records.
+
+The board **normalises for counting and preserves the raw value where it
+differs**. It does not rewrite records, and it does not treat the divergence as
+an error: `check-objection-taxonomy.py` passes on all 51 records, so the schema
+permits it. Whether the vocabulary should be unified is a separate question and
+is out of scope here.
+
+## 4. Acceptance criteria
+
+1. One invocation answers "what is blocked and what unblocks it" for every
+   artefact in the loop
+2. Each blocked item names a concrete next action rather than a state
+3. Writes no file; `git status` is unchanged after a run
+4. Where a blocker is computed by `precheck`, the board quotes it rather than
+   reimplementing it
+5. Disposition vocabulary normalised for counting, raw value preserved where it
+   differs
+6. A record the board cannot classify is shown as unclassified with its path,
+   never omitted
+7. `--timeline` renders accepted records with direction, state and expiry
+8. Exits non-zero only on its own failure, never on the corpus's state — the
+   board reports, it does not gate
+
+Criterion 6 is the one to test adversarially: seed a malformed record and assert
+it appears in the output.
+
+## 5. Rejected alternatives
+
+**Extend `/harness-status`.** Rejected: that command answers "how is the harness
+enforcing", which is a different question from "what is in flight". Merging them
+produces a screen nobody reads twice.
+
+**Write a stored `BOARD.md`, regenerated by CI.** Rejected on the strongest
+available evidence — this repository already carries two stored dashboards that
+are 106 days stale and read by nobody, and the 2026-08-25 assessment recommended
+wiring them into a cadence or retiring them. A third would be the same mistake
+with a fresher date.
+
+**Have the board act — dispose, propose, accept.** Rejected. The loop's write path
+is gated deliberately, and a board that could act would collapse the gates it
+exists to make visible.
+
+**Reimplement the refusal logic for speed.** Rejected: see §2.3.
+
+## 6. Version
+
+Minor bump — a new command. 0.87.0 → 0.88.0.

--- a/tdad_tests/scenarios/commands/harness-board/reports-without-gating.md
+++ b/tdad_tests/scenarios/commands/harness-board/reports-without-gating.md
@@ -1,0 +1,58 @@
+---
+component: harness-board
+component_type: command
+tier: structural
+---
+
+# Scenario: /harness-board reports without gating, and never omits what it cannot classify
+
+## Given
+
+A board is read instead of the records it summarises. That makes two failure
+modes worse here than elsewhere.
+
+If the board **recomputes** a refusal that `precheck` already computes, the two
+implementations will diverge — and the divergence favours the board, because the
+board is what someone reads. The record would be refused at the gate while the
+board said it was ready.
+
+If the board **omits** a record it cannot parse, it reports a smaller world than
+it checked. That is the subject of the rule this repository currently has in
+force, and a board is the worst place to reproduce it: the omission is invisible
+precisely because the board is the thing you would use to notice.
+
+A third property decides whether it stays true: a board that writes a file
+becomes a file that goes stale. This repository carries two stored dashboards
+that went 106 days unread, which is the evidence rather than the worry.
+
+## When
+
+`ai-literacy-superpowers/commands/harness-board.md` is read from the filesystem.
+
+## Then
+
+**Frontmatter:** `name: harness-board`, and a description stating it is read-only
+and writes nothing.
+
+**Body:**
+
+- States that it **quotes `precheck`** for a proposed record's blocker rather
+  than reimplementing the refusal, and gives the reason: two implementations
+  diverge in favour of the one someone reads.
+- States that a record it cannot classify appears under `UNCLASSIFIED` **with its
+  path**, and gives the reason: omitting it would report a smaller world than was
+  checked.
+- States that it **writes no file**, that there is deliberately no `BOARD.md`,
+  and cites the two dashboards that went unread as the reason.
+- Distinguishes **IN FORCE** from **ACCEPTED BUT NOT BINDING**, and states that
+  the distinction is read from the registrar's derived state rather than from
+  `status`, because a superseded rule and a retirement are both `accepted` and
+  neither binds.
+- States that every blocked item carries a **concrete next action** rather than a
+  state.
+- Notes that disposition values are normalised for counting with the raw value
+  surfaced, and that the divergence is permitted by the schema rather than an
+  error.
+
+**Forbidden:** proposing, accepting or disposing anything; writing any file;
+exiting non-zero because of the corpus's state rather than its own failure.


### PR DESCRIPTION
Closes #590. Spec first commit, implementation second.

## Why

On 2026-08-25 the evolution loop ran end to end for the first time. Answering *"what is blocked, and on what"* took running `precheck` three times, reading two objection records, and hand-computing a two-assay threshold — while every one of those answers already existed in machine-readable form.

The sharper failure was not the missing overview. It was being able to report **that** three proposals were stalled without being able to say **why each differed** — and they turned out to be blocked for three entirely different reasons.

## What it renders

```text
PROPOSALS
  2026-08-25-command-cli-parity          precheck: clean
      → gate-ready. Remaining: the cost, written at /harness-accept
  2026-08-25-workflow-step-masking       precheck: REFUSED
      → a harness-loop change requires evidence from at least two
        distinct assays, found 1

OBJECTIONS AWAITING DISPOSITION
  harness-provenance-citation            12/12 pending
      → dispose them, or record why they stand
```

Five sections ordered by closeness to a gate, plus `--timeline`.

## Three properties that are load-bearing

**It quotes `precheck`, never reimplements it.** Two implementations of a refusal diverge, and the divergence favours the board — because the board is what someone reads. A record would be refused at the gate while the board called it ready.

**It never omits what it cannot classify.** Verified adversarially against seeded malformed records:

```text
UNCLASSIFIED — shown because omitting them would report a smaller world than was checked
  harness/decisions/HDR-2026-08-25-malformed.md: no status field
  harness/decisions/HDR-2026-08-25-weird-status.md: bananas
```

A board that drops what it cannot parse is the worst place for that defect, because it is the thing you would use to notice.

**It distinguishes in force from accepted.** The first implementation listed a **superseded** record under IN FORCE — `status: accepted` is not the same as binding, since a superseded rule and a retirement are both accepted and neither binds anything. Now read from the registrar's derived `state` rather than recomputed, which is the same principle as quoting `precheck`, applied to the second place I nearly broke it.

## And it stores nothing

No `BOARD.md`. A file that must be regenerated becomes a file that is stale, and the 2026-08-25 assessment found precisely that — two stored dashboards, 106 days old, read by nobody. A third with a fresher date is the same mistake.

`git status` is unchanged after a run, asserted rather than assumed.

## Acceptance criteria

All eight from the spec verified: one invocation answers the question; every blocked item names an action rather than a state; writes no file; quotes `precheck`; normalises disposition vocabulary while surfacing the raw values (`accept`, `amend` appear in older records); shows unclassified records with their path; `--timeline` renders direction/state/expiry; exits non-zero only on its own failure.

## Ships with

Spec (first commit, spec-only), Layer 1 structural scenario at `tdad_tests/scenarios/commands/harness-board/`, reference entry in `commands.md`, and a how-to at `how-to/see-what-is-blocked.md`.

## Verification

42/42 Layer 0 suites · `mkdocs build --strict` exit 0 · convention parity 36/36 · `harness check` OK · component frontmatter 104 files · markdownlint clean · version consistent at `0.88.0` across all five CI-checked locations, command count 39 → 40 in the README badge, table and section heading.

## Version

Minor bump — a new command.
