### PR TITLE
Spec: retire the template-currency nudge (#601)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## 0.89.0 — 2026-08-25
 
+### Design — retire the template-currency nudge (spec only, #601)
+
+The `template-version` marker claims to track template content and tracks the
+plugin version. The templates shipped at plugin `0.79.0` and `0.89.0` are
+byte-identical (`diff`, exit 0); `templates/HARNESS.md` last changed at
+`d867c7c` on 2026-08-13, twelve days *before* the marker was stamped to
+`0.79.0`. The plugin moved ten minors, the template moved zero bytes — so the
+SessionStart hook asserted `Plugin template has been updated` on evidence that
+cannot establish it, and the false claim reached `HARNESS.md`'s Status block.
+
+Spec at
+`docs/superpowers/specs/2026-08-25-template-currency-measure-content-design.md`
+retires the marker, the `Template currency` GC rule, the SessionStart hook and
+the dismissal file. `/harness-upgrade` survives on demand, losing only its
+version gate and keeping its three-bucket parse.
+
+Reached at revision 4 after three adversarial reviews. Revisions 1 and 2 tried
+to keep a nudge and measure the right property, and each grew — a shared script,
+a `PATH` shim, a grammar in the governing document, a fourth command
+disposition — while each returned a critical objection. The case for deletion is
+cost and escalating complexity, not absence of value; a correct notifier remains
+buildable and the spec records how.
+
+No plugin files change in this PR, so no version bump. Implementation follows
+separately.
+
 ### Added — `/harness-board --html`, a browser view of the loop
 
 The queue view is terminal text, and the thing that answers *"where is the

--- a/docs/superpowers/objections/template-currency-measure-content-design.md
+++ b/docs/superpowers/objections/template-currency-measure-content-design.md
@@ -9,85 +9,85 @@ objections:
     severity: high
     claim: "The load-bearing claim that the mechanism has no recorded successes is a survivorship artefact — in five of six recorded runs the template had not changed, so 'adopted nothing' is a true negative rather than a failure."
     evidence: "§1: 'The plugin moved ten minor versions across that window. The template moved zero bytes.' §1.1: 'There is therefore no recorded instance of this nudge producing a useful adoption.' §2.2 rests acceptance of the loss on 'the mechanism being removed has never demonstrably provided it.'"
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "The survivorship point is taken and the decision stands. The justification is rewritten: deletion rests on cost and complexity — three revisions of escalating mechanism, two criticals — not on 'it never worked'. Note the reviewer's 'true negative' framing is itself wrong: the hook fires whenever versions differ, so it nudged all six times and was wrong five. But the surviving point holds — that history damns the broken notifier and cannot tell us whether a correct one would earn its keep."
   - id: O2
     category: implementation
     severity: critical
     claim: "Criterion 6's four search terms cannot match the phrasing that actually carries this mechanism across the tree, so the residue assertion returns the passing answer over a tree that still advertises the deleted hook in at least eleven places."
     evidence: "§6 criterion 6 searches for `template-version`, `Template currency`, `template-currency`, `harness-upgrade-dismissed`. None of these match `hooks/hooks.json:2` ('template currency check ... (SessionStart) nudge on plugin upgrade'), `README.md:371` ('SessionStart template currency check'), `commands/harness-sync.md:118,138,207,271,294` ('Template version drift' / 'Template drift'), `skills/harness-audit-engine/SKILL.md:3`, `CLAUDE.md:284`, `templates/CLAUDE.md:220`, `docs/plugins/ai-literacy-superpowers/reference/skills.md:46`, `.../tutorials/first-time-tour.md:558`, `.../explanation/the-harness-lifecycle.md:161`, `.../explanation/the-loops-that-learn.md:36`, `.../reference/output-validation.md:33`."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Broaden the residue assertion: add 'template drift' and 'template version drift', and make the search case-insensitive. The assertion was sold as the reason a complete table was no longer needed; blind to the phrasings in use, it would have certified the incomplete table instead."
   - id: O3
     category: specification quality
     severity: high
     claim: "Criterion 6's allow-list omits the two files that must contain the forbidden strings by construction — the migration command and the test that implements the criterion — so the Layer 0 test fails on its own implementation."
     evidence: "§6 criterion 6 permits matches 'only in: CHANGELOG.md, REFLECTION_LOG.md, reflections/, assessments/, harness/assay/, docs/superpowers/{specs,plans,objections}/, observability/snapshots/, and the .gitignore line.' §5 requires `/harness-upgrade` step 6 to detect 'a `<!-- template-version: … -->` marker' and 'a `### Template currency` GC rule', and §6 places the test at `tdad_tests/layer0_deterministic/test-template-currency-retired.sh` — a filename containing `template-currency`."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Exempt commands/harness-upgrade.md and the test file by name, with the reason stated, so the exemption is deliberate and narrow rather than a widening someone applied to get CI green."
   - id: O4
     category: implementation
     severity: critical
     claim: "Step 6's migration deletes content from a project's governing document unconditionally and without asking, inside a command whose entire design is per-item consent."
     evidence: "§5: 'On any run, if the project's HARNESS.md contains: a `<!-- template-version: … -->` marker, it is removed; a `### Template currency` GC rule … it is removed'. `commands/harness-upgrade.md:104` — 'Ask the user to choose for each item' — and step 4 offers 'accept, skip, or customise' for every other change the command makes. CLAUDE.md: 'hand edits are how a governing document becomes the least governed thing in the repository.'"
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Step 6 prompts per item, matching the command's existing consent design. Nothing in a project's HARNESS.md is deleted without a recorded decision — a project may have specialised that rule, which is exactly what this repository did with Consistent formatting."
   - id: O5
     category: scope
     severity: high
     claim: "The spec applies its own Status-block standard to this repository and not to the projects it migrates, so every migrated project is left with a governing document that overstates its GC coverage."
     evidence: "§10: 'Removing the `Template currency` GC rule changes the `Garbage collection active:` count in HARNESS.md's Status block … This PR runs `/harness-audit` … rather than merging a governing document that misstates its own coverage.' §5 performs the identical edit in consuming projects with no equivalent step. `skills/harness-audit-engine/SKILL.md:32` makes Status-block accuracy a tracked drift surface."
-    disposition: pending
-    disposition_rationale: null
+    disposition: rejected
+    disposition_rationale: "Out of scope. Status-block accuracy is /harness-audit's tracked drift surface and its normal cadence will catch it. This command's job is not to keep every consuming project's Status block current."
   - id: O6
     category: scope
     severity: high
     claim: "The migration reaches only projects that run `/harness-upgrade` — by the spec's own argument the population least in need of it — yet §9 records the corresponding prior objection as fully resolved."
     evidence: "§5: 'A project that never runs `/harness-upgrade` again keeps an orphaned rule.' §7 argues against the opt-out alternative because it 'silences the nudge for projects that never had one — the population most likely to need it.' §9: 'O6 | high | **Resolved** — §5 migrates consuming projects' orphaned GC rule'."
-    disposition: pending
-    disposition_rationale: null
+    disposition: rejected
+    disposition_rationale: "Resolved as written. The plugin cannot edit files in projects it is not invited into; performing the migration on every /harness-upgrade run is the maximum available reach, and that is what resolved means here."
   - id: O7
     category: scope
     severity: high
     claim: "§2.2 prices only the loss of the unprompted notification, but §3 also deletes three other consumers — the `/harness-sync` monthly drift surface, the `/harness-audit` engine row, and the assessment's harness-detection marker — including a reader for data that stays in the wild."
     evidence: "§2.2: 'A project that upgrades the plugin will no longer be told, unprompted, that the template gained content.' §3 additionally deletes `commands/harness-sync.md:118,206-207,271,294`, `skills/harness-audit-engine/SKILL.md:33`, `skills/harness-observability/references/observatory-signals.md:127`, and `skills/ai-literacy-assessment/references/habitat-discovery.md:93,141` — the last being a marker used to recognise that a project has a harness at all, which unmigrated projects will keep carrying."
-    disposition: pending
-    disposition_rationale: null
+    disposition: amend
+    disposition_rationale: "Keep habitat-discovery.md reading the marker — it is a reader, it is harmless, and unmigrated projects keep carrying the marker it recognises. Rewrite section 2.2 to name every capability removed rather than only the unprompted notification."
   - id: O8
     category: alternatives
     severity: high
     claim: "All four alternatives in §7 keep or repair the nudge; the spec never weighs deleting less — removing the SessionStart hook (the every-session false signal) while retaining the pull-direction surfaces."
     evidence: "§7 lists 'Compare heading sets', 'Filter the compared set', 'Fix the template's own content marker and read that', and 'Keep the marker but make its absence an opt-out'. §1's evidence of harm is specific to the hook's assertion ('the SessionStart hook asserts `Plugin template has been updated` on evidence that cannot establish it'), not to the `/harness-sync` row, which surfaces drift as a `[manual]` item at a monthly cadence the user chose."
-    disposition: pending
-    disposition_rationale: null
+    disposition: rejected
+    disposition_rationale: "Delete all of it. A drifted row computed from a broken proxy is still a false statement wherever it appears, including in a monthly table the user asked for. Coherence beats preserving a surface that reports the same bad signal at a slower cadence."
   - id: O9
     category: risk
     severity: medium
     claim: "The spec names the condition under which the decision is wrong and the option to reopen on, but the migration strips from the install base the marker that option depends on, making the recorded reopening path more expensive than §7 implies."
     evidence: "§2.2: 'If a future adopter reports missing template content they would have wanted to know about, that is evidence this decision was wrong and is worth reopening on.' §7: 'have the hook compare that marker rather than `plugin.json` … recorded here in enough detail to be taken up without re-deriving it.' §5 removes the project-side marker on every `/harness-upgrade` run."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "State plainly that the migration is one-way: it is not reversible from the plugin side, reverting the plugin does not restore project files, and reopening on section 7's alternative costs a second migration through the same partially-reaching channel."
   - id: O10
     category: risk
     severity: high
     claim: "Stripping the marker while older plugin copies remain installed produces a permanent every-session false nudge that the new command can no longer silence, because it stops writing the dismissal file."
     evidence: "`hooks/scripts/template-currency-check.sh:32-34` — absent marker is treated as `0.0.0` — with `:43-45` and `:48-53`, so an absent marker nudges unless a dismissal file matching the plugin version exists. §3: '`.claude/.harness-upgrade-dismissed` is no longer written or read.' CLAUDE.md documents per-version plugin caches and a separately-synced marketplace clone, so mixed versions across machines and teammates are the normal case."
-    disposition: pending
-    disposition_rationale: null
+    disposition: rejected
+    disposition_rationale: "Stated and accepted as a transitional cost. Name the mixed-version consequence in section 2.2 rather than carrying a dismissal file nothing in the new plugin reads. Users on stale plugins have other reasons to upgrade. The reference/hooks.md:287 docs bug is real but predates this spec and is tracked separately."
   - id: O11
     category: specification quality
     severity: medium
     claim: "The GC-rule removal predicate is stated in prose and never checked against the text it must match, and no behaviour is defined for a near-miss, a customised rule, or an unreadable file."
     evidence: "§5: 'a `### Template currency` GC rule whose **Tool** field references the template-version comment, it is removed'. §2.1 records that revision 2 shipped 'an exclusion predicate that matched nothing … verified by `grep '^###.*affordance-example'` returning zero matches'. §5's step 7 defines only the success report: 'step 7 reports each removal by name.'"
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Report near misses and never guess. A '### Template currency' heading whose Tool field does not match is reported and left alone, and step 7 distinguishes 'found nothing' from 'removed nothing' so silence never stands in for could-not-determine."
   - id: O12
     category: scope
     severity: high
     claim: "The §3 and §12 enumerations miss named surfaces despite claiming grep derivation, and no counterpart to §3.1's signal arithmetic exists for the hook count that a Layer 0 test enforces."
     evidence: "§12: 'Derived from the grep in §6, not by hand' — yet `how-to/sync-harness.md` matches none of the four terms, and the list omits `README.md:371`, `hooks/hooks.json:2`, `templates/CLAUDE.md:220`, `reference/skills.md:46`, `tutorials/first-time-tour.md:558`, `explanation/the-harness-lifecycle.md:161`, `explanation/the-loops-that-learn.md:36`, `reference/output-validation.md:33`. `hooks.json` declares 18 hooks (4 SessionStart); `tdad_tests/layer0_deterministic/test-hooks-doc-parity.sh:19` records the last time that count went stale. §3.1 does exactly this arithmetic for the observatory total (82 → 81) and nothing equivalent for hooks."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Regenerate the section 3 and section 12 tables from O2's broadened case-insensitive search rather than by hand, and add the hooks.json count arithmetic (18 hooks, 4 SessionStart) alongside the observatory arithmetic in section 3.1."
 ---
 
 ## O1 — premise — high

--- a/docs/superpowers/objections/template-currency-measure-content-design.md
+++ b/docs/superpowers/objections/template-currency-measure-content-design.md
@@ -1,0 +1,677 @@
+---
+spec: docs/superpowers/specs/2026-08-25-template-currency-measure-content-design.md
+date: 2026-08-25
+mode: spec
+diaboli_model: claude-opus-5[1m]
+objections:
+  - id: O1
+    category: implementation
+    severity: critical
+    claim: "A default /harness-init run produces a HARNESS.md that is missing template headings by design, so the new hook nudges on the very next session — reproducing the cry-wolf defect the spec exists to remove."
+    evidence: "§4.1 'missing = tpl_headings - proj_headings - declined'; commands/harness-init.md step 3 'Affordances ... opt-in (default off)' and step 7 'For each unselected feature, replace the section body with the placeholder marker'; templates/HARNESS.md:519-557 declares '### gh-cli', '### honeycomb-mcp', '### shell-write-to-tmp', '### sync-to-global-cache-hook', each tagged '<!-- affordance-example -->'."
+    disposition: pending
+    disposition_rationale: null
+  - id: O2
+    category: implementation
+    severity: high
+    claim: "Case-insensitive, whitespace-trimmed matching does not match the template's commented section headings, which carry instructional parentheticals on the heading line; the design produces a permanent false positive on the repository used to verify it."
+    evidence: "§4.1 'Matching is case-insensitive and whitespace-trimmed'; templates/HARNESS.md:630 '<!-- ## Cognitive reservoir  (OPTIONAL — to opt in, remove this `<!--` line and the closing `-->` below)' versus HARNESS.md:1126 '## Cognitive reservoir'."
+    disposition: pending
+    disposition_rationale: null
+  - id: O3
+    category: specification quality
+    severity: high
+    claim: "The declined block is called load-bearing but has no grammar: the stated one-line-per-entry rule is contradicted by the spec's own example, and nothing defines continuation lines, duplicate entries, headings containing a colon, or reason text containing the comment terminator."
+    evidence: "§3.4 'One line per declined heading, `Heading: reason`' immediately below an example whose single entry wraps across three indented lines; §4.3 step 4 'Declining prompts for a one-line reason and writes it to the declined block'; §3.4 'The reason text is never parsed.'"
+    disposition: pending
+    disposition_rationale: null
+  - id: O4
+    category: scope
+    severity: high
+    claim: "The surfaces table is incomplete: /harness-sync computes and reports 'Template version drift' in three places and is not listed, so a mechanism that reports drift will survive the input it reads being deleted."
+    evidence: "§4.6 lists seven files, none of them commands/harness-sync.md, which carries 'Template version drift' (line 118), the drift-table row 'Template version (HARNESS: 0.31, plugin: 0.34) drifted /harness-upgrade [manual]' (line 138), and the JSON item '\"id\": \"template\", \"label\": \"Template drift  [manual: /harness-upgrade]\"' (lines 206-208). docs/contributing/index.md:195 and docs/plugins/ai-literacy-superpowers/how-to/sync-harness.md (six references) are also absent from §4.6 and §8."
+    disposition: pending
+    disposition_rationale: null
+  - id: O5
+    category: premise
+    severity: medium
+    claim: "The only affirmative evidence for keeping a nudge at all is a case the spec admits cannot be settled, while the spec's hard evidence records no instance of the nudge ever producing a useful adoption."
+    evidence: "§1 'Five of the last six marker advances adopted nothing'; §1 'This cannot be settled now — the 0.73.2 plugin cache is no longer on the machine that ran it'; §3.3 'Rejected because the ## Stakeholders case suggests the failure mode that actually costs something is not being told.'"
+    disposition: pending
+    disposition_rationale: null
+  - id: O6
+    category: implementation
+    severity: high
+    claim: "The spec asserts the hook and the command can never disagree, but they are two independent implementations of one parser — a bash script and a prose instruction executed by a model — and the repository already carries a GC rule because that exact drift happens here."
+    evidence: "§4.1 'identical to /harness-upgrade step 2, so the hook and the command never disagree about what is new'; §4.4 'Both the hook and the command extract headings from inside HTML comments at every level'; HARNESS.md:690 '### Command-prompt sync'."
+    disposition: pending
+    disposition_rationale: null
+  - id: O7
+    category: risk
+    severity: high
+    claim: "The hook reaches the passing, silent outcome on a path where it never read the thing it reports on, which the in-force harness decision record names as a defect rather than a default."
+    evidence: "§4.1 'exit 0 if either file is unreadable (unchanged: advisory, never blocks)'; §5 criterion 9 'The hook never blocks and never exits non-zero'; HDR-2026-08-25 (compiled into skills/advocatus-diaboli/SKILL.md): 'A reachable code path that reaches a passing value without reading the thing it reports on is a defect, not a default.'"
+    disposition: pending
+    disposition_rationale: null
+  - id: O8
+    category: scope
+    severity: medium
+    claim: "The design removes the only way to silence the nudge without acting on it, so any item the user skips re-fires every session forever, and the spec never states this consequence."
+    evidence: "§4.5 '.claude/.harness-upgrade-dismissed is no longer written or read'; §4.3 step 4 'Skip remains what it is today: not now, ask again next time'; §4.1 subtracts only 'declined' from the missing set."
+    disposition: pending
+    disposition_rationale: null
+  - id: O9
+    category: specification quality
+    severity: medium
+    claim: "The test plan assigns command behaviour to a hook test file and leaves the write path of the load-bearing declined block with no acceptance criterion at all."
+    evidence: "§5 'Criteria 1-7 and 9 are Layer 0 deterministic tests at tdad_tests/layer0_deterministic/test-template-currency-check.sh' where criterion 6 is '/harness-upgrade removes it and reports having done so' and criterion 7 covers 'both the hook and the command'; no criterion covers §4.3 step 4/6 writing a declined entry."
+    disposition: pending
+    disposition_rationale: null
+  - id: O10
+    category: alternatives
+    severity: medium
+    claim: "The rejected-alternatives section weighs four ways to compare but never weighs narrowing what is compared, which would remove most false positives without inventing per-project declined state at all."
+    evidence: "§6 rejects the template's own marker, hashing, full-text diff, and a separate file — all four vary the comparison method, none varies the item set; §4.1 compares '## and ###, incl. commented' with no exclusion for placeholders, examples, or opt-in blocks."
+    disposition: pending
+    disposition_rationale: null
+  - id: O11
+    category: implementation
+    severity: medium
+    claim: "The spec never states which copy of the template is authoritative, and in this repository the copy it names is rsynced from the working tree on every Stop, so editing the template nudges the editor about their own unfinished edit."
+    evidence: "§4.1 'tpl = $CLAUDE_PLUGIN_ROOT/templates/HARNESS.md'; CLAUDE.md 'sync-to-global-cache.sh — rsyncs plugin content into the versioned plugin cache (runs on every Stop)'; §1's ## Stakeholders timeline turns on which copy 89b46f9 compared against and the spec does not say."
+    disposition: pending
+    disposition_rationale: null
+  - id: O12
+    category: risk
+    severity: medium
+    claim: "The PR knowingly merges a governing document whose Status block overstates its own coverage, and removes a signal the observatory reference marks required."
+    evidence: "§4.6 'HARNESS.md's Status block references the marker. It is owned by /harness-audit and is corrected by running it, not by hand-editing this PR'; HARNESS.md:760-769 declares 'Template currency' with 'Enforcement: deterministic'; HARNESS.md:1174 'Garbage collection active: 19/19'; §4.6 'observatory-signals.md:127 | Template version is marked required; remove the row'."
+    disposition: pending
+    disposition_rationale: null
+---
+
+## O1 — implementation — critical
+
+### Claim
+
+A default `/harness-init` run produces a `HARNESS.md` that is missing template
+headings by design. Under the proposed set difference, that project is nudged on
+its very next session — naming, among other things, example affordances it was
+never meant to adopt. The replacement signal cries wolf on day one, for the
+default user, which is the defect the spec exists to remove.
+
+### Evidence
+
+The algorithm is a plain set difference over headings:
+
+> `missing = tpl_headings - proj_headings - declined` (§4.1)
+
+`/harness-init` is documented to produce a project file that is *not* a superset
+of the template:
+
+> **Affordances** is opt-in: if **unselected** (the default), replace the
+> `## Affordances` section body with the placeholder marker like any other
+> unselected feature. (`commands/harness-init.md`, step 7)
+
+and, generally:
+
+> For each unselected feature, replace the section body with the placeholder
+> marker. (`commands/harness-init.md`, step 7)
+
+The template's `## Affordances` body contains four headings, each explicitly
+tagged as an example:
+
+```text
+templates/HARNESS.md:519  ### gh-cli                    <!-- affordance-example -->
+templates/HARNESS.md:534  ### honeycomb-mcp             <!-- affordance-example -->
+templates/HARNESS.md:545  ### shell-write-to-tmp        <!-- affordance-example -->
+templates/HARNESS.md:556  ### sync-to-global-cache-hook <!-- affordance-example -->
+```
+
+The template also carries a literal placeholder heading no project should ever
+have: `templates/HARNESS.md:194  ### [Governance constraint name]`.
+
+A user who deselects Garbage collection loses roughly twenty-five `###` headings
+in one step. The spec verified its algorithm against one repository — this one —
+whose `HARNESS.md` happens to be a near-superset of the template, including the
+`[Governance constraint name]` placeholder at line 639 and all four affordance
+examples. That is the single least representative sample available.
+
+### Why this matters
+
+§1's charge against the marker is that it "asserts `Plugin template has been
+updated` on evidence that cannot establish it". The replacement asserts
+`Template has 4 item(s) your harness does not: "gh-cli", "honeycomb-mcp", ...`
+on evidence that is technically true and semantically false — those are examples,
+not items. The message §4.2 is proud of ("A reader can falsify it against their
+own file") is worse here, not better: the reader falsifies it, finds it correct,
+and concludes the mechanism is stupid rather than wrong.
+
+§3.4 anticipates the *class* of this problem and answers it with the declined
+block. But that answer has a cost the spec does not budget: the only way to
+populate the declined block is to run `/harness-upgrade` and decline each item.
+The nudge whose purpose is to sell `/harness-upgrade` can only be silenced by
+running `/harness-upgrade` — on a fresh project, before the user has any reason
+to trust it, for four items that were never content. Either the template must
+mark non-adoptable headings so the comparison can exclude them, or `/harness-init`
+must seed the declined block from what it chose not to write.
+
+## O2 — implementation — high
+
+### Claim
+
+The specified normalisation — case-insensitive and whitespace-trimmed — does not
+match the template's commented section headings, because those headings carry
+instructional parentheticals on the heading line itself. The result is a
+permanent false positive on the very repository the spec used to verify the
+design.
+
+### Evidence
+
+> Matching is case-insensitive and whitespace-trimmed, identical to
+> `/harness-upgrade` step 2, so the hook and the command never disagree about
+> what is new. (§4.1)
+
+The template's opt-in section heading:
+
+```text
+templates/HARNESS.md:630
+<!-- ## Cognitive reservoir  (OPTIONAL — to opt in, remove this `<!--` line and the closing `-->` below)
+```
+
+This repository's adopted version:
+
+```text
+HARNESS.md:1126
+## Cognitive reservoir
+```
+
+Extracted per §4.4 ("extract headings from inside HTML comments at every level"),
+the template heading is `Cognitive reservoir  (OPTIONAL — to opt in, remove this
+` + backtick-quoted markup + `line and the closing ... below)`. Trimming and
+case-folding do not reduce that to `Cognitive reservoir`. The heading is reported
+missing, every session, on a repository that adopted it months ago.
+
+Acceptance criterion 4 covers commented headings and criterion 7 covers case and
+whitespace. Neither covers a parenthetical suffix, so a conforming implementation
+passes the whole suite and still fires this every session.
+
+### Why this matters
+
+The spec's §1 does its verification work well — `diff`, exit codes, commit
+hashes, dates. §5 does not extend that discipline to the new algorithm. Nothing
+in the spec records the output of running the proposed comparison against this
+repository's real `HARNESS.md` and the real template. Had that been run, this
+would have surfaced before review, along with whatever else it turns up. The
+missing artefact is one paragraph: *here is the missing set the new rule produces
+today, and here is why each entry is correct.*
+
+## O3 — specification quality — high
+
+### Claim
+
+§3.4 calls the declined-item record load-bearing and then gives it no grammar.
+The stated format contradicts the spec's own example, and nothing defines
+continuation lines, duplicates, headings containing a colon, or the one input
+that can corrupt the file it lives in.
+
+### Evidence
+
+The rule:
+
+> One line per declined heading, `Heading: reason`. (§3.4)
+
+The example, directly above it:
+
+```html
+<!-- template-declined
+     Consistent formatting: specialised here as "Consistent markdown
+       formatting" (deterministic, markdownlint, commit + pr). Adopting the
+       template's unverified placeholder would be a downgrade.
+-->
+```
+
+That is one declined heading occupying three lines with two distinct indentation
+levels. A parser written to the rule reads three entries: `Consistent formatting`,
+`formatting" (deterministic, markdownlint, commit + pr). Adopting the` (no
+colon — dropped or malformed), and one more. A parser written to the example
+needs a continuation convention the spec never states.
+
+The reason text is user-supplied and machine-written:
+
+> Declining prompts for a one-line reason and writes it to the declined block.
+> (§4.3, step 4)
+
+> The reason text is never parsed. (§3.4)
+
+Never parsed is not the same as harmless. The block is an HTML comment. A reason
+containing `-->` terminates it early, uncommenting whatever follows — in a file
+whose commented blocks are semantically load-bearing, since §4.1 and the
+`## Cognitive reservoir` opt-in both turn on comment state.
+
+### Why this matters
+
+This block is the only thing standing between the new comparison and the old
+defect — §3.4 says so plainly: "Heading comparison alone reproduces the original
+defect in a new coat." It is read by a bash script and written by a model
+following prose. A silent parse failure does not fail loudly; it re-admits the
+declined item to the missing set, and the mechanism resumes crying wolf about
+the exact item three humans already declined on the record. That failure is
+indistinguishable, from the user's seat, from the bug being fixed.
+
+Specify the grammar as strictly as the `## Cognitive reservoir` value lines are
+specified — that block already carries a written warning about exactly this class
+of parser fragility (`HARNESS.md:1145-1148`), which is the precedent to follow.
+
+## O4 — scope — high
+
+### Claim
+
+The §4.6 surfaces table is incomplete. `/harness-sync` reads and reports
+`Template version drift` in three separate places and does not appear in the
+table, so after this ships a drift-reporting mechanism will be reporting on an
+input that no longer exists.
+
+### Evidence
+
+§4.6 lists seven files. `commands/harness-sync.md` is not among them, and it
+carries:
+
+```text
+line 118  - Template version drift                            (surface list)
+line 138  Template version (HARNESS: 0.31, plugin: 0.34) drifted  /harness-upgrade  [manual]
+line 207  "label": "Template drift  [manual: /harness-upgrade]"    (checkbox JSON, id: "template")
+line 271  Manual remediation suggested for: Template version drift
+```
+
+Also absent from §4.6 and from §8's docs list:
+
+- `docs/contributing/index.md:195` — "**Template currency** — detects when the
+  HARNESS.md template version is behind the installed plugin version."
+- `docs/plugins/ai-literacy-superpowers/how-to/sync-harness.md` — six references,
+  including a worked drift-table row and a "Template drift" remediation section.
+
+§4.6 does list `skills/harness-audit-engine/SKILL.md:33`, which is the drift
+surface table row — correctly. The point is not that the spec was careless; it is
+that the enumeration method found seven of ten and the spec presents it as
+complete.
+
+### Why this matters
+
+`/harness-sync` is one of the two monthly operations in `CLAUDE.md`. After this
+merges, its drift scan has a row whose input has been deleted. It will either
+error, or report `drifted` forever, or — most likely, and worst — report
+`in sync`, because "no marker found" collapses to "nothing to compare". That is
+the failure HDR-2026-08-25 names: a status mechanism reaching the reassuring
+answer without reading the thing it reports on. The spec removes the marker on
+the strength of an inventory that missed the mechanism most likely to fail that
+way.
+
+## O5 — premise — medium
+
+### Claim
+
+The spec's own evidence records no instance of this nudge ever producing a useful
+adoption, and the single case offered in its favour is one the spec states cannot
+be settled. On that basis the design keeps the nudge and adds new per-project
+governance state to it.
+
+### Evidence
+
+Against:
+
+> Five of the last six marker advances adopted nothing. (§1)
+
+> The 2026-08-25 run reached the same conclusion about the same item a third
+> time. (§1)
+
+In favour, in full:
+
+> `d867c7c` added a commented-out `## Stakeholders` section ... `89b46f9` ran six
+> hours later, reported "byte-identical … nothing to adopt" ... This cannot be
+> settled now — the `0.73.2` plugin cache is no longer on the machine that ran
+> it. (§1)
+
+And the decision that rests on it:
+
+> Rejected because the `## Stakeholders` case *suggests* the failure mode that
+> actually costs something is *not being told*. (§3.3, emphasis added)
+
+### Why this matters
+
+§3.3 is the right question asked once and answered from the weaker of the two
+available bodies of evidence. Six recorded runs adopting nothing is data; one
+unattributable miss is an anecdote whose cause §4.4 guesses at (see O11 for a
+third candidate cause). The cost of being wrong here is not the hook — it is
+§3.4's declined block, a new durable governance artefact in every project that
+adopts the plugin, kept alive to serve a signal with no recorded success.
+
+I am not asserting the nudge is worthless; §3.3 may well be right that *not being
+told* is the expensive failure. I am objecting that the spec does not know, says
+so, and proceeds as though the question were closed. The honest form of §3.3 is
+either evidence that someone was ever usefully told, or an explicit statement
+that the nudge is being retained on judgement rather than data.
+
+## O6 — implementation — high
+
+### Claim
+
+The spec asserts an invariant its architecture cannot supply. The hook and the
+command are two independent implementations of one parser — one bash, one prose
+executed by a model — and this repository already runs a GC rule because that
+exact drift is a known local failure class.
+
+### Evidence
+
+> Matching is case-insensitive and whitespace-trimmed, identical to
+> `/harness-upgrade` step 2, so the hook and the command never disagree about
+> what is new. (§4.1)
+
+> Both the hook and the command extract headings from inside HTML comments at
+> every level. (§4.4)
+
+`hooks/scripts/template-currency-check.sh` is bash. `commands/harness-upgrade.md`
+is a markdown prompt: "Match items by heading name (case-insensitive, trimmed)"
+(step 2). The second is an instruction to a model, not an implementation.
+
+The repository's own position on this class:
+
+```text
+HARNESS.md:690  ### Command-prompt sync
+```
+
+### Why this matters
+
+"Never disagree" is doing load-bearing work in this design. §4.3 has the command
+subtract declined headings and present a *Previously declined* group; §4.1 has
+the hook subtract the same set. If they diverge, the user is nudged about an item
+the command will not show them, or shown an item the hook never mentions —
+either of which reads as the mechanism being broken, because it is.
+
+The single-implementation alternative is available and unweighed: have step 2
+invoke `template-currency-check.sh` (or a shared extraction script) and consume
+its output, rather than restating its rules in prose. That would make the
+invariant structural instead of asserted, and would collapse §4.4's "both the
+hook and the command" into one change instead of two that must agree.
+
+## O7 — risk — high
+
+### Claim
+
+The hook reaches its silent, passing outcome on a code path where it has not read
+the thing it reports on. The harness decision record in force names that a defect
+rather than a default, and the spec carries the behaviour forward marked
+"unchanged".
+
+### Evidence
+
+> `exit 0 if either file is unreadable          (unchanged: advisory, never blocks)`
+> (§4.1)
+
+> 9. The hook never blocks and never exits non-zero. (§5)
+
+Against HDR-2026-08-25, compiled into
+`ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md` and in force until
+2026-11-23:
+
+> A mechanism that reports a status ... must have a defined value for the case
+> where it could not determine the answer, and that value may not be the passing
+> one. Where an input is missing, unreadable or not supplied, the mechanism
+> reports the degraded or unknown state and names the input it could not read.
+
+The unreadable case is not hypothetical for this hook: `$CLAUDE_PLUGIN_ROOT` is
+unset outside a plugin context, and the current script already exits 0 in three
+such places (lines 19-26, 38-40).
+
+### Why this matters
+
+There is no tension between the HDR and "never blocks" — a `systemMessage` naming
+the unreadable input satisfies both, and §4.2 already establishes the message
+channel. What the spec has done is carry an old behaviour forward under the word
+"unchanged", which is precisely how a mechanism that fails toward the reassuring
+answer survives a rewrite that was otherwise willing to delete everything.
+
+The consequence is specific: a project whose plugin root is misconfigured gets
+silence, reads silence as "my harness is current", and stops looking. That is the
+same failure §1 describes, arrived at from the other direction — §1's mechanism
+lied loudly, this path lies quietly.
+
+## O8 — scope — medium
+
+### Claim
+
+The design removes the only mechanism for silencing the nudge without acting on
+it, leaving *skip* as a disposition that guarantees the item re-fires every
+session forever. The spec does not state this consequence.
+
+### Evidence
+
+> `.claude/.harness-upgrade-dismissed` is no longer written or read. (§4.5)
+
+> **Skip** remains what it is today: not now, ask again next time. (§4.3, step 4)
+
+> `missing = tpl_headings - proj_headings - declined` (§4.1)
+
+Skipped items are not in `declined`, so they remain in `missing`. Under the old
+design, the dismissal file silenced the hook until the next plugin version — a
+skip bought the user weeks. Under the new one, "ask again next time" means the
+next session, and the one after that.
+
+### Why this matters
+
+The spec's central charge is alert fatigue: an item declined three times on
+recorded reasoning kept coming back. §3.4 solves that for *decline* and leaves
+*skip* with strictly worse ergonomics than it has today. A user who wants to
+consider an item next month has exactly two options: adopt it, or record a formal
+decline they do not mean. The predictable outcome is that people decline things
+to make the nudge stop, which converts §3.4's "declining is a considered act
+rather than a suppression" into its opposite.
+
+Either skip needs a time-boxed silence, or the spec should say plainly that skip
+now means "nudge me every session until you decide" and accept that as the design.
+
+## O9 — specification quality — medium
+
+### Claim
+
+The test plan assigns command behaviour to a hook test file, and leaves the write
+path of the declined block — the mechanism §3.4 calls load-bearing — with no
+acceptance criterion at all.
+
+### Evidence
+
+> Criteria 1-7 and 9 are Layer 0 deterministic tests at
+> `tdad_tests/layer0_deterministic/test-template-currency-check.sh` (§5)
+
+Criterion 6 is:
+
+> Given a `HARNESS.md` with a `template-version` marker, `/harness-upgrade`
+> removes it and reports having done so.
+
+That is a model-executed command, not the hook script named as its test location.
+Criterion 7 spans "both the hook and the command", so at most half of it can live
+there. Criterion 8, correctly, is excluded from the deterministic list — which
+shows the boundary was noticed for one criterion and not the neighbouring two.
+
+Every declined-block criterion is a *read* criterion. Criterion 3 assumes a
+correctly formed block already exists; criterion 8 assumes the command can read
+one. Nothing tests that §4.3 step 4 and step 6 *write* a block that criterion 3
+can read.
+
+### Why this matters
+
+Given O3, the write path is where this design is most likely to fail, and it is
+the one path with neither a specified format nor a test. The round trip is the
+thing worth pinning: decline an item via the command, then run the hook and
+observe silence. Written as a Layer 0 fixture pair, that single test would catch
+every grammar ambiguity in O3 without the spec having to resolve them in prose
+first.
+
+## O10 — alternatives — medium
+
+### Claim
+
+§6 weighs four alternative ways to *compare*, and never weighs narrowing *what*
+is compared. Excluding placeholders, examples, and opt-in blocks from the item
+set removes most of the false-positive load without inventing per-project
+declined state at all.
+
+### Evidence
+
+All four rejected alternatives vary the comparison method:
+
+> **Compare the template's own content marker** ... **Hash the template and store
+> the hash** ... **Full-text diff instead of heading sets** ... **Record declines
+> in a separate file.** (§6)
+
+The item set is fixed by one parenthetical and never revisited:
+
+> `tpl_headings   = headings of tpl             (## and ###, incl. commented)` (§4.1)
+
+The template already distinguishes the categories that would be excluded, in
+machine-readable form: `<!-- affordance-example -->` (lines 520, 535, 546, 557),
+`<!-- Uncomment if ... -->` wrappers (lines 147, 181, 192, 372, 406, 446), and a
+bracketed placeholder heading (`### [Governance constraint name]`, line 194).
+`/harness-upgrade` step 2 already keys on the `<!-- Uncomment if...` pattern
+today.
+
+### Why this matters
+
+§3.4's declined block exists because "heading comparison alone reproduces the
+original defect in a new coat". That is true of an *unfiltered* heading
+comparison. A filtered one — active constraints and GC rules, excluding examples
+and placeholders — reduces the standing false-positive set from O1's dozens to
+approximately the one case §3.4 actually cites (`Consistent formatting` versus
+`Consistent markdown formatting`), which is a genuine specialisation and the only
+case where a recorded human decision is really needed.
+
+That is a materially cheaper design: it drops a new durable per-project artefact,
+its grammar (O3), its write path (O9), and the new `decline` disposition, in
+exchange for a filter over a set the template already tags. §6 should say why it
+is worse, or take it.
+
+## O11 — implementation — medium
+
+### Claim
+
+The spec never states which copy of the template is authoritative. The path it
+names is, in this repository, rsynced from the working tree on every `Stop` —
+which both creates a self-referential false positive during template development
+and supplies a third, simpler explanation for §1's `## Stakeholders` case than
+the parsing asymmetry §4.4 fixes.
+
+### Evidence
+
+> `tpl      = $CLAUDE_PLUGIN_ROOT/templates/HARNESS.md` (§4.1)
+
+`CLAUDE.md`, Marketplace Cache Auto-Sync:
+
+> `ai-literacy-superpowers/scripts/sync-to-global-cache.sh` — rsyncs plugin
+> content into the versioned plugin cache (runs on every `Stop`)
+
+So in this repository the hook compares the project's `HARNESS.md` against a
+template copy that tracks the working tree within one session. And §1's timeline:
+
+> `d867c7c` added a commented-out `## Stakeholders` section to the template on
+> 2026-08-13 at 09:11. `89b46f9` ran six hours later, reported "byte-identical …
+> nothing to adopt". (§1)
+
+Whether that report was wrong depends entirely on which copy `89b46f9` read — and
+the spec does not say, while §4.4 proceeds as though parsing were the cause:
+
+> This is the parsing half of the `## Stakeholders` case in §1. (§4.4)
+
+### Why this matters
+
+Two distinct consequences. First, operationally: a maintainer who adds a heading
+to `templates/HARNESS.md` gets nudged, in their next session, that their own
+harness is missing the thing they just wrote. That is a new failure the current
+version-based hook does not have.
+
+Second, epistemically: if `89b46f9` compared against a cache copy that predated
+`d867c7c`, then the comparison was *correct*, §4.4 fixes a bug that was not the
+cause, and the one piece of evidence sustaining §3.3's decision to keep the nudge
+(O5) evaporates. §4.4 is worth doing regardless — commented headings should parse
+uniformly — but it should not be presented as the explanation of a case the spec
+has not attributed. Naming the authoritative copy, and what happens when it is
+the working tree, closes both.
+
+## O12 — risk — medium
+
+### Claim
+
+The PR knowingly merges a governing document whose Status block overstates its own
+coverage, and removes a row the observatory reference marks required, without
+saying what either consequence is.
+
+### Evidence
+
+> `HARNESS.md`'s Status block references the marker. It is owned by
+> `/harness-audit` and is corrected by running it, not by hand-editing this PR.
+> (§4.6)
+
+The rule being removed is deterministic and counted:
+
+```text
+HARNESS.md:760-769   ### Template currency ... **Enforcement**: deterministic
+HARNESS.md:1174      Garbage collection active: 19/19
+```
+
+After the removal, 19/19 describes eighteen rules. And:
+
+> `skills/harness-observability/references/observatory-signals.md:127` |
+> `Template version` is marked **required**; remove the row (§4.6)
+
+### Why this matters
+
+§4.6's reasoning is right about ownership — `/harness-audit` owns the Status
+block, and hand-editing it is worse than leaving it. But the choice presented is
+false: the third option is to run `/harness-audit` as part of this change, which
+the repository's own convention supports, and which turns "the governing document
+is wrong until someone notices" into "the governing document is correct at merge".
+Leaving it stale is the same fail-toward-reassuring pattern as O7, in the document
+that is supposed to be the source of truth for all the others — and this
+repository's Status block already carries a written record of exactly this
+happening before ("The 2026-08-13 audit recorded `Drift detected: no` against a
+tree that already carried every failure listed here", `HARNESS.md:1177`).
+
+On the observatory signal: the spec says to remove a row marked **required**
+without stating whether `required` is enforced, what reads it, or what happens to
+archived snapshots that carry the field. If nothing enforces it, say so; if
+something does, this is a schema change and belongs in §4.6 with its consumers
+named.
+
+## Explicitly not objecting to
+
+- **§1's evidence quality**: the problem statement is the strongest part of this
+  spec — byte-level `diff` results, commit hashes, dates, and a stated
+  verification date. It establishes the marker is a bad proxy beyond argument,
+  and I am not challenging that conclusion anywhere in this record.
+- **Retiring the marker rather than making it optional (§3.1)**: the reasoning is
+  correct and well argued — opting out of a broken signal is not fixing it, and
+  the projects most in need of a nudge are exactly the ones that would go quiet.
+- **Rejecting the `none` sentinel (§3.2)**: "Retiring the signal is cheaper than
+  governing it" is the right call, and the spec correctly identifies that it is
+  trading against a local declare-don't-infer preference rather than a rule.
+- **Keeping the declined record in `HARNESS.md` rather than a new file (§6)**:
+  the "two committed dashboards went 106 days unread" argument is concrete,
+  local, and decisive. My objections to the declined block (O3, O9) are about its
+  grammar and its tests, never its location.
+- **The minor version bump and the five CI-checked locations (§7)**: correct per
+  `CLAUDE.md`, correctly scoped as behavioural, and nothing here warrants a
+  challenge.
+- **Rejecting full-text diff (§6)**: "The property worth surfacing is a *missing
+  item*, not a reworded one" is exactly right, and it is the sentence that keeps
+  the message in §4.2 honest about what it compared.
+- **The TDAD constraint analysis (§5)**: the spec correctly reasons that the
+  *New plugin components must ship with a TDAD scenario* constraint does not gate
+  this work, and adds the Layer 0 test anyway with a stated reason. That is the
+  right relationship to a constraint and I am not going to punish it.
+- **Leaving the `.gitignore` entry in place (§4.5)**: the reasoning — the file
+  exists on machines that ran the old command, and removing the ignore surfaces
+  it as untracked — is a small, correct piece of migration thinking that many
+  specs would have missed.
+- **The out-of-scope boundary**: excluding adoption mechanics, the evolution
+  loop, and the `/harness-propose` routing question is a defensible line. My
+  scope objections (O4, O8) are about surfaces inside the declared scope that the
+  spec missed, not about where the line was drawn.

--- a/docs/superpowers/objections/template-currency-measure-content-design.md
+++ b/docs/superpowers/objections/template-currency-measure-content-design.md
@@ -7,623 +7,571 @@ objections:
   - id: O1
     category: premise
     severity: high
-    claim: "The spec retains a nudge it admits has zero recorded successes, and compares the retained option against deletion using a cost figure ('two greps at session start') that omits the shared script, the bin shim, the new HARNESS.md grammar, the new command disposition, the eighteen acceptance criteria and the twelve-file migration the same spec specifies."
-    evidence: "§3.3 'there is no recorded instance of this nudge producing a useful adoption. Six runs are recorded; five adopted nothing, and the sixth cannot be attributed'; §3.3 'a correctly filtered comparison costs two greps at session start'; §6 'Delete the nudge entirely … Still live, and strengthened by §1.1 removing the evidence that favoured keeping it.'"
+    claim: "The load-bearing claim that the mechanism has no recorded successes is a survivorship artefact — in five of six recorded runs the template had not changed, so 'adopted nothing' is a true negative rather than a failure."
+    evidence: "§1: 'The plugin moved ten minor versions across that window. The template moved zero bytes.' §1.1: 'There is therefore no recorded instance of this nudge producing a useful adoption.' §2.2 rests acceptance of the loss on 'the mechanism being removed has never demonstrably provided it.'"
     disposition: pending
     disposition_rationale: null
   - id: O2
     category: implementation
     severity: critical
-    claim: "The filter does not exclude commented-out opt-in template blocks, and §5.1 criterion 4 mandates including them, so a default-initialised project is told on day one that it is missing 'Stakeholders' and 'Cognitive reservoir' — content the template itself labels OPTIONAL. This is the day-one false positive §3.4 exists to eliminate."
-    evidence: "§4.1 'tpl_headings = ## and ### headings of tpl, including inside HTML comments' with exclusions only for affordance-example and ^\\[.*\\]$; §5.1 criterion 4 'A template heading that appears only inside an HTML comment is treated like any other'; templates/HARNESS.md:39 '<!-- ## Stakeholders' with ':41 OPTIONAL.'; templates/HARNESS.md:630 '<!-- ## Cognitive reservoir  (OPTIONAL — to opt in …)'; §3.4 'An unfiltered heading comparison fires on the default install, on day one.'"
+    claim: "Criterion 6's four search terms cannot match the phrasing that actually carries this mechanism across the tree, so the residue assertion returns the passing answer over a tree that still advertises the deleted hook in at least eleven places."
+    evidence: "§6 criterion 6 searches for `template-version`, `Template currency`, `template-currency`, `harness-upgrade-dismissed`. None of these match `hooks/hooks.json:2` ('template currency check ... (SessionStart) nudge on plugin upgrade'), `README.md:371` ('SessionStart template currency check'), `commands/harness-sync.md:118,138,207,271,294` ('Template version drift' / 'Template drift'), `skills/harness-audit-engine/SKILL.md:3`, `CLAUDE.md:284`, `templates/CLAUDE.md:220`, `docs/plugins/ai-literacy-superpowers/reference/skills.md:46`, `.../tutorials/first-time-tour.md:558`, `.../explanation/the-harness-lifecycle.md:161`, `.../explanation/the-loops-that-learn.md:36`, `.../reference/output-validation.md:33`."
     disposition: pending
     disposition_rationale: null
   - id: O3
-    category: implementation
+    category: specification quality
     severity: high
-    claim: "The affordance-example exclusion, as specified, matches nothing: the tag sits on the line after each heading in the real template, not on the heading line."
-    evidence: "§4.1 excludes 'a heading whose line carries <!-- affordance-example -->'; §3.4 cites 'four headings tagged <!-- affordance-example --> (templates/HARNESS.md:520,535,546,557)'. In the file, the headings are at :519 '### gh-cli', :534 '### honeycomb-mcp', :545 '### shell-write-to-tmp', :556 '### sync-to-global-cache-hook'; lines 520/535/546/557 are the standalone comment lines beneath them."
+    claim: "Criterion 6's allow-list omits the two files that must contain the forbidden strings by construction — the migration command and the test that implements the criterion — so the Layer 0 test fails on its own implementation."
+    evidence: "§6 criterion 6 permits matches 'only in: CHANGELOG.md, REFLECTION_LOG.md, reflections/, assessments/, harness/assay/, docs/superpowers/{specs,plans,objections}/, observability/snapshots/, and the .gitignore line.' §5 requires `/harness-upgrade` step 6 to detect 'a `<!-- template-version: … -->` marker' and 'a `### Template currency` GC rule', and §6 places the test at `tdad_tests/layer0_deterministic/test-template-currency-retired.sh` — a filename containing `template-currency`."
     disposition: pending
     disposition_rationale: null
   - id: O4
-    category: scope
-    severity: high
-    claim: "No acceptance criterion runs the algorithm against a default-initialised project, and the one real-input criterion runs against a repository that is a superset of the template — an input on which every exclusion rule is unobservable, so O2 and O3 both ship green."
-    evidence: "§5.2 criterion 14 'Run against this repository's committed HARNESS.md and templates/HARNESS.md, the missing set is empty'; §5.2 'This criterion exists because revision 1 never ran its own algorithm.' This repository's HARNESS.md already contains '### gh-cli' (:1014), '### honeycomb-mcp' (:1032), '### shell-write-to-tmp' (:1043), '### sync-to-global-cache-hook' (:1054) and '### [Governance constraint name]' (:639), so criteria 5 and 6 pass on this input whether or not the exclusions fire. Criteria 5–7 are fixture tests authored from the same rule text they are meant to check."
+    category: implementation
+    severity: critical
+    claim: "Step 6's migration deletes content from a project's governing document unconditionally and without asking, inside a command whose entire design is per-item consent."
+    evidence: "§5: 'On any run, if the project's HARNESS.md contains: a `<!-- template-version: … -->` marker, it is removed; a `### Template currency` GC rule … it is removed'. `commands/harness-upgrade.md:104` — 'Ask the user to choose for each item' — and step 4 offers 'accept, skip, or customise' for every other change the command makes. CLAUDE.md: 'hand edits are how a governing document becomes the least governed thing in the repository.'"
     disposition: pending
     disposition_rationale: null
   - id: O5
     category: scope
     severity: high
-    claim: "Replacing /harness-upgrade step 2's parse with harness-template-diff silently deletes two of the command's three finding buckets: the script computes only the missing set, while the command today also produces 'Updated items' and 'Removed items'."
-    evidence: "§4.4 'Step 2 invokes harness-template-diff --format=json rather than restating the matching rules'; §4.1's contract yields only 'missing'. commands/harness-upgrade.md:74 'Sort items into three buckets', :79 '**Updated items** — present in both files, but the template content differs', :86 '**Removed items** — present in the user's HARNESS.md but absent from the current template.' §4.4 lists changes to steps 1, 2, 3, 4, 6 and 7 and never mentions either bucket."
+    claim: "The spec applies its own Status-block standard to this repository and not to the projects it migrates, so every migrated project is left with a governing document that overstates its GC coverage."
+    evidence: "§10: 'Removing the `Template currency` GC rule changes the `Garbage collection active:` count in HARNESS.md's Status block … This PR runs `/harness-audit` … rather than merging a governing document that misstates its own coverage.' §5 performs the identical edit in consuming projects with no equivalent step. `skills/harness-audit-engine/SKILL.md:32` makes Status-block accuracy a tracked drift surface."
     disposition: pending
     disposition_rationale: null
   - id: O6
-    category: risk
+    category: scope
     severity: high
-    claim: "Migration deletes the marker from every consuming project's HARNESS.md while leaving the `Template currency` GC rule that reads it in place, converting a noisy-but-explicable signal into a permanently failing one — and, per O5, removing the only path by which the command would have surfaced the orphan."
-    evidence: "§4.5 'The marker becomes inert on the release that ships this. Nothing reads it, so a project that still has one is not broken' and '/harness-upgrade removes it when it next runs'; §4.5 scopes rule removal to 'This repository removes its own in this PR, along with the Template currency GC rule.' templates/HARNESS.md:335-342 shipped the rule to every project ('Tool: compare template-version comment in HARNESS.md against …'). Under the pre-existing semantics a missing marker is 0.0.0 (hooks/scripts/template-currency-check.sh:32-34), i.e. permanently drifted."
+    claim: "The migration reaches only projects that run `/harness-upgrade` — by the spec's own argument the population least in need of it — yet §9 records the corresponding prior objection as fully resolved."
+    evidence: "§5: 'A project that never runs `/harness-upgrade` again keeps an orphaned rule.' §7 argues against the opt-out alternative because it 'silences the nudge for projects that never had one — the population most likely to need it.' §9: 'O6 | high | **Resolved** — §5 migrates consuming projects' orphaned GC rule'."
     disposition: pending
     disposition_rationale: null
   - id: O7
-    category: alternatives
+    category: scope
     severity: high
-    claim: "The template's own content marker is rejected for being unmaintained and unread — both fixable properties, and this spec already demonstrates the fix it declines to apply. A Layer 0 assertion that a change to templates/HARNESS.md moves its marker, plus a hook that compares that marker instead of plugin.json, measures the stated property with one CI check and no new script, grammar, shim or declined-item mechanism."
-    evidence: "§6 'Compare the template's own content marker. Unmaintained — d867c7c changed the template without moving it — and nothing reads it.' §4.2 adds exactly this class of guard for a different defect: 'A Layer 0 test asserts no heading line in templates/HARNESS.md carries a trailing parenthetical, so the class cannot return.' §6's other rejection, 'reintroduces per-project state that drifts', does not apply: the marker lives in the plugin's template, not per project."
+    claim: "§2.2 prices only the loss of the unprompted notification, but §3 also deletes three other consumers — the `/harness-sync` monthly drift surface, the `/harness-audit` engine row, and the assessment's harness-detection marker — including a reader for data that stays in the wild."
+    evidence: "§2.2: 'A project that upgrades the plugin will no longer be told, unprompted, that the template gained content.' §3 additionally deletes `commands/harness-sync.md:118,206-207,271,294`, `skills/harness-audit-engine/SKILL.md:33`, `skills/harness-observability/references/observatory-signals.md:127`, and `skills/ai-literacy-assessment/references/habitat-discovery.md:93,141` — the last being a marker used to recognise that a project has a harness at all, which unmigrated projects will keep carrying."
     disposition: pending
     disposition_rationale: null
   - id: O8
-    category: implementation
+    category: alternatives
     severity: high
-    claim: "The skip semantics reason about sessions, but SessionStart re-fires on resume, clear and compact; with the dismissal file removed and no startup guard specified, a project with one genuinely new template item gets the nudge re-injected repeatedly within a single working session."
-    evidence: "§4.4 'Skip means not now, ask again next session … being reminded of those each session is the intended behaviour'; §4.5 '.claude/.harness-upgrade-dismissed is no longer written or read.' hooks/hooks.json:106 registers the hook under SessionStart with matcher '*'. The sibling hook on the same rail guards for this explicitly — hooks/scripts/wip-check.sh:28-29 'STARTUP ONLY. SessionStart re-fires on resume, clear and compact, and a breach report re-injected mid-session is the thrash this exists to name' and :47 '[ \"$source_field\" = \"startup\" ] || exit 0'. §4.1 and §4.4 specify no equivalent."
+    claim: "All four alternatives in §7 keep or repair the nudge; the spec never weighs deleting less — removing the SessionStart hook (the every-session false signal) while retaining the pull-direction surfaces."
+    evidence: "§7 lists 'Compare heading sets', 'Filter the compared set', 'Fix the template's own content marker and read that', and 'Keep the marker but make its absence an opt-out'. §1's evidence of harm is specific to the hook's assertion ('the SessionStart hook asserts `Plugin template has been updated` on evidence that cannot establish it'), not to the `/harness-sync` row, which surfaces drift as a `[manual]` item at a monthly cadence the user chose."
     disposition: pending
     disposition_rationale: null
   - id: O9
-    category: scope
-    severity: high
-    claim: "The §4.7/§8 inventories are again presented as complete and are again incomplete, and the spec adds no acceptance criterion asserting that no live reference to the marker survives — so the only defence against a third recurrence is a third hand-made list."
-    evidence: "§4.7 'Revision 1's table listed seven files and presented the inventory as complete; it found seven of ten.' Unlisted live references: skills/harness-observability/references/observatory-signals.md:157 '| **Total** | **82** |'; commands/observatory-verify.md:3 '82-signal checklist' and :17 '82 signals across 5 sources'; README.md:77 'the Template currency rule checks the same marker'; docs/plugins/ai-literacy-superpowers/reference/hooks.md:277 '### Template currency check'; docs/plugins/ai-literacy-superpowers/reference/commands.md:133 '.claude/.harness-upgrade-dismissed marker'; commands/harness-upgrade.md:152 'Template version updated from X.Y.Z to A.B.C'. §5 contains no criterion of the form 'grep finds no remaining reference outside CHANGELOG and archives'."
+    category: risk
+    severity: medium
+    claim: "The spec names the condition under which the decision is wrong and the option to reopen on, but the migration strips from the install base the marker that option depends on, making the recorded reopening path more expensive than §7 implies."
+    evidence: "§2.2: 'If a future adopter reports missing template content they would have wanted to know about, that is evidence this decision was wrong and is worth reopening on.' §7: 'have the hook compare that marker rather than `plugin.json` … recorded here in enough detail to be taken up without re-deriving it.' §5 removes the project-side marker on every `/harness-upgrade` run."
     disposition: pending
     disposition_rationale: null
   - id: O10
-    category: specification quality
-    severity: medium
-    claim: "The comparison rule specifies HTML-comment handling for the template side and is silent for the project side, and this repository's own file makes the two readings give opposite results for criterion 14."
-    evidence: "§4.1 'tpl_headings = ## and ### headings of tpl, including inside HTML comments' — the corresponding proj_headings term is used undefined in 'skip if normalise(h) is in normalise(proj_headings)'. This repository's HARNESS.md:55 carries '<!-- ## Stakeholders' inside a comment. Under a comment-excluding read of the project side, criterion 14's missing set is not empty; under a comment-including read it is."
+    category: risk
+    severity: high
+    claim: "Stripping the marker while older plugin copies remain installed produces a permanent every-session false nudge that the new command can no longer silence, because it stops writing the dismissal file."
+    evidence: "`hooks/scripts/template-currency-check.sh:32-34` — absent marker is treated as `0.0.0` — with `:43-45` and `:48-53`, so an absent marker nudges unless a dismissal file matching the plugin version exists. §3: '`.claude/.harness-upgrade-dismissed` is no longer written or read.' CLAUDE.md documents per-version plugin caches and a separately-synced marketplace clone, so mixed versions across machines and teammates are the normal case."
     disposition: pending
     disposition_rationale: null
   - id: O11
     category: specification quality
     severity: medium
-    claim: "Criterion 10 is filed under §5.1 as a Layer 0 test of harness-template-diff, but the script has no write path — the `--` rejection is a behaviour of the model-executed command, which is exactly the misfiling §5.3 says revision 1 committed."
-    evidence: "§5.1 heading 'harness-template-diff — Layer 0 deterministic', criterion 10 'A declined reason containing -- is rejected on write.' §4.1's interface is 'harness-template-diff [--format=text|json]' with read-only inputs and four outcomes, none of which write. §4.4 assigns the behaviour elsewhere: 'Step 4 … Declining prompts for a reason and writes it per §3.5's grammar, rejecting a reason containing --.' §5.3 'Not Layer 0; these are model-executed … Revision 1 assigned them to the hook's test file in error.'"
+    claim: "The GC-rule removal predicate is stated in prose and never checked against the text it must match, and no behaviour is defined for a near-miss, a customised rule, or an unreadable file."
+    evidence: "§5: 'a `### Template currency` GC rule whose **Tool** field references the template-version comment, it is removed'. §2.1 records that revision 2 shipped 'an exclusion predicate that matched nothing … verified by `grep '^###.*affordance-example'` returning zero matches'. §5's step 7 defines only the success report: 'step 7 reports each removal by name.'"
     disposition: pending
     disposition_rationale: null
   - id: O12
-    category: risk
-    severity: medium
-    claim: "§4.3 states an absolute contract — silence never means could-not-check — but only one input failure is covered. The hook's own failure modes (script absent from a partial or stale plugin install, non-zero exit under strict mode, the 10s timeout) all produce silence, which the spec has just defined as the reassuring answer."
-    evidence: "§4.3 'Silence means checked-and-current. It never means could-not-check', citing the harness decision record 'a mechanism that could not determine the answer reports the degraded state and names the input it could not read.' §4.1 defines exactly two non-missing outcomes: 'proj absent -> exit 0, emit nothing' and 'tpl absent/unreadable -> exit 0, emit DEGRADED'. §4.7 specifies the hook only as 'Rewritten to call harness-template-diff'; hooks/hooks.json:107 sets 'timeout: 10', and the current hook runs under 'set -euo pipefail' (hooks/scripts/template-currency-check.sh:11)."
+    category: scope
+    severity: high
+    claim: "The §3 and §12 enumerations miss named surfaces despite claiming grep derivation, and no counterpart to §3.1's signal arithmetic exists for the hook count that a Layer 0 test enforces."
+    evidence: "§12: 'Derived from the grep in §6, not by hand' — yet `how-to/sync-harness.md` matches none of the four terms, and the list omits `README.md:371`, `hooks/hooks.json:2`, `templates/CLAUDE.md:220`, `reference/skills.md:46`, `tutorials/first-time-tour.md:558`, `explanation/the-harness-lifecycle.md:161`, `explanation/the-loops-that-learn.md:36`, `reference/output-validation.md:33`. `hooks.json` declares 18 hooks (4 SessionStart); `tdad_tests/layer0_deterministic/test-hooks-doc-parity.sh:19` records the last time that count went stale. §3.1 does exactly this arithmetic for the observatory total (82 → 81) and nothing equivalent for hooks."
     disposition: pending
     disposition_rationale: null
 ---
-
-# Objections — template currency measures content (revision 2)
 
 ## O1 — premise — high
 
 ### Claim
 
-The spec retains the nudge on a judgement it states honestly, and then prices
-that judgement wrongly. The comparison offered to the reviewer is "two greps at
-session start" versus deleting the hook. The actual retained option is a new
-shared script, a `bin/` shim, a new grammar embedded in the governing document,
-a fourth disposition in `/harness-upgrade`, fifteen Layer 0 criteria, three
-behavioural criteria, a twelve-file migration and eight documentation edits — in
-service of a mechanism with no recorded instance of ever having worked.
+The spec's decisive claim — that the mechanism has never demonstrably worked — is
+read off a sample in which success was structurally impossible for five of six
+trials. In those five windows the template had not changed, so "found nothing to
+adopt" is the mechanism correctly reporting a true negative, not the mechanism
+failing. The one window in which the template *did* change is precisely the one
+§1.1 says cannot be attributed. The informative sample size is therefore one, and
+the spec treats it as six.
 
 ### Evidence
 
-> §3.3: "there is no recorded instance of this nudge producing a useful
-> adoption. Six runs are recorded; five adopted nothing, and the sixth cannot
-> be attributed."
+> The plugin moved ten minor versions across that window. The template moved zero
+> bytes.
 
-> §3.3: "a correctly filtered comparison costs two greps at session start."
+and
 
-> §6: "**Delete the nudge entirely, keeping `/harness-upgrade` on demand.**
-> Still live, and strengthened by §1.1 removing the evidence that favoured
-> keeping it."
+> **There is therefore no recorded instance of this nudge producing a useful
+> adoption.** Six runs are recorded; five adopted nothing and the sixth cannot be
+> attributed.
 
-The spec is candid that this is a judgement and that a reviewer may reject it.
-The objection is not to the candour; it is that the two options are not
-presented in commensurable terms, so the reviewer is choosing between "two
-greps" and "delete the hook" rather than between the real build and the real
-saving. §6's own description of the deletion option — "deletes the hook, the
-shared script, the declined block and §5.1 entirely" — states the true cost of
-the retained option more accurately than §3.3 does.
+and §2.2:
+
+> This is a real reduction in discoverability, and it is accepted on the grounds
+> that the mechanism being removed has never demonstrably provided it.
 
 ### Why this matters
 
-This is the highest-leverage decision in the spec and every other objection
-here is downstream of it. If the nudge goes, O2 through O6, O8, O10 and O12
-evaporate with it. A premise this thinly evidenced deserves the comparison
-stated in like terms before the build proceeds.
+§1's evidence is strong and, I think, correct about a different proposition: that
+plugin version is a broken proxy for template content. That proposition supports
+fixing or removing the *proxy*. The spec then uses a second proposition — that
+notification itself is worthless — to justify removing the *capability*, and
+grounds it in a run history that mostly records the template not moving. If the
+template rarely changes, the correct inference is that a correct marker would fire
+rarely, which is an argument for the cheap version in §7's third alternative, not
+against having one. The deletion may still be right on cost grounds; the spec
+should not rest it on a statistic that a period of template stability generated.
 
 ## O2 — implementation — critical
 
 ### Claim
 
-The filtered item set does not exclude the template's commented-out opt-in
-blocks, and §5.1 criterion 4 explicitly requires including them. A
-default-initialised project has neither `## Stakeholders` nor
-`## Cognitive reservoir`, because both are shipped commented out and are
-labelled OPTIONAL in the template. On day one, such a project is told its
-harness is missing two items it was never meant to have. This is precisely the
-failure mode §3.4 asserts the filter removes.
+Criterion 6 is the spec's central safety mechanism, introduced explicitly because
+hand enumeration failed twice. Its four search terms do not match the phrasing in
+which this mechanism is most widely described. A tree that still advertises the
+SessionStart nudge in at least eleven places — including `hooks.json`'s own
+description and the README's mechanism map — passes criterion 6 clean.
 
 ### Evidence
 
-The template's two opt-in blocks:
+> **Residue assertion.** A repository-wide search for `template-version`,
+> `Template currency`, `template-currency` and `harness-upgrade-dismissed`
+> returns matches only in: …
 
-> `templates/HARNESS.md:39` — `<!-- ## Stakeholders`
-> `templates/HARNESS.md:41` — "OPTIONAL. Who this project affects…"
+Surviving references that match none of those four terms, verified in the tree
+today:
 
-> `templates/HARNESS.md:630` — `<!-- ## Cognitive reservoir  (OPTIONAL — to opt in, remove this `<!--` line and the closing `-->` below)`
+- `ai-literacy-superpowers/hooks/hooks.json:2` — "template currency check and
+  session-registry start (SessionStart) nudge on plugin upgrade" (lower-case
+  "template currency", space-separated)
+- `README.md:371` — "**SessionStart template currency check** — detects when the
+  HARNESS.md template version is behind the installed plugin version"
+- `ai-literacy-superpowers/commands/harness-sync.md:118, 138, 207, 271, 294` —
+  "Template version drift", "Template drift  [manual: /harness-upgrade]"
+  (note that §3 lists 118, 206-207, 271, 294 and misses 138)
+- `ai-literacy-superpowers/skills/harness-audit-engine/SKILL.md:3` — the skill
+  description advertising "template drift" coverage
+- `CLAUDE.md:284` and `ai-literacy-superpowers/templates/CLAUDE.md:220` — "Surfaces
+  ONBOARDING.md staleness, template drift, and recurring reflection patterns"
+- `docs/plugins/ai-literacy-superpowers/reference/skills.md:46`,
+  `.../reference/output-validation.md:33`, `.../tutorials/first-time-tour.md:558`,
+  `.../explanation/the-harness-lifecycle.md:161`,
+  `.../explanation/the-loops-that-learn.md:36`
 
-The rule includes them:
-
-> §4.1: "tpl_headings = ## and ### headings of tpl, **including inside HTML
-> comments**, EXCLUDING: a heading whose line carries `<!-- affordance-example -->`;
-> a heading matching `^\[.*\]$`"
-
-> §5.1 criterion 4: "A template heading that appears only inside an HTML comment
-> is treated like any other; criteria 1–3 hold for it unchanged."
-
-The unconfigured-section skip does not reach them: it fires when "h's owning
-`##` section is unconfigured in proj", and these headings *are* the `##`
-sections. A project that never adopted them has no section body to carry the
-placeholder marker.
-
-The spec came within one line of noticing. §3.4's own trial run reported
-`Cognitive reservoir  (OPTIONAL — …)` as a false positive, and §4.2 diagnosed
-that as a trailing-parenthetical matching failure. That diagnosis is correct for
-*this* repository, which has an uncommented `## Cognitive reservoir`
-(`HARNESS.md:1126`). It is the wrong diagnosis for a default project, which does
-not have the heading at all and will be reported regardless of §4.2's fix. And
-§4.3's exemplar message — `Template has 1 item your harness does not:
-"Stakeholders"` — uses one of the two OPTIONAL blocks as the illustration of a
-legitimately missing item.
+The criterion also does not state whether the search is case-sensitive. Listing
+both `Template currency` and `template-currency` implies it is, which is the
+reading under which the misses above are worst.
 
 ### Why this matters
 
-§3 states the case for revision 2 as "The filter is what makes the mechanism
-quiet; the declined-item record handles only the residue." If the filter leaves
-two OPTIONAL blocks in, the mechanism is not quiet on a default install, and the
-only silencing route available to a new user is the one §3.4 already identified
-as unacceptable: "silenceable only by running the command the nudge advertises."
-The central claim of the revision does not hold as specified.
+The repository's own harness carries
+`HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one`:
+a mechanism that reaches a passing value without reading the thing it reports on
+is a defect, not a default. Criterion 6 is exactly that. Worse, the spec presents
+it as the reason the author no longer needs a complete table — "The assertion is
+cheaper than the table and does not depend on the author having remembered
+everything." If the assertion is blind to the phrasing the mechanism is described
+in, the spec has traded an incomplete table for a check that certifies the
+incomplete table. That is a third repetition of the failure §6 was written to end,
+this time with a green test on top of it.
 
-## O3 — implementation — high
+## O3 — specification quality — high
 
 ### Claim
 
-The `affordance-example` exclusion excludes nothing, because in the real
-template the tag is on the line *following* each heading, not on the heading
-line.
+The allow-list in criterion 6 omits the two files that must contain the forbidden
+strings for the spec to be implementable at all: `commands/harness-upgrade.md`,
+which has to name the marker and the rule in order to remove them, and the test
+file itself, whose filename and search patterns contain them. As written, the
+criterion fails against its own implementation.
 
 ### Evidence
 
-> §4.1: "EXCLUDING: — a heading whose line carries `<!-- affordance-example -->`"
+Criterion 6 permits matches "only in: `CHANGELOG.md`, `REFLECTION_LOG.md`,
+`reflections/`, `assessments/`, `harness/assay/`,
+`docs/superpowers/{specs,plans,objections}/`, `observability/snapshots/`, and the
+`.gitignore` line." Neither `ai-literacy-superpowers/commands/` nor `tdad_tests/`
+appears.
 
-> §3.4: "The template's `## Affordances` body carries four headings tagged
-> `<!-- affordance-example -->` (`templates/HARNESS.md:520,535,546,557`)."
-
-The cited lines are the tags, not the headings:
-
-```text
-519  ### gh-cli
-520  <!-- affordance-example -->
-...
-534  ### honeycomb-mcp
-535  <!-- affordance-example -->
-...
-545  ### shell-write-to-tmp
-546  <!-- affordance-example -->
-...
-556  ### sync-to-global-cache-hook
-557  <!-- affordance-example -->
-```
-
-An implementer following §4.1 literally writes a predicate over the heading
-line and it never matches. An implementer who infers the intent writes a
-lookahead — and the two implementations disagree on any future entry where a
-blank line or a schema comment intervenes.
+§5 requires the command to detect "a `<!-- template-version: … -->` marker" and "a
+`### Template currency` GC rule whose **Tool** field references the template-version
+comment". §6 names the test `test-template-currency-retired.sh`.
 
 ### Why this matters
 
-This is the exclusion §3.4 identifies as the primary day-one false-positive
-source for a project that opted out of Affordances, and it is one of the two
-mechanisms §9 claims resolves the critical objection O1 from the previous
-review. As written it is inert, and per O4 nothing in §5 would reveal that.
+An implementer hitting this has three moves, and two of them are bad: widen the
+allow-list until the test passes (which is how allow-lists become meaningless),
+or write the migration predicate obliquely to dodge the grep (which makes the
+command harder to read and no safer). Only the third — writing the criterion so
+that it exempts the implementation while still constraining everything else — is
+the one the spec wanted, and the spec does not say it. Since criterion 6 is
+Layer 0 and will be committed as a passing test, whichever compromise gets made
+becomes the durable definition of "no residue" with no record that it was a
+compromise.
 
-## O4 — scope — high
+## O4 — implementation — critical
 
 ### Claim
 
-The acceptance criteria never run the algorithm against a default-initialised
-project, and the single real-input criterion runs against a repository that is a
-near-superset of the template — an input on which no exclusion rule is
-observable. Both O2 and O3 pass every criterion in §5.
+Step 6's migration performs an unannounced, unconditional deletion of two blocks
+from a file the plugin does not own, in the one command in the suite whose design
+premise is that the user adjudicates every change to their harness individually.
 
 ### Evidence
 
-> §5.2 criterion 14: "Run against this repository's committed `HARNESS.md` and
-> `templates/HARNESS.md`, the missing set is **empty** …"
->
-> "This criterion exists because revision 1 never ran its own algorithm; §3.4
-> records what happened when it finally was."
+> §5: On any run, if the project's `HARNESS.md` contains: a
+> `<!-- template-version: … -->` marker, it is removed; a `### Template currency`
+> GC rule whose **Tool** field references the template-version comment, it is
+> removed;
 
-This repository already contains every heading the exclusions are supposed to
-suppress:
+Against the existing command:
 
-```text
-HARNESS.md:1014  ### gh-cli
-HARNESS.md:1032  ### honeycomb-mcp
-HARNESS.md:1043  ### shell-write-to-tmp
-HARNESS.md:1054  ### sync-to-global-cache-hook
-HARNESS.md:639   ### [Governance constraint name]
-HARNESS.md:1126  ## Cognitive reservoir
-```
+> `commands/harness-upgrade.md:104` — "Ask the user to choose for each item."
+> `:96-102` — every new item is presented with "Options: **accept**, **skip**, or
+> **customise**." `:131` — "Preserve all existing content that was not part of the
+> upgrade."
 
-So criteria 5 and 6 are satisfied by the project side of the comparison, not by
-the exclusion logic. Criterion 14 will read green with the exclusions removed
-entirely. Criteria 5, 6 and 7 are fixture tests, and the fixtures will be
-authored from the same rule text that carries the defect in O3.
+And against this repository's stated posture toward governing documents:
 
-What is absent is the case the design exists for: run the tool against the
-output of a default `/harness-init` — Affordances off, Stakeholders and
-Cognitive reservoir not adopted — and assert an empty missing set.
+> CLAUDE.md: "Once a harness exists, changing it goes through the governed loop
+> rather than a hand edit to `HARNESS.md` … After that, hand edits are how a
+> governing document becomes the least governed thing in the repository."
 
 ### Why this matters
 
-§5.2 presents criterion 14 as the guard against shipping an unrun algorithm a
-second time. On the input chosen it is a weak guard: it validates that this
-repository is a superset, which was already known, and it is structurally
-incapable of detecting a broken exclusion. The one population the filter was
-designed for — new adopters — is the one population no criterion covers.
+The spec's justification for unconditional removal is sound as far as it goes: a
+rule whose tool compares a marker that no longer exists reports drift forever.
+But the remedy it chose is the plugin silently editing someone's source of truth
+during a command they ran for an unrelated reason, with no prompt, no diff shown
+before the fact, no opt-out, and no undo. A user who had specialised that GC rule
+— which is exactly what §1 says this repository did with `Consistent formatting` —
+loses their work without being asked. A prompt costs one `AskUserQuestion` and
+converts a silent mutation into a recorded decision; the spec does not weigh
+whether to have one. The migration is also the only part of this change that
+touches files outside the repository, which makes it the part that most needs the
+consent posture the rest of the command already has.
 
 ## O5 — scope — high
 
 ### Claim
 
-Step 2 of `/harness-upgrade` currently parses both files into three buckets.
-`harness-template-diff` computes one. Substituting the script for the parse
-deletes the "Updated items" and "Removed items" buckets, and §4.4 does not
-mention either.
+The spec identifies that removing the GC rule invalidates the Status block, refuses
+to merge a governing document that misstates its own coverage, and then performs the
+same edit in every consuming project it reaches without any equivalent repair.
 
 ### Evidence
 
-> §4.4: "**Step 2** invokes `harness-template-diff --format=json` rather than
-> restating the matching rules."
+> §10: Removing the `Template currency` GC rule changes the
+> `Garbage collection active:` count in `HARNESS.md`'s Status block, which is owned
+> by `/harness-audit` and must not be hand-edited. **This PR runs `/harness-audit`**
+> and commits its output, rather than merging a governing document that misstates
+> its own coverage.
 
-§4.1's contract emits `missing` and nothing else.
-
-The command today:
-
-> `commands/harness-upgrade.md:74`: "Sort items into three buckets:"
-> `:79`: "**Updated items** — present in both files, but the template content
-> differs. Only flag items the user has not customised…"
-> `:86`: "**Removed items** — present in the user's HARNESS.md but absent from
-> the current template. Advisory only."
-
-§4.4 enumerates changes to steps 1, 2, 3, 4, 6 and 7. Step 3's new **Previously
-declined** group is described; the two disappearing groups are not. §6 offers a
-rationale for choosing heading sets over full-text diff — "The property worth
-surfacing is a *missing item*, not a reworded one" — which is a defensible
-answer for the *hook*, but "Updated items" is a `/harness-upgrade` feature about
-content, and dropping it is a decision the spec does not record as one.
+§5 contains no counterpart. `skills/harness-audit-engine/SKILL.md:32` makes
+"`HARNESS.md` Status block matches actual constraint enforcement counts" a tracked
+drift surface, auto-fixable via `/harness-audit`.
 
 ### Why this matters
 
-A user who runs `/harness-upgrade` after this change will no longer be shown
-that a constraint they never customised has been rewritten in the template, nor
-that their harness carries items the template has dropped. Both are silent
-regressions in a command whose stated job is bringing a harness in line with the
-template. The second one has a direct consequence — see O6.
+After migration, every consuming project's Status block claims one more active GC
+rule than it has, and their next `/harness-audit` or `/harness-sync` reports drift
+that the plugin introduced. This is the same class of defect §1 opens with — a
+governing document carrying a false statement about itself — and §10 shows the
+author already holds the standard. Step 6 either needs to say "then tell the user
+to run `/harness-audit`", or step 7's report needs to name the consequence.
+Neither is expensive; neither is present.
 
-## O6 — risk — high
+## O6 — scope — high
 
 ### Claim
 
-Migration deletes the `template-version` marker from consuming projects while
-leaving the `Template currency` GC rule that reads it. Under the pre-existing
-"missing marker means 0.0.0" semantics, that rule then reports drift on every
-run, forever, in every project that ever ran `/harness-init`. Nothing in the
-spec removes it, and per O5 the one bucket that would have flagged it is being
-removed in the same change.
+The migration only fires when a project runs `/harness-upgrade`, which by the
+spec's own reasoning is the population that least needs help. §9 nonetheless
+records the prior objection about orphaned rules as "Resolved".
 
 ### Evidence
 
-> §4.5: "The marker becomes inert on the release that ships this. Nothing reads
-> it, so a project that still has one is not broken."
-> "`/harness-upgrade` removes it when it next runs, and says so in its report."
-> "This repository removes its own in this PR, along with the `Template
-> currency` GC rule."
+§5 concedes:
 
-The rule was shipped to every adopter by the template:
+> A project that never runs `/harness-upgrade` again keeps an orphaned rule. That
+> is not fully solvable from here …
 
-> `templates/HARNESS.md:335` `### Template currency`
-> `:337` "**What it checks**: Whether the HARNESS.md template-version marker…"
-> `:342` "**Tool**: compare template-version comment in HARNESS.md against…"
+§7 rejects the opt-out alternative on precisely this asymmetry:
 
-The failure semantics are already established in the code being replaced:
+> silences the nudge for projects that never had one — the population most likely
+> to need it.
 
-> `hooks/scripts/template-currency-check.sh:32-34`
-> ```bash
-> if [ -z "$harness_version" ]; then
->   harness_version="0.0.0"
-> fi
-> ```
+§9:
 
-§4.7's row for the rule is scoped to `templates/HARNESS.md:337-342` and
-`HARNESS.md:760-769` — the plugin's copy and this repository's copy. A consuming
-project's copy is its own file and is reached by no listed change.
+> O6 | high | **Resolved** — §5 migrates consuming projects' orphaned GC rule
 
 ### Why this matters
 
-The spec's problem statement is a mechanism that "asserts `Plugin template has
-been updated` on evidence that cannot establish it", and whose "false signal
-reached the governing document" (§1). This migration reproduces that outcome
-exactly, in every project except this one: a GC rule declared in the governing
-document, comparing a value that no longer exists, reporting drift that cannot
-be cleared. It is the defect being fixed, exported to the install base.
+The disposition table is the artefact a future reader will trust when deciding
+whether this ground was covered. "Resolved" overstates what §5 delivers: a partial
+migration that reaches the engaged population, with the unengaged population left
+with a permanently-drifting deterministic GC rule and no notification path — the
+notification path having just been deleted. That combination is worse for those
+projects than the status quo, and it deserves to be recorded as a carried cost
+rather than a resolved objection. The honest entry is "partially resolved for
+projects that re-run the command; unresolved for the rest", which is also what
+§2.2's plain-statement style would produce if applied here.
 
-## O7 — alternatives — high
+## O7 — scope — high
 
 ### Claim
 
-The template's own content marker is rejected on two grounds — unmaintained, and
-unread — that are both properties of the current state rather than of the
-mechanism, and this spec already demonstrates the repair for the first one on
-another defect three sections later. A hook that compares the template's content
-marker against the project's, plus a Layer 0 assertion that any change to
-`templates/HARNESS.md` moves that marker, measures the property §2 names and
-needs no script, shim, grammar, declined-item record or new command disposition.
+"What is lost, stated plainly" states one loss. §3 deletes four consumers. One of
+them is a *reader* for data that will remain in the wild indefinitely.
 
 ### Evidence
 
-> §6: "**Compare the template's own content marker.** Unmaintained — `d867c7c`
-> changed the template without moving it — and nothing reads it. Substitutes one
-> unreliable signal for another."
+> §2.2: A project that upgrades the plugin will no longer be told, unprompted,
+> that the template gained content. They learn it by running `/harness-upgrade`,
+> which the README already tells them to do after an upgrade.
 
-The repair pattern is already in the spec:
+§3 also removes:
 
-> §4.2: "A Layer 0 test asserts no heading line in `templates/HARNESS.md`
-> carries a trailing parenthetical, so the class cannot return."
-
-The same sentence shape applies: *a Layer 0 test asserts that a diff touching
-`templates/HARNESS.md` also moves `<!-- template-version -->`, so the class
-cannot return.* "Nothing reads it" is answered by having the hook read it, which
-is one line's change from the code in `template-currency-check.sh:29`.
-
-§6's other stored-state objection does not transfer:
-
-> "**Hash the template and store the hash.** … reintroduces per-project state
-> that drifts, which is the class of defect being removed."
-
-The template's marker is not per-project state. It ships in the plugin, is
-authored by the maintainer, and is enforceable in this repository's CI — which
-is where §4.2 is already putting an assertion.
+- `commands/harness-sync.md:118,206-207,271,294` — the template-drift row in the
+  monthly `/harness-sync` ritual, which is a pull-direction path the user chose,
+  not an unprompted nudge (CLAUDE.md, Monthly Operations)
+- `skills/harness-audit-engine/SKILL.md:33` — the same finding for `/harness-audit`
+- `skills/harness-observability/references/observatory-signals.md:127` — a required
+  observatory signal
+- `skills/ai-literacy-assessment/references/habitat-discovery.md:93,141` — "The
+  string `template-version:` in an HTML comment near the top", one of the markers
+  `/assess` uses to recognise that a project has a harness at all
 
 ### Why this matters
 
-Spec time is when alternatives are still cheap. The rejected option is roughly
-one CI check and one `sed` expression against a design that adds a script, a
-`PATH` shim, an HTML-comment grammar in the governing document, a fourth
-disposition in a command, eighteen acceptance criteria and a twelve-file
-migration. The rejection is one sentence, and the sentence relies on a fact the
-spec's own method dissolves.
+Two distinct problems. First, §2.2 says the discovery story reduces to the README
+line, but it currently also includes a monthly command that prints
+`Manual remediation suggested for: Template version drift`. Deleting that is a
+second, separate reduction, and the section that exists to state losses plainly
+does not state it. Second, `habitat-discovery` is a reader, not a writer: removing
+it stops `/assess` recognising markers that, per O6, will remain in most projects
+for a long time. Deleting the reader before the data is gone is backwards, and it
+is invisible in a table whose column heading is "What is deleted".
 
-## O8 — implementation — high
+## O8 — alternatives — high
 
 ### Claim
 
-`SessionStart` fires on startup, resume, clear and compact. §4.4 reasons about
-skip semantics in units of "session", removes the only time-boxed silence, and
-specifies no startup guard — so a project with one genuinely new template item
-receives the nudge repeatedly inside one working session.
+Every alternative in §7 preserves or repairs the nudge. The option of deleting
+less — removing the SessionStart hook, which is where the demonstrated harm lives,
+while keeping the pull-direction surfaces — is never weighed.
 
 ### Evidence
 
-> §4.4: "Skip means *not now, ask again next session*. Revision 1 removed the
-> dismissal file, which was the only time-boxed silence, without saying so. This
-> revision states it: … being reminded of those each session is the intended
-> behaviour."
+§7's four entries are "Compare heading sets (revision 1)", "Filter the compared set
+(revision 2)", "Fix the template's own content marker and read that", and "Keep the
+marker but make its absence an opt-out". The harm §1 documents is specific to the
+hook:
 
-> §4.5: "`.claude/.harness-upgrade-dismissed` is no longer written or read."
+> So the SessionStart hook asserts `Plugin template has been updated` on evidence
+> that cannot establish it, and the false signal reached the governing document
 
-The hook's registration:
-
-> `hooks/hooks.json:100-108` — `"SessionStart"`, `"matcher": "*"`,
-> `bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/template-currency-check.sh`
-
-The project has already learned this lesson on the same rail:
-
-> `hooks/scripts/wip-check.sh:28-29`: "STARTUP ONLY. SessionStart re-fires on
-> resume, clear and compact, and a breach report re-injected mid-session is the
-> thrash this exists to name."
-> `:47`: `[ "$source_field" = "startup" ] || exit 0`
-
-`parked-resume-check.sh:13` carries the same note. Neither §4.1, §4.3 nor §4.4
-specifies the equivalent gate, and no acceptance criterion covers it.
+Whereas the `/harness-sync` surface presents the same fact as a `[manual]` row in a
+table the user asked for, at a monthly cadence, alongside eight other surfaces
+(`commands/harness-sync.md:130-144`).
 
 ### Why this matters
 
-The dismissal file was doing more work than §4.4 credits: it suppressed re-fires
-within a version, not just across sessions. Removing it while keeping the nudge
-on a `*` matcher turns a once-per-upgrade message into a per-compaction one on
-exactly the population the nudge is meant to serve — a project that really is
-missing template content and has not yet acted. Alarm fatigue on the only true
-positives the mechanism has is the worst available distribution of noise.
+Spec time is the only moment this question is cheap. The spec's own §2.1 argument
+is that each revision paid in mechanism to defend a nudge; deleting the hook and
+nothing else pays *nothing* in mechanism, removes the every-session false
+assertion, and leaves the monthly surface, the observatory signal, and the
+habitat-discovery marker in place. It may be the wrong answer — a `drifted` row
+computed from a broken proxy is still a false statement, and there is a real case
+for coherence — but it is the alternative closest to the problem statement, and
+the reader cannot see whether it was considered and rejected or simply not
+considered.
 
-## O9 — scope — high
+## O9 — risk — medium
 
 ### Claim
 
-The §4.7 and §8 inventories are again presented as authoritative and are again
-incomplete, and no acceptance criterion asserts that no live reference survives.
-The correction mechanism for a defect that has now recurred twice is a third
-hand-made list.
+The spec records a reopening condition and a reopening option, and then removes
+from the install base the artefact that option needs, without noting that
+reopening now costs a second migration.
 
 ### Evidence
 
-> §4.7: "Revision 1's table listed seven files and presented the inventory as
-> complete; it found seven of ten (O4)."
+> §2.2: If a future adopter reports missing template content they would have wanted
+> to know about, that is evidence this decision was wrong and is worth reopening
+> on
 
-Live references absent from both §4.7 and §8:
+> §7: **If the answer to §2.2 turns out to be wrong, this is the option to reopen
+> on** — it is recorded here in enough detail to be taken up without re-deriving it.
 
-```text
-skills/harness-observability/references/observatory-signals.md:157  | **Total** | **82** |
-commands/observatory-verify.md:3    "…runs the 82-signal checklist against the latest output files"
-commands/observatory-verify.md:17   "This is the authoritative list of all signals to verify — 82 signals"
-README.md:77                        "the `Template currency` rule checks the same marker on…"
-docs/plugins/…/reference/hooks.md:277               "### Template currency check"
-docs/plugins/…/reference/commands.md:133            ".claude/.harness-upgrade-dismissed marker so the SessionStart hook"
-commands/harness-upgrade.md:152                     "Template version updated from X.Y.Z to A.B.C"
-```
-
-The observatory count is the same enforcement surface §4.7 itself flags as
-load-bearing: "**The observatory row is enforced.**" Removing row 127 without
-moving 82 → 81 in three places leaves the reference internally inconsistent with
-the command that reads it.
-
-§5 contains no criterion of the form "a repository-wide search for
-`template-version` returns only CHANGELOG entries, archived snapshots and
-historical spec/objection records."
+§5 removes the project-side `<!-- template-version: … -->` marker on every run,
+and §3 removes it from the template so new projects never get one.
 
 ### Why this matters
 
-The spec's method for this class is enumeration by hand, and enumeration by hand
-is what produced seven-of-ten last time. The fix that would end the recurrence —
-one grep assertion in the Layer 0 suite — costs less than the table and is the
-same technique §4.2 and §5.2 already reach for elsewhere in this spec.
+The reopening option compares a marker in the project's harness against the
+template's own content marker. Taking it up later means re-introducing the marker
+to the template *and* re-populating it across projects — a second migration through
+the same partially-reaching channel as the first. "Without re-deriving it" is true
+of the design and false of the cost. There is also no rollback story anywhere in
+the spec: reverting the plugin does not restore what step 6 removed from files the
+plugin does not own. A deletion spec that names its own falsification condition
+should say what undoing looks like, even if the answer is "we accept it is
+one-way".
 
-## O10 — specification quality — medium
+## O10 — risk — high
 
 ### Claim
 
-The comparison rule states HTML-comment handling for the template side and
-leaves it undefined for the project side. This repository's own file makes the
-two readings produce opposite outcomes for criterion 14.
+Stripping the marker while the old hook still exists on other machines and in older
+plugin caches converts a per-upgrade nudge into a permanent every-session one, and
+the new command removes the only mechanism that could silence it.
 
 ### Evidence
 
-> §4.1: "tpl_headings = ## and ### headings of tpl, **including inside HTML
-> comments**, EXCLUDING: …"
+`hooks/scripts/template-currency-check.sh`:
 
-`proj_headings` then appears undefined:
+> `:32-34` — `# If no marker exists, treat as needing upgrade` … `harness_version="0.0.0"`
+> `:43-45` — exits only when versions match
+> `:48-53` — silenced only by `.claude/.harness-upgrade-dismissed` containing the current plugin version
 
-> "skip if normalise(h) is in normalise(proj_headings)"
-
-> `HARNESS.md:55` — `<!-- ## Stakeholders`
-
-Under a comment-excluding read of the project side, `Stakeholders` is missing
-from this repository and criterion 14 fails. Under a comment-including read it
-is present and criterion 14 passes. Since the template side is explicitly
-specified and the project side is not, the asymmetry reads as deliberate to at
-least one reasonable implementer.
+§5 relies on exactly this semantics for its own argument — "Under the semantics
+being deleted, an absent marker reads as `0.0.0` … so the rule reports drift on
+every run, permanently, with no way to clear it" — and applies it to the GC rule
+but not to the hook. §3 then states: "`.claude/.harness-upgrade-dismissed` is no
+longer written or read."
 
 ### Why this matters
 
-Criterion 14 is the spec's headline guard and its pass/fail depends on an
-unstated rule. Worse, the two readings differ in meaning: "you have adopted this
-in commented form" and "you have not adopted this" are different states, and the
-spec has not decided which one counts as having the item.
+The reasoning in §5 is correct and incomplete. The same "absent reads as 0.0.0"
+property makes the old hook fire on every session for any project whose marker has
+been migrated away but which is opened with an older plugin version — a teammate
+who has not upgraded, a second machine with a stale versioned cache, or a
+deliberate downgrade. Previously that user could silence it by running
+`/harness-upgrade`; after this change the command no longer writes the dismissal
+file, so the only escape is to upgrade the plugin or hand-edit a gitignored file
+they have never heard of. §3 keeps the `.gitignore` line specifically because "the
+file exists on machines that ran the old command" — the spec is already reasoning
+about heterogeneous installs at that point and stops one step short. Note also that
+`docs/plugins/ai-literacy-superpowers/reference/hooks.md:287` documents the
+opposite behaviour ("Exits silently if `HARNESS.md` does not exist or the marker is
+absent"), so anyone checking this against the docs rather than the script will
+conclude there is no problem.
 
 ## O11 — specification quality — medium
 
 ### Claim
 
-Criterion 10 tests a write behaviour against a component that has no write path,
-in the section §5.3 was added to stop exactly that misfiling.
+The GC-rule removal predicate is prose that was never checked against the text it
+must match, and the spec defines no behaviour for the cases where it half-matches
+or cannot run.
 
 ### Evidence
 
-> §5.1, "`harness-template-diff` — Layer 0 deterministic", criterion 10:
-> "A declined reason containing `--` is rejected on write."
+> §5: a `### Template currency` GC rule whose **Tool** field references the
+> template-version comment, it is removed;
 
-The script's contract (§4.1) is `harness-template-diff [--format=text|json]`
-with two file inputs and four read-only outcomes. The behaviour belongs to the
-command:
+The shipped template's rule (`templates/HARNESS.md:335-344`) has
+`**Tool**: compare template-version comment in HARNESS.md against plugin.json
+version`, spanning two lines. This repository's copy (`HARNESS.md:760-769`) matches.
+Nothing in the spec records that check, and §2.1 records what happened last time:
 
-> §4.4: "**Step 4** … Declining prompts for a reason and writes it per §3.5's
-> grammar, rejecting a reason containing `--`."
+> an exclusion predicate that matched nothing — the `<!-- affordance-example -->`
+> tag sits on the line *below* each heading … verified by
+> `grep '^###.*affordance-example'` returning zero matches
 
-And the section immediately following states the principle being violated:
-
-> §5.3: "Not Layer 0; these are model-executed and belong in a behavioural
-> scenario, not in the hook's test file. Revision 1 assigned them to the hook's
-> file in error."
+§5's only defined output is "step 7 reports each removal by name."
 
 ### Why this matters
 
-An implementer building the Layer 0 suite from §5.1 will either add a write path
-to a read-only tool to satisfy criterion 10, or quietly drop the criterion. The
-first widens the script's surface beyond §4.1's contract; the second loses the
-only check on the `--` rule that §3.5 calls "semantically load-bearing".
+Three unhandled cases, all plausible: a project that renamed the heading (the rule
+is removed from neither the marker nor the report — it just silently persists); a
+project that reworded the Tool field, perhaps to point at a script, which was
+revision 2's own proposal; and a project that specialised the rule into something
+it still wants. The first two leave the orphan the migration exists to remove while
+reporting success; the third deletes wanted content. Because the report only names
+removals, "nothing was reported" is indistinguishable from "nothing was found" and
+from "the file could not be parsed" — the reassuring answer again, which the
+repository's harness names a defect rather than a default. A one-line "if a
+`### Template currency` heading is present but the Tool field does not match,
+report it and leave it alone" closes all three.
 
-## O12 — risk — medium
+## O12 — scope — high
 
 ### Claim
 
-§4.3 makes an absolute claim about what silence means, and the design honours it
-for one input only. The hook's own failure modes all produce silence, which this
-spec has just defined as the reassuring answer.
+The surface enumerations in §3 and §12 are presented as grep-derived and are not
+complete, and no counterpart to §3.1's careful signal arithmetic exists for the
+hook count that a committed Layer 0 test enforces.
 
 ### Evidence
 
-> §4.3: "Silence means checked-and-current. It never means could-not-check. This
-> follows the harness decision record in force until 2026-11-23 … a mechanism
-> that could not determine the answer reports the degraded state and names the
-> input it could not read."
+> §12: Same PR. Derived from the grep in §6, not by hand:
 
-§4.1 defines exactly one degraded outcome — `tpl absent/unreadable`. It defines
-none for the hook that wraps it. §4.7 specifies the wrapper only as
-`hooks/scripts/template-currency-check.sh` "Rewritten to call
-`harness-template-diff`". The surrounding conditions:
+`how-to/sync-harness.md` is in that list but matches none of §6's four terms, so
+the list is partly hand-made. Missing from §3/§12 entirely: `README.md:371`,
+`hooks/hooks.json:2` (the description field), `templates/CLAUDE.md:220`,
+`docs/plugins/ai-literacy-superpowers/reference/skills.md:46`,
+`.../reference/output-validation.md:33`, `.../tutorials/first-time-tour.md:558`
+(a tutorial section that walks a new user through the hook),
+`.../explanation/the-harness-lifecycle.md:161`,
+`.../explanation/the-loops-that-learn.md:36`, and
+`commands/harness-sync.md:138`. §12 also describes sync-harness.md as carrying
+"three references"; it carries four (`:36`, `:65`, `:86`, `:134`).
 
-> `hooks/hooks.json:107` — `"timeout": 10`
-> `hooks/scripts/template-currency-check.sh:11` — `set -euo pipefail`
-
-A stale marketplace cache or partial install in which
-`scripts/harness-template-diff.sh` is absent, a non-zero exit propagating under
-strict mode, or a timeout, all yield no `systemMessage` — indistinguishable from
-"checked and current".
+On counts, `hooks.json` declares 18 hooks, four of them SessionStart.
+`tdad_tests/layer0_deterministic/test-hooks-doc-parity.sh:19` records what happened
+when that count last went stale: "hooks.json declares 18; the page documented 16".
+§3.1 does this arithmetic explicitly for the observatory total (82 → 81, in four
+places) and the spec contains nothing equivalent for hooks.
 
 ### Why this matters
 
-The decision record cited in §4.3 is enforced against this plugin and names this
-exact shape: "A reachable code path that reaches a passing value without reading
-the thing it reports on is a defect, not a default." The spec invokes the record
-correctly for the template-unreadable case and then stops one layer short of the
-component that actually decides whether the user sees anything.
+CLAUDE.md's docs convention is explicit that behaviour changes require checking
+whether explanation pages describe the old behaviour. A tutorial that tells a new
+user "compares the template version marker in your…" and a concepts page that says
+"SessionStart hook nudges you when the template version has moved" will be
+published describing a mechanism that does not exist — which is the same failure
+mode §1 opens with, relocated from `HARNESS.md` to the docs site. The hook count is
+narrower but sharper: it is enforced by a test, the spec shows it knows this class
+of arithmetic exists, and the omission means CI is the thing that discovers it.
 
 ## Explicitly not objecting to
 
-- **The core premise that the marker measures the wrong property**: §1's
-  evidence is independently checkable and holds — `templates/HARNESS.md` last
-  changed at `d867c7c` (2026-08-13), the repository marker reads `0.79.0`
-  (`HARNESS.md:13`) against `plugin.json` `0.89.0`, and `HARNESS.md:1185`
-  records the resulting false claim in the governing document. Retiring
-  version-as-proxy is right.
-- **Heading sets over full-text diff**: §6's reasoning is correct — the property
-  worth surfacing is a missing item, not a reworded one — and a full-text diff
-  would fire on every prose edit.
-- **Fixing the template rather than the parser in §4.2**: the right layer, and
-  the justification checks out — `templates/HARNESS.md:463` and `:476` carry
-  `(LOCAL — per-machine only)` parentheticals that appear identically on both
-  sides and would be collapsed by a general normalisation.
-- **Keeping the declined record in `HARNESS.md` rather than a new file**: the
-  "two committed dashboards went 106 days unread" evidence is the strongest
-  argument in §6, and it is applied correctly.
-- **Running `/harness-audit` in this PR (§4.8)**: this is a genuine improvement
-  over revision 1, and `HARNESS.md:1177`'s record of the 2026-08-13 audit
-  reporting `Drift detected: no` against a failing tree is the right evidence
-  for it.
-- **§1.1's withdrawal of the Stakeholders attribution**: naming three candidate
-  causes and attributing none, rather than keeping a convenient one, is
-  intellectually honest and I have no basis to challenge it.
-- **The declined-block grammar's strictness (§3.5)**: the `::` separator, the
-  no-continuation rule, the `--` prohibition and "reported, never skipped" are
-  well specified; my only objection touching it is where criterion 10 was filed,
-  not what it says.
-- **The version bump, docs list and Layer 0 platform conventions (§7, §8)**:
-  these follow the repository's existing conventions and I found nothing wrong
-  with them beyond the completeness point in O9.
-- **The `New plugin components must ship with a TDAD scenario` reasoning in
-  §5.3**: the constraint genuinely names skills, agents and commands, a script
-  is none of those, and the spec adds the tests anyway.
-- **Not objecting to the `/harness-upgrade`-routes-through-`/harness-propose`
-  question**: explicitly out of scope per the header, and legitimately so.
+- **The decision to delete rather than repair.** The cost argument in §2.1 —
+  three revisions, each paying more mechanism to defend the same premise — is
+  strong on its own terms, and O1 challenges the evidence it is stated on, not
+  the conclusion.
+- **§4's decision to leave the three-bucket parse alone.** This is the clearest
+  improvement over revision 2 and directly answers a prior objection; touching
+  neither the parse nor the buckets is the right call and is well justified.
+- **§3.1's observatory arithmetic.** It is the one place the spec chases a
+  hard-coded count to every location and reasons about archived snapshots; I
+  verified the signal row at `observatory-signals.md:127` and the required flag,
+  and the reasoning is sound. My objection is that this care was not extended to
+  hooks, not that it was misapplied here.
+- **Keeping the `.gitignore` line.** The reasoning — the file exists on machines
+  that ran the old command, and removing the ignore would surface it as untracked
+  — is correct and is the kind of residue thinking the rest of §6 needs more of.
+- **§8's out-of-scoping of the declined-item record.** Deferring it is defensible,
+  and the reason given (the record's grammar generated two prior objections) is
+  honest about why.
+- **§11's version bump.** Minor for a behavioural plugin change across the five
+  CI-checked locations is exactly what CLAUDE.md prescribes; there is nothing to
+  challenge.
+- **"Who in the install base relies on this nudge."** Someone should ask adopters
+  before removing a capability from their projects, but the remedy is a
+  conversation rather than a change to the spec, so under the Routing Rule that
+  finding belongs to the Convener's consultation record, not here.
+- **Grammar, line-number drift, and table formatting.** Several cited line numbers
+  are already one or two off (`harness-init.md:184,211` against `:182,210,222`);
+  that is normal spec decay and not worth an objection, except where it indicates
+  a missed surface, which O12 covers.

--- a/docs/superpowers/objections/template-currency-measure-content-design.md
+++ b/docs/superpowers/objections/template-currency-measure-content-design.md
@@ -5,673 +5,625 @@ mode: spec
 diaboli_model: claude-opus-5[1m]
 objections:
   - id: O1
-    category: implementation
-    severity: critical
-    claim: "A default /harness-init run produces a HARNESS.md that is missing template headings by design, so the new hook nudges on the very next session — reproducing the cry-wolf defect the spec exists to remove."
-    evidence: "§4.1 'missing = tpl_headings - proj_headings - declined'; commands/harness-init.md step 3 'Affordances ... opt-in (default off)' and step 7 'For each unselected feature, replace the section body with the placeholder marker'; templates/HARNESS.md:519-557 declares '### gh-cli', '### honeycomb-mcp', '### shell-write-to-tmp', '### sync-to-global-cache-hook', each tagged '<!-- affordance-example -->'."
+    category: premise
+    severity: high
+    claim: "The spec retains a nudge it admits has zero recorded successes, and compares the retained option against deletion using a cost figure ('two greps at session start') that omits the shared script, the bin shim, the new HARNESS.md grammar, the new command disposition, the eighteen acceptance criteria and the twelve-file migration the same spec specifies."
+    evidence: "§3.3 'there is no recorded instance of this nudge producing a useful adoption. Six runs are recorded; five adopted nothing, and the sixth cannot be attributed'; §3.3 'a correctly filtered comparison costs two greps at session start'; §6 'Delete the nudge entirely … Still live, and strengthened by §1.1 removing the evidence that favoured keeping it.'"
     disposition: pending
     disposition_rationale: null
   - id: O2
     category: implementation
-    severity: high
-    claim: "Case-insensitive, whitespace-trimmed matching does not match the template's commented section headings, which carry instructional parentheticals on the heading line; the design produces a permanent false positive on the repository used to verify it."
-    evidence: "§4.1 'Matching is case-insensitive and whitespace-trimmed'; templates/HARNESS.md:630 '<!-- ## Cognitive reservoir  (OPTIONAL — to opt in, remove this `<!--` line and the closing `-->` below)' versus HARNESS.md:1126 '## Cognitive reservoir'."
+    severity: critical
+    claim: "The filter does not exclude commented-out opt-in template blocks, and §5.1 criterion 4 mandates including them, so a default-initialised project is told on day one that it is missing 'Stakeholders' and 'Cognitive reservoir' — content the template itself labels OPTIONAL. This is the day-one false positive §3.4 exists to eliminate."
+    evidence: "§4.1 'tpl_headings = ## and ### headings of tpl, including inside HTML comments' with exclusions only for affordance-example and ^\\[.*\\]$; §5.1 criterion 4 'A template heading that appears only inside an HTML comment is treated like any other'; templates/HARNESS.md:39 '<!-- ## Stakeholders' with ':41 OPTIONAL.'; templates/HARNESS.md:630 '<!-- ## Cognitive reservoir  (OPTIONAL — to opt in …)'; §3.4 'An unfiltered heading comparison fires on the default install, on day one.'"
     disposition: pending
     disposition_rationale: null
   - id: O3
-    category: specification quality
+    category: implementation
     severity: high
-    claim: "The declined block is called load-bearing but has no grammar: the stated one-line-per-entry rule is contradicted by the spec's own example, and nothing defines continuation lines, duplicate entries, headings containing a colon, or reason text containing the comment terminator."
-    evidence: "§3.4 'One line per declined heading, `Heading: reason`' immediately below an example whose single entry wraps across three indented lines; §4.3 step 4 'Declining prompts for a one-line reason and writes it to the declined block'; §3.4 'The reason text is never parsed.'"
+    claim: "The affordance-example exclusion, as specified, matches nothing: the tag sits on the line after each heading in the real template, not on the heading line."
+    evidence: "§4.1 excludes 'a heading whose line carries <!-- affordance-example -->'; §3.4 cites 'four headings tagged <!-- affordance-example --> (templates/HARNESS.md:520,535,546,557)'. In the file, the headings are at :519 '### gh-cli', :534 '### honeycomb-mcp', :545 '### shell-write-to-tmp', :556 '### sync-to-global-cache-hook'; lines 520/535/546/557 are the standalone comment lines beneath them."
     disposition: pending
     disposition_rationale: null
   - id: O4
     category: scope
     severity: high
-    claim: "The surfaces table is incomplete: /harness-sync computes and reports 'Template version drift' in three places and is not listed, so a mechanism that reports drift will survive the input it reads being deleted."
-    evidence: "§4.6 lists seven files, none of them commands/harness-sync.md, which carries 'Template version drift' (line 118), the drift-table row 'Template version (HARNESS: 0.31, plugin: 0.34) drifted /harness-upgrade [manual]' (line 138), and the JSON item '\"id\": \"template\", \"label\": \"Template drift  [manual: /harness-upgrade]\"' (lines 206-208). docs/contributing/index.md:195 and docs/plugins/ai-literacy-superpowers/how-to/sync-harness.md (six references) are also absent from §4.6 and §8."
+    claim: "No acceptance criterion runs the algorithm against a default-initialised project, and the one real-input criterion runs against a repository that is a superset of the template — an input on which every exclusion rule is unobservable, so O2 and O3 both ship green."
+    evidence: "§5.2 criterion 14 'Run against this repository's committed HARNESS.md and templates/HARNESS.md, the missing set is empty'; §5.2 'This criterion exists because revision 1 never ran its own algorithm.' This repository's HARNESS.md already contains '### gh-cli' (:1014), '### honeycomb-mcp' (:1032), '### shell-write-to-tmp' (:1043), '### sync-to-global-cache-hook' (:1054) and '### [Governance constraint name]' (:639), so criteria 5 and 6 pass on this input whether or not the exclusions fire. Criteria 5–7 are fixture tests authored from the same rule text they are meant to check."
     disposition: pending
     disposition_rationale: null
   - id: O5
-    category: premise
-    severity: medium
-    claim: "The only affirmative evidence for keeping a nudge at all is a case the spec admits cannot be settled, while the spec's hard evidence records no instance of the nudge ever producing a useful adoption."
-    evidence: "§1 'Five of the last six marker advances adopted nothing'; §1 'This cannot be settled now — the 0.73.2 plugin cache is no longer on the machine that ran it'; §3.3 'Rejected because the ## Stakeholders case suggests the failure mode that actually costs something is not being told.'"
+    category: scope
+    severity: high
+    claim: "Replacing /harness-upgrade step 2's parse with harness-template-diff silently deletes two of the command's three finding buckets: the script computes only the missing set, while the command today also produces 'Updated items' and 'Removed items'."
+    evidence: "§4.4 'Step 2 invokes harness-template-diff --format=json rather than restating the matching rules'; §4.1's contract yields only 'missing'. commands/harness-upgrade.md:74 'Sort items into three buckets', :79 '**Updated items** — present in both files, but the template content differs', :86 '**Removed items** — present in the user's HARNESS.md but absent from the current template.' §4.4 lists changes to steps 1, 2, 3, 4, 6 and 7 and never mentions either bucket."
     disposition: pending
     disposition_rationale: null
   - id: O6
-    category: implementation
+    category: risk
     severity: high
-    claim: "The spec asserts the hook and the command can never disagree, but they are two independent implementations of one parser — a bash script and a prose instruction executed by a model — and the repository already carries a GC rule because that exact drift happens here."
-    evidence: "§4.1 'identical to /harness-upgrade step 2, so the hook and the command never disagree about what is new'; §4.4 'Both the hook and the command extract headings from inside HTML comments at every level'; HARNESS.md:690 '### Command-prompt sync'."
+    claim: "Migration deletes the marker from every consuming project's HARNESS.md while leaving the `Template currency` GC rule that reads it in place, converting a noisy-but-explicable signal into a permanently failing one — and, per O5, removing the only path by which the command would have surfaced the orphan."
+    evidence: "§4.5 'The marker becomes inert on the release that ships this. Nothing reads it, so a project that still has one is not broken' and '/harness-upgrade removes it when it next runs'; §4.5 scopes rule removal to 'This repository removes its own in this PR, along with the Template currency GC rule.' templates/HARNESS.md:335-342 shipped the rule to every project ('Tool: compare template-version comment in HARNESS.md against …'). Under the pre-existing semantics a missing marker is 0.0.0 (hooks/scripts/template-currency-check.sh:32-34), i.e. permanently drifted."
     disposition: pending
     disposition_rationale: null
   - id: O7
-    category: risk
+    category: alternatives
     severity: high
-    claim: "The hook reaches the passing, silent outcome on a path where it never read the thing it reports on, which the in-force harness decision record names as a defect rather than a default."
-    evidence: "§4.1 'exit 0 if either file is unreadable (unchanged: advisory, never blocks)'; §5 criterion 9 'The hook never blocks and never exits non-zero'; HDR-2026-08-25 (compiled into skills/advocatus-diaboli/SKILL.md): 'A reachable code path that reaches a passing value without reading the thing it reports on is a defect, not a default.'"
+    claim: "The template's own content marker is rejected for being unmaintained and unread — both fixable properties, and this spec already demonstrates the fix it declines to apply. A Layer 0 assertion that a change to templates/HARNESS.md moves its marker, plus a hook that compares that marker instead of plugin.json, measures the stated property with one CI check and no new script, grammar, shim or declined-item mechanism."
+    evidence: "§6 'Compare the template's own content marker. Unmaintained — d867c7c changed the template without moving it — and nothing reads it.' §4.2 adds exactly this class of guard for a different defect: 'A Layer 0 test asserts no heading line in templates/HARNESS.md carries a trailing parenthetical, so the class cannot return.' §6's other rejection, 'reintroduces per-project state that drifts', does not apply: the marker lives in the plugin's template, not per project."
     disposition: pending
     disposition_rationale: null
   - id: O8
-    category: scope
-    severity: medium
-    claim: "The design removes the only way to silence the nudge without acting on it, so any item the user skips re-fires every session forever, and the spec never states this consequence."
-    evidence: "§4.5 '.claude/.harness-upgrade-dismissed is no longer written or read'; §4.3 step 4 'Skip remains what it is today: not now, ask again next time'; §4.1 subtracts only 'declined' from the missing set."
+    category: implementation
+    severity: high
+    claim: "The skip semantics reason about sessions, but SessionStart re-fires on resume, clear and compact; with the dismissal file removed and no startup guard specified, a project with one genuinely new template item gets the nudge re-injected repeatedly within a single working session."
+    evidence: "§4.4 'Skip means not now, ask again next session … being reminded of those each session is the intended behaviour'; §4.5 '.claude/.harness-upgrade-dismissed is no longer written or read.' hooks/hooks.json:106 registers the hook under SessionStart with matcher '*'. The sibling hook on the same rail guards for this explicitly — hooks/scripts/wip-check.sh:28-29 'STARTUP ONLY. SessionStart re-fires on resume, clear and compact, and a breach report re-injected mid-session is the thrash this exists to name' and :47 '[ \"$source_field\" = \"startup\" ] || exit 0'. §4.1 and §4.4 specify no equivalent."
     disposition: pending
     disposition_rationale: null
   - id: O9
-    category: specification quality
-    severity: medium
-    claim: "The test plan assigns command behaviour to a hook test file and leaves the write path of the load-bearing declined block with no acceptance criterion at all."
-    evidence: "§5 'Criteria 1-7 and 9 are Layer 0 deterministic tests at tdad_tests/layer0_deterministic/test-template-currency-check.sh' where criterion 6 is '/harness-upgrade removes it and reports having done so' and criterion 7 covers 'both the hook and the command'; no criterion covers §4.3 step 4/6 writing a declined entry."
+    category: scope
+    severity: high
+    claim: "The §4.7/§8 inventories are again presented as complete and are again incomplete, and the spec adds no acceptance criterion asserting that no live reference to the marker survives — so the only defence against a third recurrence is a third hand-made list."
+    evidence: "§4.7 'Revision 1's table listed seven files and presented the inventory as complete; it found seven of ten.' Unlisted live references: skills/harness-observability/references/observatory-signals.md:157 '| **Total** | **82** |'; commands/observatory-verify.md:3 '82-signal checklist' and :17 '82 signals across 5 sources'; README.md:77 'the Template currency rule checks the same marker'; docs/plugins/ai-literacy-superpowers/reference/hooks.md:277 '### Template currency check'; docs/plugins/ai-literacy-superpowers/reference/commands.md:133 '.claude/.harness-upgrade-dismissed marker'; commands/harness-upgrade.md:152 'Template version updated from X.Y.Z to A.B.C'. §5 contains no criterion of the form 'grep finds no remaining reference outside CHANGELOG and archives'."
     disposition: pending
     disposition_rationale: null
   - id: O10
-    category: alternatives
+    category: specification quality
     severity: medium
-    claim: "The rejected-alternatives section weighs four ways to compare but never weighs narrowing what is compared, which would remove most false positives without inventing per-project declined state at all."
-    evidence: "§6 rejects the template's own marker, hashing, full-text diff, and a separate file — all four vary the comparison method, none varies the item set; §4.1 compares '## and ###, incl. commented' with no exclusion for placeholders, examples, or opt-in blocks."
+    claim: "The comparison rule specifies HTML-comment handling for the template side and is silent for the project side, and this repository's own file makes the two readings give opposite results for criterion 14."
+    evidence: "§4.1 'tpl_headings = ## and ### headings of tpl, including inside HTML comments' — the corresponding proj_headings term is used undefined in 'skip if normalise(h) is in normalise(proj_headings)'. This repository's HARNESS.md:55 carries '<!-- ## Stakeholders' inside a comment. Under a comment-excluding read of the project side, criterion 14's missing set is not empty; under a comment-including read it is."
     disposition: pending
     disposition_rationale: null
   - id: O11
-    category: implementation
+    category: specification quality
     severity: medium
-    claim: "The spec never states which copy of the template is authoritative, and in this repository the copy it names is rsynced from the working tree on every Stop, so editing the template nudges the editor about their own unfinished edit."
-    evidence: "§4.1 'tpl = $CLAUDE_PLUGIN_ROOT/templates/HARNESS.md'; CLAUDE.md 'sync-to-global-cache.sh — rsyncs plugin content into the versioned plugin cache (runs on every Stop)'; §1's ## Stakeholders timeline turns on which copy 89b46f9 compared against and the spec does not say."
+    claim: "Criterion 10 is filed under §5.1 as a Layer 0 test of harness-template-diff, but the script has no write path — the `--` rejection is a behaviour of the model-executed command, which is exactly the misfiling §5.3 says revision 1 committed."
+    evidence: "§5.1 heading 'harness-template-diff — Layer 0 deterministic', criterion 10 'A declined reason containing -- is rejected on write.' §4.1's interface is 'harness-template-diff [--format=text|json]' with read-only inputs and four outcomes, none of which write. §4.4 assigns the behaviour elsewhere: 'Step 4 … Declining prompts for a reason and writes it per §3.5's grammar, rejecting a reason containing --.' §5.3 'Not Layer 0; these are model-executed … Revision 1 assigned them to the hook's test file in error.'"
     disposition: pending
     disposition_rationale: null
   - id: O12
     category: risk
     severity: medium
-    claim: "The PR knowingly merges a governing document whose Status block overstates its own coverage, and removes a signal the observatory reference marks required."
-    evidence: "§4.6 'HARNESS.md's Status block references the marker. It is owned by /harness-audit and is corrected by running it, not by hand-editing this PR'; HARNESS.md:760-769 declares 'Template currency' with 'Enforcement: deterministic'; HARNESS.md:1174 'Garbage collection active: 19/19'; §4.6 'observatory-signals.md:127 | Template version is marked required; remove the row'."
+    claim: "§4.3 states an absolute contract — silence never means could-not-check — but only one input failure is covered. The hook's own failure modes (script absent from a partial or stale plugin install, non-zero exit under strict mode, the 10s timeout) all produce silence, which the spec has just defined as the reassuring answer."
+    evidence: "§4.3 'Silence means checked-and-current. It never means could-not-check', citing the harness decision record 'a mechanism that could not determine the answer reports the degraded state and names the input it could not read.' §4.1 defines exactly two non-missing outcomes: 'proj absent -> exit 0, emit nothing' and 'tpl absent/unreadable -> exit 0, emit DEGRADED'. §4.7 specifies the hook only as 'Rewritten to call harness-template-diff'; hooks/hooks.json:107 sets 'timeout: 10', and the current hook runs under 'set -euo pipefail' (hooks/scripts/template-currency-check.sh:11)."
     disposition: pending
     disposition_rationale: null
 ---
 
-## O1 — implementation — critical
+# Objections — template currency measures content (revision 2)
+
+## O1 — premise — high
 
 ### Claim
 
-A default `/harness-init` run produces a `HARNESS.md` that is missing template
-headings by design. Under the proposed set difference, that project is nudged on
-its very next session — naming, among other things, example affordances it was
-never meant to adopt. The replacement signal cries wolf on day one, for the
-default user, which is the defect the spec exists to remove.
+The spec retains the nudge on a judgement it states honestly, and then prices
+that judgement wrongly. The comparison offered to the reviewer is "two greps at
+session start" versus deleting the hook. The actual retained option is a new
+shared script, a `bin/` shim, a new grammar embedded in the governing document,
+a fourth disposition in `/harness-upgrade`, fifteen Layer 0 criteria, three
+behavioural criteria, a twelve-file migration and eight documentation edits — in
+service of a mechanism with no recorded instance of ever having worked.
 
 ### Evidence
 
-The algorithm is a plain set difference over headings:
+> §3.3: "there is no recorded instance of this nudge producing a useful
+> adoption. Six runs are recorded; five adopted nothing, and the sixth cannot
+> be attributed."
 
-> `missing = tpl_headings - proj_headings - declined` (§4.1)
+> §3.3: "a correctly filtered comparison costs two greps at session start."
 
-`/harness-init` is documented to produce a project file that is *not* a superset
-of the template:
+> §6: "**Delete the nudge entirely, keeping `/harness-upgrade` on demand.**
+> Still live, and strengthened by §1.1 removing the evidence that favoured
+> keeping it."
 
-> **Affordances** is opt-in: if **unselected** (the default), replace the
-> `## Affordances` section body with the placeholder marker like any other
-> unselected feature. (`commands/harness-init.md`, step 7)
-
-and, generally:
-
-> For each unselected feature, replace the section body with the placeholder
-> marker. (`commands/harness-init.md`, step 7)
-
-The template's `## Affordances` body contains four headings, each explicitly
-tagged as an example:
-
-```text
-templates/HARNESS.md:519  ### gh-cli                    <!-- affordance-example -->
-templates/HARNESS.md:534  ### honeycomb-mcp             <!-- affordance-example -->
-templates/HARNESS.md:545  ### shell-write-to-tmp        <!-- affordance-example -->
-templates/HARNESS.md:556  ### sync-to-global-cache-hook <!-- affordance-example -->
-```
-
-The template also carries a literal placeholder heading no project should ever
-have: `templates/HARNESS.md:194  ### [Governance constraint name]`.
-
-A user who deselects Garbage collection loses roughly twenty-five `###` headings
-in one step. The spec verified its algorithm against one repository — this one —
-whose `HARNESS.md` happens to be a near-superset of the template, including the
-`[Governance constraint name]` placeholder at line 639 and all four affordance
-examples. That is the single least representative sample available.
+The spec is candid that this is a judgement and that a reviewer may reject it.
+The objection is not to the candour; it is that the two options are not
+presented in commensurable terms, so the reviewer is choosing between "two
+greps" and "delete the hook" rather than between the real build and the real
+saving. §6's own description of the deletion option — "deletes the hook, the
+shared script, the declined block and §5.1 entirely" — states the true cost of
+the retained option more accurately than §3.3 does.
 
 ### Why this matters
 
-§1's charge against the marker is that it "asserts `Plugin template has been
-updated` on evidence that cannot establish it". The replacement asserts
-`Template has 4 item(s) your harness does not: "gh-cli", "honeycomb-mcp", ...`
-on evidence that is technically true and semantically false — those are examples,
-not items. The message §4.2 is proud of ("A reader can falsify it against their
-own file") is worse here, not better: the reader falsifies it, finds it correct,
-and concludes the mechanism is stupid rather than wrong.
+This is the highest-leverage decision in the spec and every other objection
+here is downstream of it. If the nudge goes, O2 through O6, O8, O10 and O12
+evaporate with it. A premise this thinly evidenced deserves the comparison
+stated in like terms before the build proceeds.
 
-§3.4 anticipates the *class* of this problem and answers it with the declined
-block. But that answer has a cost the spec does not budget: the only way to
-populate the declined block is to run `/harness-upgrade` and decline each item.
-The nudge whose purpose is to sell `/harness-upgrade` can only be silenced by
-running `/harness-upgrade` — on a fresh project, before the user has any reason
-to trust it, for four items that were never content. Either the template must
-mark non-adoptable headings so the comparison can exclude them, or `/harness-init`
-must seed the declined block from what it chose not to write.
-
-## O2 — implementation — high
+## O2 — implementation — critical
 
 ### Claim
 
-The specified normalisation — case-insensitive and whitespace-trimmed — does not
-match the template's commented section headings, because those headings carry
-instructional parentheticals on the heading line itself. The result is a
-permanent false positive on the very repository the spec used to verify the
-design.
+The filtered item set does not exclude the template's commented-out opt-in
+blocks, and §5.1 criterion 4 explicitly requires including them. A
+default-initialised project has neither `## Stakeholders` nor
+`## Cognitive reservoir`, because both are shipped commented out and are
+labelled OPTIONAL in the template. On day one, such a project is told its
+harness is missing two items it was never meant to have. This is precisely the
+failure mode §3.4 asserts the filter removes.
 
 ### Evidence
 
-> Matching is case-insensitive and whitespace-trimmed, identical to
-> `/harness-upgrade` step 2, so the hook and the command never disagree about
-> what is new. (§4.1)
+The template's two opt-in blocks:
 
-The template's opt-in section heading:
+> `templates/HARNESS.md:39` — `<!-- ## Stakeholders`
+> `templates/HARNESS.md:41` — "OPTIONAL. Who this project affects…"
 
-```text
-templates/HARNESS.md:630
-<!-- ## Cognitive reservoir  (OPTIONAL — to opt in, remove this `<!--` line and the closing `-->` below)
-```
+> `templates/HARNESS.md:630` — `<!-- ## Cognitive reservoir  (OPTIONAL — to opt in, remove this `<!--` line and the closing `-->` below)`
 
-This repository's adopted version:
+The rule includes them:
 
-```text
-HARNESS.md:1126
-## Cognitive reservoir
-```
+> §4.1: "tpl_headings = ## and ### headings of tpl, **including inside HTML
+> comments**, EXCLUDING: a heading whose line carries `<!-- affordance-example -->`;
+> a heading matching `^\[.*\]$`"
 
-Extracted per §4.4 ("extract headings from inside HTML comments at every level"),
-the template heading is `Cognitive reservoir  (OPTIONAL — to opt in, remove this
-` + backtick-quoted markup + `line and the closing ... below)`. Trimming and
-case-folding do not reduce that to `Cognitive reservoir`. The heading is reported
-missing, every session, on a repository that adopted it months ago.
+> §5.1 criterion 4: "A template heading that appears only inside an HTML comment
+> is treated like any other; criteria 1–3 hold for it unchanged."
 
-Acceptance criterion 4 covers commented headings and criterion 7 covers case and
-whitespace. Neither covers a parenthetical suffix, so a conforming implementation
-passes the whole suite and still fires this every session.
+The unconfigured-section skip does not reach them: it fires when "h's owning
+`##` section is unconfigured in proj", and these headings *are* the `##`
+sections. A project that never adopted them has no section body to carry the
+placeholder marker.
+
+The spec came within one line of noticing. §3.4's own trial run reported
+`Cognitive reservoir  (OPTIONAL — …)` as a false positive, and §4.2 diagnosed
+that as a trailing-parenthetical matching failure. That diagnosis is correct for
+*this* repository, which has an uncommented `## Cognitive reservoir`
+(`HARNESS.md:1126`). It is the wrong diagnosis for a default project, which does
+not have the heading at all and will be reported regardless of §4.2's fix. And
+§4.3's exemplar message — `Template has 1 item your harness does not:
+"Stakeholders"` — uses one of the two OPTIONAL blocks as the illustration of a
+legitimately missing item.
 
 ### Why this matters
 
-The spec's §1 does its verification work well — `diff`, exit codes, commit
-hashes, dates. §5 does not extend that discipline to the new algorithm. Nothing
-in the spec records the output of running the proposed comparison against this
-repository's real `HARNESS.md` and the real template. Had that been run, this
-would have surfaced before review, along with whatever else it turns up. The
-missing artefact is one paragraph: *here is the missing set the new rule produces
-today, and here is why each entry is correct.*
+§3 states the case for revision 2 as "The filter is what makes the mechanism
+quiet; the declined-item record handles only the residue." If the filter leaves
+two OPTIONAL blocks in, the mechanism is not quiet on a default install, and the
+only silencing route available to a new user is the one §3.4 already identified
+as unacceptable: "silenceable only by running the command the nudge advertises."
+The central claim of the revision does not hold as specified.
 
-## O3 — specification quality — high
+## O3 — implementation — high
 
 ### Claim
 
-§3.4 calls the declined-item record load-bearing and then gives it no grammar.
-The stated format contradicts the spec's own example, and nothing defines
-continuation lines, duplicates, headings containing a colon, or the one input
-that can corrupt the file it lives in.
+The `affordance-example` exclusion excludes nothing, because in the real
+template the tag is on the line *following* each heading, not on the heading
+line.
 
 ### Evidence
 
-The rule:
+> §4.1: "EXCLUDING: — a heading whose line carries `<!-- affordance-example -->`"
 
-> One line per declined heading, `Heading: reason`. (§3.4)
+> §3.4: "The template's `## Affordances` body carries four headings tagged
+> `<!-- affordance-example -->` (`templates/HARNESS.md:520,535,546,557`)."
 
-The example, directly above it:
+The cited lines are the tags, not the headings:
 
-```html
-<!-- template-declined
-     Consistent formatting: specialised here as "Consistent markdown
-       formatting" (deterministic, markdownlint, commit + pr). Adopting the
-       template's unverified placeholder would be a downgrade.
--->
+```text
+519  ### gh-cli
+520  <!-- affordance-example -->
+...
+534  ### honeycomb-mcp
+535  <!-- affordance-example -->
+...
+545  ### shell-write-to-tmp
+546  <!-- affordance-example -->
+...
+556  ### sync-to-global-cache-hook
+557  <!-- affordance-example -->
 ```
 
-That is one declined heading occupying three lines with two distinct indentation
-levels. A parser written to the rule reads three entries: `Consistent formatting`,
-`formatting" (deterministic, markdownlint, commit + pr). Adopting the` (no
-colon — dropped or malformed), and one more. A parser written to the example
-needs a continuation convention the spec never states.
-
-The reason text is user-supplied and machine-written:
-
-> Declining prompts for a one-line reason and writes it to the declined block.
-> (§4.3, step 4)
-
-> The reason text is never parsed. (§3.4)
-
-Never parsed is not the same as harmless. The block is an HTML comment. A reason
-containing `-->` terminates it early, uncommenting whatever follows — in a file
-whose commented blocks are semantically load-bearing, since §4.1 and the
-`## Cognitive reservoir` opt-in both turn on comment state.
+An implementer following §4.1 literally writes a predicate over the heading
+line and it never matches. An implementer who infers the intent writes a
+lookahead — and the two implementations disagree on any future entry where a
+blank line or a schema comment intervenes.
 
 ### Why this matters
 
-This block is the only thing standing between the new comparison and the old
-defect — §3.4 says so plainly: "Heading comparison alone reproduces the original
-defect in a new coat." It is read by a bash script and written by a model
-following prose. A silent parse failure does not fail loudly; it re-admits the
-declined item to the missing set, and the mechanism resumes crying wolf about
-the exact item three humans already declined on the record. That failure is
-indistinguishable, from the user's seat, from the bug being fixed.
-
-Specify the grammar as strictly as the `## Cognitive reservoir` value lines are
-specified — that block already carries a written warning about exactly this class
-of parser fragility (`HARNESS.md:1145-1148`), which is the precedent to follow.
+This is the exclusion §3.4 identifies as the primary day-one false-positive
+source for a project that opted out of Affordances, and it is one of the two
+mechanisms §9 claims resolves the critical objection O1 from the previous
+review. As written it is inert, and per O4 nothing in §5 would reveal that.
 
 ## O4 — scope — high
 
 ### Claim
 
-The §4.6 surfaces table is incomplete. `/harness-sync` reads and reports
-`Template version drift` in three separate places and does not appear in the
-table, so after this ships a drift-reporting mechanism will be reporting on an
-input that no longer exists.
+The acceptance criteria never run the algorithm against a default-initialised
+project, and the single real-input criterion runs against a repository that is a
+near-superset of the template — an input on which no exclusion rule is
+observable. Both O2 and O3 pass every criterion in §5.
 
 ### Evidence
 
-§4.6 lists seven files. `commands/harness-sync.md` is not among them, and it
-carries:
+> §5.2 criterion 14: "Run against this repository's committed `HARNESS.md` and
+> `templates/HARNESS.md`, the missing set is **empty** …"
+>
+> "This criterion exists because revision 1 never ran its own algorithm; §3.4
+> records what happened when it finally was."
+
+This repository already contains every heading the exclusions are supposed to
+suppress:
 
 ```text
-line 118  - Template version drift                            (surface list)
-line 138  Template version (HARNESS: 0.31, plugin: 0.34) drifted  /harness-upgrade  [manual]
-line 207  "label": "Template drift  [manual: /harness-upgrade]"    (checkbox JSON, id: "template")
-line 271  Manual remediation suggested for: Template version drift
+HARNESS.md:1014  ### gh-cli
+HARNESS.md:1032  ### honeycomb-mcp
+HARNESS.md:1043  ### shell-write-to-tmp
+HARNESS.md:1054  ### sync-to-global-cache-hook
+HARNESS.md:639   ### [Governance constraint name]
+HARNESS.md:1126  ## Cognitive reservoir
 ```
 
-Also absent from §4.6 and from §8's docs list:
+So criteria 5 and 6 are satisfied by the project side of the comparison, not by
+the exclusion logic. Criterion 14 will read green with the exclusions removed
+entirely. Criteria 5, 6 and 7 are fixture tests, and the fixtures will be
+authored from the same rule text that carries the defect in O3.
 
-- `docs/contributing/index.md:195` — "**Template currency** — detects when the
-  HARNESS.md template version is behind the installed plugin version."
-- `docs/plugins/ai-literacy-superpowers/how-to/sync-harness.md` — six references,
-  including a worked drift-table row and a "Template drift" remediation section.
-
-§4.6 does list `skills/harness-audit-engine/SKILL.md:33`, which is the drift
-surface table row — correctly. The point is not that the spec was careless; it is
-that the enumeration method found seven of ten and the spec presents it as
-complete.
+What is absent is the case the design exists for: run the tool against the
+output of a default `/harness-init` — Affordances off, Stakeholders and
+Cognitive reservoir not adopted — and assert an empty missing set.
 
 ### Why this matters
 
-`/harness-sync` is one of the two monthly operations in `CLAUDE.md`. After this
-merges, its drift scan has a row whose input has been deleted. It will either
-error, or report `drifted` forever, or — most likely, and worst — report
-`in sync`, because "no marker found" collapses to "nothing to compare". That is
-the failure HDR-2026-08-25 names: a status mechanism reaching the reassuring
-answer without reading the thing it reports on. The spec removes the marker on
-the strength of an inventory that missed the mechanism most likely to fail that
-way.
+§5.2 presents criterion 14 as the guard against shipping an unrun algorithm a
+second time. On the input chosen it is a weak guard: it validates that this
+repository is a superset, which was already known, and it is structurally
+incapable of detecting a broken exclusion. The one population the filter was
+designed for — new adopters — is the one population no criterion covers.
 
-## O5 — premise — medium
+## O5 — scope — high
 
 ### Claim
 
-The spec's own evidence records no instance of this nudge ever producing a useful
-adoption, and the single case offered in its favour is one the spec states cannot
-be settled. On that basis the design keeps the nudge and adds new per-project
-governance state to it.
+Step 2 of `/harness-upgrade` currently parses both files into three buckets.
+`harness-template-diff` computes one. Substituting the script for the parse
+deletes the "Updated items" and "Removed items" buckets, and §4.4 does not
+mention either.
 
 ### Evidence
 
-Against:
+> §4.4: "**Step 2** invokes `harness-template-diff --format=json` rather than
+> restating the matching rules."
 
-> Five of the last six marker advances adopted nothing. (§1)
+§4.1's contract emits `missing` and nothing else.
 
-> The 2026-08-25 run reached the same conclusion about the same item a third
-> time. (§1)
+The command today:
 
-In favour, in full:
+> `commands/harness-upgrade.md:74`: "Sort items into three buckets:"
+> `:79`: "**Updated items** — present in both files, but the template content
+> differs. Only flag items the user has not customised…"
+> `:86`: "**Removed items** — present in the user's HARNESS.md but absent from
+> the current template. Advisory only."
 
-> `d867c7c` added a commented-out `## Stakeholders` section ... `89b46f9` ran six
-> hours later, reported "byte-identical … nothing to adopt" ... This cannot be
-> settled now — the `0.73.2` plugin cache is no longer on the machine that ran
-> it. (§1)
-
-And the decision that rests on it:
-
-> Rejected because the `## Stakeholders` case *suggests* the failure mode that
-> actually costs something is *not being told*. (§3.3, emphasis added)
+§4.4 enumerates changes to steps 1, 2, 3, 4, 6 and 7. Step 3's new **Previously
+declined** group is described; the two disappearing groups are not. §6 offers a
+rationale for choosing heading sets over full-text diff — "The property worth
+surfacing is a *missing item*, not a reworded one" — which is a defensible
+answer for the *hook*, but "Updated items" is a `/harness-upgrade` feature about
+content, and dropping it is a decision the spec does not record as one.
 
 ### Why this matters
 
-§3.3 is the right question asked once and answered from the weaker of the two
-available bodies of evidence. Six recorded runs adopting nothing is data; one
-unattributable miss is an anecdote whose cause §4.4 guesses at (see O11 for a
-third candidate cause). The cost of being wrong here is not the hook — it is
-§3.4's declined block, a new durable governance artefact in every project that
-adopts the plugin, kept alive to serve a signal with no recorded success.
+A user who runs `/harness-upgrade` after this change will no longer be shown
+that a constraint they never customised has been rewritten in the template, nor
+that their harness carries items the template has dropped. Both are silent
+regressions in a command whose stated job is bringing a harness in line with the
+template. The second one has a direct consequence — see O6.
 
-I am not asserting the nudge is worthless; §3.3 may well be right that *not being
-told* is the expensive failure. I am objecting that the spec does not know, says
-so, and proceeds as though the question were closed. The honest form of §3.3 is
-either evidence that someone was ever usefully told, or an explicit statement
-that the nudge is being retained on judgement rather than data.
-
-## O6 — implementation — high
+## O6 — risk — high
 
 ### Claim
 
-The spec asserts an invariant its architecture cannot supply. The hook and the
-command are two independent implementations of one parser — one bash, one prose
-executed by a model — and this repository already runs a GC rule because that
-exact drift is a known local failure class.
+Migration deletes the `template-version` marker from consuming projects while
+leaving the `Template currency` GC rule that reads it. Under the pre-existing
+"missing marker means 0.0.0" semantics, that rule then reports drift on every
+run, forever, in every project that ever ran `/harness-init`. Nothing in the
+spec removes it, and per O5 the one bucket that would have flagged it is being
+removed in the same change.
 
 ### Evidence
 
-> Matching is case-insensitive and whitespace-trimmed, identical to
-> `/harness-upgrade` step 2, so the hook and the command never disagree about
-> what is new. (§4.1)
+> §4.5: "The marker becomes inert on the release that ships this. Nothing reads
+> it, so a project that still has one is not broken."
+> "`/harness-upgrade` removes it when it next runs, and says so in its report."
+> "This repository removes its own in this PR, along with the `Template
+> currency` GC rule."
 
-> Both the hook and the command extract headings from inside HTML comments at
-> every level. (§4.4)
+The rule was shipped to every adopter by the template:
 
-`hooks/scripts/template-currency-check.sh` is bash. `commands/harness-upgrade.md`
-is a markdown prompt: "Match items by heading name (case-insensitive, trimmed)"
-(step 2). The second is an instruction to a model, not an implementation.
+> `templates/HARNESS.md:335` `### Template currency`
+> `:337` "**What it checks**: Whether the HARNESS.md template-version marker…"
+> `:342` "**Tool**: compare template-version comment in HARNESS.md against…"
 
-The repository's own position on this class:
+The failure semantics are already established in the code being replaced:
+
+> `hooks/scripts/template-currency-check.sh:32-34`
+> ```bash
+> if [ -z "$harness_version" ]; then
+>   harness_version="0.0.0"
+> fi
+> ```
+
+§4.7's row for the rule is scoped to `templates/HARNESS.md:337-342` and
+`HARNESS.md:760-769` — the plugin's copy and this repository's copy. A consuming
+project's copy is its own file and is reached by no listed change.
+
+### Why this matters
+
+The spec's problem statement is a mechanism that "asserts `Plugin template has
+been updated` on evidence that cannot establish it", and whose "false signal
+reached the governing document" (§1). This migration reproduces that outcome
+exactly, in every project except this one: a GC rule declared in the governing
+document, comparing a value that no longer exists, reporting drift that cannot
+be cleared. It is the defect being fixed, exported to the install base.
+
+## O7 — alternatives — high
+
+### Claim
+
+The template's own content marker is rejected on two grounds — unmaintained, and
+unread — that are both properties of the current state rather than of the
+mechanism, and this spec already demonstrates the repair for the first one on
+another defect three sections later. A hook that compares the template's content
+marker against the project's, plus a Layer 0 assertion that any change to
+`templates/HARNESS.md` moves that marker, measures the property §2 names and
+needs no script, shim, grammar, declined-item record or new command disposition.
+
+### Evidence
+
+> §6: "**Compare the template's own content marker.** Unmaintained — `d867c7c`
+> changed the template without moving it — and nothing reads it. Substitutes one
+> unreliable signal for another."
+
+The repair pattern is already in the spec:
+
+> §4.2: "A Layer 0 test asserts no heading line in `templates/HARNESS.md`
+> carries a trailing parenthetical, so the class cannot return."
+
+The same sentence shape applies: *a Layer 0 test asserts that a diff touching
+`templates/HARNESS.md` also moves `<!-- template-version -->`, so the class
+cannot return.* "Nothing reads it" is answered by having the hook read it, which
+is one line's change from the code in `template-currency-check.sh:29`.
+
+§6's other stored-state objection does not transfer:
+
+> "**Hash the template and store the hash.** … reintroduces per-project state
+> that drifts, which is the class of defect being removed."
+
+The template's marker is not per-project state. It ships in the plugin, is
+authored by the maintainer, and is enforceable in this repository's CI — which
+is where §4.2 is already putting an assertion.
+
+### Why this matters
+
+Spec time is when alternatives are still cheap. The rejected option is roughly
+one CI check and one `sed` expression against a design that adds a script, a
+`PATH` shim, an HTML-comment grammar in the governing document, a fourth
+disposition in a command, eighteen acceptance criteria and a twelve-file
+migration. The rejection is one sentence, and the sentence relies on a fact the
+spec's own method dissolves.
+
+## O8 — implementation — high
+
+### Claim
+
+`SessionStart` fires on startup, resume, clear and compact. §4.4 reasons about
+skip semantics in units of "session", removes the only time-boxed silence, and
+specifies no startup guard — so a project with one genuinely new template item
+receives the nudge repeatedly inside one working session.
+
+### Evidence
+
+> §4.4: "Skip means *not now, ask again next session*. Revision 1 removed the
+> dismissal file, which was the only time-boxed silence, without saying so. This
+> revision states it: … being reminded of those each session is the intended
+> behaviour."
+
+> §4.5: "`.claude/.harness-upgrade-dismissed` is no longer written or read."
+
+The hook's registration:
+
+> `hooks/hooks.json:100-108` — `"SessionStart"`, `"matcher": "*"`,
+> `bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/template-currency-check.sh`
+
+The project has already learned this lesson on the same rail:
+
+> `hooks/scripts/wip-check.sh:28-29`: "STARTUP ONLY. SessionStart re-fires on
+> resume, clear and compact, and a breach report re-injected mid-session is the
+> thrash this exists to name."
+> `:47`: `[ "$source_field" = "startup" ] || exit 0`
+
+`parked-resume-check.sh:13` carries the same note. Neither §4.1, §4.3 nor §4.4
+specifies the equivalent gate, and no acceptance criterion covers it.
+
+### Why this matters
+
+The dismissal file was doing more work than §4.4 credits: it suppressed re-fires
+within a version, not just across sessions. Removing it while keeping the nudge
+on a `*` matcher turns a once-per-upgrade message into a per-compaction one on
+exactly the population the nudge is meant to serve — a project that really is
+missing template content and has not yet acted. Alarm fatigue on the only true
+positives the mechanism has is the worst available distribution of noise.
+
+## O9 — scope — high
+
+### Claim
+
+The §4.7 and §8 inventories are again presented as authoritative and are again
+incomplete, and no acceptance criterion asserts that no live reference survives.
+The correction mechanism for a defect that has now recurred twice is a third
+hand-made list.
+
+### Evidence
+
+> §4.7: "Revision 1's table listed seven files and presented the inventory as
+> complete; it found seven of ten (O4)."
+
+Live references absent from both §4.7 and §8:
 
 ```text
-HARNESS.md:690  ### Command-prompt sync
+skills/harness-observability/references/observatory-signals.md:157  | **Total** | **82** |
+commands/observatory-verify.md:3    "…runs the 82-signal checklist against the latest output files"
+commands/observatory-verify.md:17   "This is the authoritative list of all signals to verify — 82 signals"
+README.md:77                        "the `Template currency` rule checks the same marker on…"
+docs/plugins/…/reference/hooks.md:277               "### Template currency check"
+docs/plugins/…/reference/commands.md:133            ".claude/.harness-upgrade-dismissed marker so the SessionStart hook"
+commands/harness-upgrade.md:152                     "Template version updated from X.Y.Z to A.B.C"
 ```
 
+The observatory count is the same enforcement surface §4.7 itself flags as
+load-bearing: "**The observatory row is enforced.**" Removing row 127 without
+moving 82 → 81 in three places leaves the reference internally inconsistent with
+the command that reads it.
+
+§5 contains no criterion of the form "a repository-wide search for
+`template-version` returns only CHANGELOG entries, archived snapshots and
+historical spec/objection records."
+
 ### Why this matters
 
-"Never disagree" is doing load-bearing work in this design. §4.3 has the command
-subtract declined headings and present a *Previously declined* group; §4.1 has
-the hook subtract the same set. If they diverge, the user is nudged about an item
-the command will not show them, or shown an item the hook never mentions —
-either of which reads as the mechanism being broken, because it is.
+The spec's method for this class is enumeration by hand, and enumeration by hand
+is what produced seven-of-ten last time. The fix that would end the recurrence —
+one grep assertion in the Layer 0 suite — costs less than the table and is the
+same technique §4.2 and §5.2 already reach for elsewhere in this spec.
 
-The single-implementation alternative is available and unweighed: have step 2
-invoke `template-currency-check.sh` (or a shared extraction script) and consume
-its output, rather than restating its rules in prose. That would make the
-invariant structural instead of asserted, and would collapse §4.4's "both the
-hook and the command" into one change instead of two that must agree.
-
-## O7 — risk — high
+## O10 — specification quality — medium
 
 ### Claim
 
-The hook reaches its silent, passing outcome on a code path where it has not read
-the thing it reports on. The harness decision record in force names that a defect
-rather than a default, and the spec carries the behaviour forward marked
-"unchanged".
+The comparison rule states HTML-comment handling for the template side and
+leaves it undefined for the project side. This repository's own file makes the
+two readings produce opposite outcomes for criterion 14.
 
 ### Evidence
 
-> `exit 0 if either file is unreadable          (unchanged: advisory, never blocks)`
-> (§4.1)
+> §4.1: "tpl_headings = ## and ### headings of tpl, **including inside HTML
+> comments**, EXCLUDING: …"
 
-> 9. The hook never blocks and never exits non-zero. (§5)
+`proj_headings` then appears undefined:
 
-Against HDR-2026-08-25, compiled into
-`ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md` and in force until
-2026-11-23:
+> "skip if normalise(h) is in normalise(proj_headings)"
 
-> A mechanism that reports a status ... must have a defined value for the case
-> where it could not determine the answer, and that value may not be the passing
-> one. Where an input is missing, unreadable or not supplied, the mechanism
-> reports the degraded or unknown state and names the input it could not read.
+> `HARNESS.md:55` — `<!-- ## Stakeholders`
 
-The unreadable case is not hypothetical for this hook: `$CLAUDE_PLUGIN_ROOT` is
-unset outside a plugin context, and the current script already exits 0 in three
-such places (lines 19-26, 38-40).
+Under a comment-excluding read of the project side, `Stakeholders` is missing
+from this repository and criterion 14 fails. Under a comment-including read it
+is present and criterion 14 passes. Since the template side is explicitly
+specified and the project side is not, the asymmetry reads as deliberate to at
+least one reasonable implementer.
 
 ### Why this matters
 
-There is no tension between the HDR and "never blocks" — a `systemMessage` naming
-the unreadable input satisfies both, and §4.2 already establishes the message
-channel. What the spec has done is carry an old behaviour forward under the word
-"unchanged", which is precisely how a mechanism that fails toward the reassuring
-answer survives a rewrite that was otherwise willing to delete everything.
+Criterion 14 is the spec's headline guard and its pass/fail depends on an
+unstated rule. Worse, the two readings differ in meaning: "you have adopted this
+in commented form" and "you have not adopted this" are different states, and the
+spec has not decided which one counts as having the item.
 
-The consequence is specific: a project whose plugin root is misconfigured gets
-silence, reads silence as "my harness is current", and stops looking. That is the
-same failure §1 describes, arrived at from the other direction — §1's mechanism
-lied loudly, this path lies quietly.
-
-## O8 — scope — medium
+## O11 — specification quality — medium
 
 ### Claim
 
-The design removes the only mechanism for silencing the nudge without acting on
-it, leaving *skip* as a disposition that guarantees the item re-fires every
-session forever. The spec does not state this consequence.
+Criterion 10 tests a write behaviour against a component that has no write path,
+in the section §5.3 was added to stop exactly that misfiling.
 
 ### Evidence
 
-> `.claude/.harness-upgrade-dismissed` is no longer written or read. (§4.5)
+> §5.1, "`harness-template-diff` — Layer 0 deterministic", criterion 10:
+> "A declined reason containing `--` is rejected on write."
 
-> **Skip** remains what it is today: not now, ask again next time. (§4.3, step 4)
+The script's contract (§4.1) is `harness-template-diff [--format=text|json]`
+with two file inputs and four read-only outcomes. The behaviour belongs to the
+command:
 
-> `missing = tpl_headings - proj_headings - declined` (§4.1)
+> §4.4: "**Step 4** … Declining prompts for a reason and writes it per §3.5's
+> grammar, rejecting a reason containing `--`."
 
-Skipped items are not in `declined`, so they remain in `missing`. Under the old
-design, the dismissal file silenced the hook until the next plugin version — a
-skip bought the user weeks. Under the new one, "ask again next time" means the
-next session, and the one after that.
+And the section immediately following states the principle being violated:
 
-### Why this matters
-
-The spec's central charge is alert fatigue: an item declined three times on
-recorded reasoning kept coming back. §3.4 solves that for *decline* and leaves
-*skip* with strictly worse ergonomics than it has today. A user who wants to
-consider an item next month has exactly two options: adopt it, or record a formal
-decline they do not mean. The predictable outcome is that people decline things
-to make the nudge stop, which converts §3.4's "declining is a considered act
-rather than a suppression" into its opposite.
-
-Either skip needs a time-boxed silence, or the spec should say plainly that skip
-now means "nudge me every session until you decide" and accept that as the design.
-
-## O9 — specification quality — medium
-
-### Claim
-
-The test plan assigns command behaviour to a hook test file, and leaves the write
-path of the declined block — the mechanism §3.4 calls load-bearing — with no
-acceptance criterion at all.
-
-### Evidence
-
-> Criteria 1-7 and 9 are Layer 0 deterministic tests at
-> `tdad_tests/layer0_deterministic/test-template-currency-check.sh` (§5)
-
-Criterion 6 is:
-
-> Given a `HARNESS.md` with a `template-version` marker, `/harness-upgrade`
-> removes it and reports having done so.
-
-That is a model-executed command, not the hook script named as its test location.
-Criterion 7 spans "both the hook and the command", so at most half of it can live
-there. Criterion 8, correctly, is excluded from the deterministic list — which
-shows the boundary was noticed for one criterion and not the neighbouring two.
-
-Every declined-block criterion is a *read* criterion. Criterion 3 assumes a
-correctly formed block already exists; criterion 8 assumes the command can read
-one. Nothing tests that §4.3 step 4 and step 6 *write* a block that criterion 3
-can read.
+> §5.3: "Not Layer 0; these are model-executed and belong in a behavioural
+> scenario, not in the hook's test file. Revision 1 assigned them to the hook's
+> file in error."
 
 ### Why this matters
 
-Given O3, the write path is where this design is most likely to fail, and it is
-the one path with neither a specified format nor a test. The round trip is the
-thing worth pinning: decline an item via the command, then run the hook and
-observe silence. Written as a Layer 0 fixture pair, that single test would catch
-every grammar ambiguity in O3 without the spec having to resolve them in prose
-first.
-
-## O10 — alternatives — medium
-
-### Claim
-
-§6 weighs four alternative ways to *compare*, and never weighs narrowing *what*
-is compared. Excluding placeholders, examples, and opt-in blocks from the item
-set removes most of the false-positive load without inventing per-project
-declined state at all.
-
-### Evidence
-
-All four rejected alternatives vary the comparison method:
-
-> **Compare the template's own content marker** ... **Hash the template and store
-> the hash** ... **Full-text diff instead of heading sets** ... **Record declines
-> in a separate file.** (§6)
-
-The item set is fixed by one parenthetical and never revisited:
-
-> `tpl_headings   = headings of tpl             (## and ###, incl. commented)` (§4.1)
-
-The template already distinguishes the categories that would be excluded, in
-machine-readable form: `<!-- affordance-example -->` (lines 520, 535, 546, 557),
-`<!-- Uncomment if ... -->` wrappers (lines 147, 181, 192, 372, 406, 446), and a
-bracketed placeholder heading (`### [Governance constraint name]`, line 194).
-`/harness-upgrade` step 2 already keys on the `<!-- Uncomment if...` pattern
-today.
-
-### Why this matters
-
-§3.4's declined block exists because "heading comparison alone reproduces the
-original defect in a new coat". That is true of an *unfiltered* heading
-comparison. A filtered one — active constraints and GC rules, excluding examples
-and placeholders — reduces the standing false-positive set from O1's dozens to
-approximately the one case §3.4 actually cites (`Consistent formatting` versus
-`Consistent markdown formatting`), which is a genuine specialisation and the only
-case where a recorded human decision is really needed.
-
-That is a materially cheaper design: it drops a new durable per-project artefact,
-its grammar (O3), its write path (O9), and the new `decline` disposition, in
-exchange for a filter over a set the template already tags. §6 should say why it
-is worse, or take it.
-
-## O11 — implementation — medium
-
-### Claim
-
-The spec never states which copy of the template is authoritative. The path it
-names is, in this repository, rsynced from the working tree on every `Stop` —
-which both creates a self-referential false positive during template development
-and supplies a third, simpler explanation for §1's `## Stakeholders` case than
-the parsing asymmetry §4.4 fixes.
-
-### Evidence
-
-> `tpl      = $CLAUDE_PLUGIN_ROOT/templates/HARNESS.md` (§4.1)
-
-`CLAUDE.md`, Marketplace Cache Auto-Sync:
-
-> `ai-literacy-superpowers/scripts/sync-to-global-cache.sh` — rsyncs plugin
-> content into the versioned plugin cache (runs on every `Stop`)
-
-So in this repository the hook compares the project's `HARNESS.md` against a
-template copy that tracks the working tree within one session. And §1's timeline:
-
-> `d867c7c` added a commented-out `## Stakeholders` section to the template on
-> 2026-08-13 at 09:11. `89b46f9` ran six hours later, reported "byte-identical …
-> nothing to adopt". (§1)
-
-Whether that report was wrong depends entirely on which copy `89b46f9` read — and
-the spec does not say, while §4.4 proceeds as though parsing were the cause:
-
-> This is the parsing half of the `## Stakeholders` case in §1. (§4.4)
-
-### Why this matters
-
-Two distinct consequences. First, operationally: a maintainer who adds a heading
-to `templates/HARNESS.md` gets nudged, in their next session, that their own
-harness is missing the thing they just wrote. That is a new failure the current
-version-based hook does not have.
-
-Second, epistemically: if `89b46f9` compared against a cache copy that predated
-`d867c7c`, then the comparison was *correct*, §4.4 fixes a bug that was not the
-cause, and the one piece of evidence sustaining §3.3's decision to keep the nudge
-(O5) evaporates. §4.4 is worth doing regardless — commented headings should parse
-uniformly — but it should not be presented as the explanation of a case the spec
-has not attributed. Naming the authoritative copy, and what happens when it is
-the working tree, closes both.
+An implementer building the Layer 0 suite from §5.1 will either add a write path
+to a read-only tool to satisfy criterion 10, or quietly drop the criterion. The
+first widens the script's surface beyond §4.1's contract; the second loses the
+only check on the `--` rule that §3.5 calls "semantically load-bearing".
 
 ## O12 — risk — medium
 
 ### Claim
 
-The PR knowingly merges a governing document whose Status block overstates its own
-coverage, and removes a row the observatory reference marks required, without
-saying what either consequence is.
+§4.3 makes an absolute claim about what silence means, and the design honours it
+for one input only. The hook's own failure modes all produce silence, which this
+spec has just defined as the reassuring answer.
 
 ### Evidence
 
-> `HARNESS.md`'s Status block references the marker. It is owned by
-> `/harness-audit` and is corrected by running it, not by hand-editing this PR.
-> (§4.6)
+> §4.3: "Silence means checked-and-current. It never means could-not-check. This
+> follows the harness decision record in force until 2026-11-23 … a mechanism
+> that could not determine the answer reports the degraded state and names the
+> input it could not read."
 
-The rule being removed is deterministic and counted:
+§4.1 defines exactly one degraded outcome — `tpl absent/unreadable`. It defines
+none for the hook that wraps it. §4.7 specifies the wrapper only as
+`hooks/scripts/template-currency-check.sh` "Rewritten to call
+`harness-template-diff`". The surrounding conditions:
 
-```text
-HARNESS.md:760-769   ### Template currency ... **Enforcement**: deterministic
-HARNESS.md:1174      Garbage collection active: 19/19
-```
+> `hooks/hooks.json:107` — `"timeout": 10`
+> `hooks/scripts/template-currency-check.sh:11` — `set -euo pipefail`
 
-After the removal, 19/19 describes eighteen rules. And:
-
-> `skills/harness-observability/references/observatory-signals.md:127` |
-> `Template version` is marked **required**; remove the row (§4.6)
+A stale marketplace cache or partial install in which
+`scripts/harness-template-diff.sh` is absent, a non-zero exit propagating under
+strict mode, or a timeout, all yield no `systemMessage` — indistinguishable from
+"checked and current".
 
 ### Why this matters
 
-§4.6's reasoning is right about ownership — `/harness-audit` owns the Status
-block, and hand-editing it is worse than leaving it. But the choice presented is
-false: the third option is to run `/harness-audit` as part of this change, which
-the repository's own convention supports, and which turns "the governing document
-is wrong until someone notices" into "the governing document is correct at merge".
-Leaving it stale is the same fail-toward-reassuring pattern as O7, in the document
-that is supposed to be the source of truth for all the others — and this
-repository's Status block already carries a written record of exactly this
-happening before ("The 2026-08-13 audit recorded `Drift detected: no` against a
-tree that already carried every failure listed here", `HARNESS.md:1177`).
-
-On the observatory signal: the spec says to remove a row marked **required**
-without stating whether `required` is enforced, what reads it, or what happens to
-archived snapshots that carry the field. If nothing enforces it, say so; if
-something does, this is a schema change and belongs in §4.6 with its consumers
-named.
+The decision record cited in §4.3 is enforced against this plugin and names this
+exact shape: "A reachable code path that reaches a passing value without reading
+the thing it reports on is a defect, not a default." The spec invokes the record
+correctly for the template-unreadable case and then stops one layer short of the
+component that actually decides whether the user sees anything.
 
 ## Explicitly not objecting to
 
-- **§1's evidence quality**: the problem statement is the strongest part of this
-  spec — byte-level `diff` results, commit hashes, dates, and a stated
-  verification date. It establishes the marker is a bad proxy beyond argument,
-  and I am not challenging that conclusion anywhere in this record.
-- **Retiring the marker rather than making it optional (§3.1)**: the reasoning is
-  correct and well argued — opting out of a broken signal is not fixing it, and
-  the projects most in need of a nudge are exactly the ones that would go quiet.
-- **Rejecting the `none` sentinel (§3.2)**: "Retiring the signal is cheaper than
-  governing it" is the right call, and the spec correctly identifies that it is
-  trading against a local declare-don't-infer preference rather than a rule.
-- **Keeping the declined record in `HARNESS.md` rather than a new file (§6)**:
-  the "two committed dashboards went 106 days unread" argument is concrete,
-  local, and decisive. My objections to the declined block (O3, O9) are about its
-  grammar and its tests, never its location.
-- **The minor version bump and the five CI-checked locations (§7)**: correct per
-  `CLAUDE.md`, correctly scoped as behavioural, and nothing here warrants a
-  challenge.
-- **Rejecting full-text diff (§6)**: "The property worth surfacing is a *missing
-  item*, not a reworded one" is exactly right, and it is the sentence that keeps
-  the message in §4.2 honest about what it compared.
-- **The TDAD constraint analysis (§5)**: the spec correctly reasons that the
-  *New plugin components must ship with a TDAD scenario* constraint does not gate
-  this work, and adds the Layer 0 test anyway with a stated reason. That is the
-  right relationship to a constraint and I am not going to punish it.
-- **Leaving the `.gitignore` entry in place (§4.5)**: the reasoning — the file
-  exists on machines that ran the old command, and removing the ignore surfaces
-  it as untracked — is a small, correct piece of migration thinking that many
-  specs would have missed.
-- **The out-of-scope boundary**: excluding adoption mechanics, the evolution
-  loop, and the `/harness-propose` routing question is a defensible line. My
-  scope objections (O4, O8) are about surfaces inside the declared scope that the
-  spec missed, not about where the line was drawn.
+- **The core premise that the marker measures the wrong property**: §1's
+  evidence is independently checkable and holds — `templates/HARNESS.md` last
+  changed at `d867c7c` (2026-08-13), the repository marker reads `0.79.0`
+  (`HARNESS.md:13`) against `plugin.json` `0.89.0`, and `HARNESS.md:1185`
+  records the resulting false claim in the governing document. Retiring
+  version-as-proxy is right.
+- **Heading sets over full-text diff**: §6's reasoning is correct — the property
+  worth surfacing is a missing item, not a reworded one — and a full-text diff
+  would fire on every prose edit.
+- **Fixing the template rather than the parser in §4.2**: the right layer, and
+  the justification checks out — `templates/HARNESS.md:463` and `:476` carry
+  `(LOCAL — per-machine only)` parentheticals that appear identically on both
+  sides and would be collapsed by a general normalisation.
+- **Keeping the declined record in `HARNESS.md` rather than a new file**: the
+  "two committed dashboards went 106 days unread" evidence is the strongest
+  argument in §6, and it is applied correctly.
+- **Running `/harness-audit` in this PR (§4.8)**: this is a genuine improvement
+  over revision 1, and `HARNESS.md:1177`'s record of the 2026-08-13 audit
+  reporting `Drift detected: no` against a failing tree is the right evidence
+  for it.
+- **§1.1's withdrawal of the Stakeholders attribution**: naming three candidate
+  causes and attributing none, rather than keeping a convenient one, is
+  intellectually honest and I have no basis to challenge it.
+- **The declined-block grammar's strictness (§3.5)**: the `::` separator, the
+  no-continuation rule, the `--` prohibition and "reported, never skipped" are
+  well specified; my only objection touching it is where criterion 10 was filed,
+  not what it says.
+- **The version bump, docs list and Layer 0 platform conventions (§7, §8)**:
+  these follow the repository's existing conventions and I found nothing wrong
+  with them beyond the completeness point in O9.
+- **The `New plugin components must ship with a TDAD scenario` reasoning in
+  §5.3**: the constraint genuinely names skills, agents and commands, a script
+  is none of those, and the spec adds the tests anyway.
+- **Not objecting to the `/harness-upgrade`-routes-through-`/harness-propose`
+  question**: explicitly out of scope per the header, and legitimately so.

--- a/docs/superpowers/specs/2026-08-25-template-currency-measure-content-design.md
+++ b/docs/superpowers/specs/2026-08-25-template-currency-measure-content-design.md
@@ -1,18 +1,24 @@
 # Template currency measures content — design
 
-**Status:** proposed
+**Status:** proposed (revision 2)
 **Date:** 2026-08-25
 **Issue:** #601
 **Provenance:** `docs/superpowers/specs/2026-04-15-harness-upgrade-design.md`,
 which introduced the `template-version` marker and decided that a missing
 marker means "treat as `0.0.0`". This spec retires the marker outright. The
 issue as filed proposed making the marker optional; the approach here is
-broader and is argued for in §3.
+broader and is argued for in §3.1.
+**Revision 2** rewrites §3 and §4 against
+`docs/superpowers/objections/template-currency-measure-content-design.md`.
+The comparison is now over a *filtered* item set (O10), which removes the
+false-positive load that O1 and O2 identified and shrinks the declined-item
+mechanism to the one case that needs it. §11 maps every objection to what
+changed.
 **Scope:** the SessionStart template-currency hook, `/harness-upgrade` step 1
 and step 6, `/harness-init`'s marker write, the `Template currency` GC rule,
-and the declined-item record that makes the new comparison quiet.
+the `/harness-sync` template-drift surface, and the declined-item record.
 **Out of scope:** `/harness-upgrade`'s adoption mechanics (steps 2–5) beyond
-the parsing fix in §4.4; the harness evolution loop; whether
+the parsing changes in §4; the harness evolution loop; whether
 `/harness-upgrade` should route adopted items through `/harness-propose`.
 
 ## 1. Problem statement
@@ -38,22 +44,33 @@ updated` on evidence that cannot establish it. The false signal reached the
 governing document: `HARNESS.md`'s Status block records "eight minors of
 unreviewed template content" against a template that had not changed.
 
-The failure has two halves, and fixing only one leaves the mechanism broken.
+Five of the last six marker advances adopted nothing. `58d3dda` (2026-07-22)
+and `89b46f9` (2026-08-13) each record "found nothing to adopt", both naming
+the same item — the generic `Consistent formatting` placeholder, declined
+because this repository has specialised it into a deterministic markdownlint
+rule. The 2026-08-25 run reached the same conclusion about the same item a
+third time.
 
-**It cries wolf.** Five of the last six marker advances adopted nothing.
-`58d3dda` (2026-07-22) and `89b46f9` (2026-08-13) each record "found nothing to
-adopt", both naming the same item — the generic `Consistent formatting`
-placeholder, declined because this repository has specialised it into a
-deterministic markdownlint rule. The 2026-08-25 run reached the same conclusion
-about the same item a third time.
+### 1.1 The `## Stakeholders` case, and what it does not establish
 
-**It may also be silent when it matters.** `d867c7c` added a commented-out
-`## Stakeholders` section to the template on 2026-08-13 at 09:11. `89b46f9` ran
-six hours later, reported "byte-identical … nothing to adopt", and stamped the
-marker forward. The block was not adopted until twelve days later, by a human
-who noticed it another way. This cannot be settled now — the `0.73.2` plugin
-cache is no longer on the machine that ran it — but §4.4 addresses the parsing
-asymmetry that makes the "genuinely missed it" reading plausible.
+`d867c7c` added a commented-out `## Stakeholders` section to the template on
+2026-08-13 at 09:11. `89b46f9` ran six hours later, reported "byte-identical …
+nothing to adopt", and stamped the marker forward. The block was not adopted
+until twelve days later, by a human who noticed it another way.
+
+Revision 1 presented this as evidence that the nudge's valuable failure mode is
+*not being told*, and presented §4's parsing fix as its explanation. Both
+overstated it. There are at least three candidate causes and this spec
+attributes none of them:
+
+1. The run genuinely missed a commented-out section (a parsing gap).
+2. The cache had not yet synced, so `89b46f9` compared against a copy predating
+   `d867c7c` — plausible, because in this repository the cache is rsynced from
+   the working tree on `Stop` (§4.6).
+3. The section was seen and skipped.
+
+The `0.73.2` plugin cache is no longer on the machine that ran it, so this
+cannot be settled. §3.3 no longer rests on it.
 
 ## 2. The property that should be measured
 
@@ -62,16 +79,21 @@ does not*. The marker measures a different one: *the plugin has been released
 since you last stamped a number*. These come apart on every release that does
 not touch the template, which is nearly all of them.
 
-`/harness-upgrade` already computes the real property. Steps 2–3 parse both
-files into named items and diff them. Step 1's version gate is a pre-filter in
-front of a comparison that does not need it, and the pre-filter is the part
-that is wrong.
+`/harness-upgrade` already computes something close to the real property. Steps
+2–3 parse both files into named items and diff them. Step 1's version gate is a
+pre-filter in front of a comparison that does not need it, and the pre-filter is
+the part that is wrong.
 
-## 3. Decision — compare headings, retire the marker
+## 3. Decision — compare a filtered item set, retire the marker
 
 The hook and the command compare **heading sets** between the plugin's
 `templates/HARNESS.md` and the project's `HARNESS.md`. There is no marker, no
 `plugin.json` read, and no stored version state.
+
+The comparison is over a filtered set. Revision 1 compared every `##` and `###`
+heading in the template, which produces false positives by construction — see
+§3.4. The filter is what makes the mechanism quiet; the declined-item record
+(§3.5) handles only the residue.
 
 ### 3.1 Why not the narrower change in #601
 
@@ -89,97 +111,202 @@ declare-don't-infer culture, but it is additional mechanism in service of a
 signal §1 shows is unreliable in both directions. Retiring the signal is
 cheaper than governing it.
 
-### 3.3 Why not delete the nudge entirely
+### 3.3 Why keep a nudge at all — on judgement, not on data
 
-Considered. `/harness-upgrade` survives as an on-demand command either way, and
-the README already directs people to run it after a plugin upgrade. Rejected
-because the `## Stakeholders` case suggests the failure mode that actually costs
-something is *not being told*, and a nudge that measures the right property is
-cheap enough to keep.
+Stated plainly, because §1.1 removed the evidence revision 1 leaned on: **there
+is no recorded instance of this nudge producing a useful adoption.** Six runs
+are recorded; five adopted nothing, and the sixth cannot be attributed.
 
-### 3.4 The declined-item record is load-bearing
+The nudge is retained on the judgement that a project which never learns its
+template gained content has no other path to finding out, and that a correctly
+filtered comparison costs two greps at session start. That is a judgement, and
+a reviewer is entitled to reject it — §6 records deleting the nudge entirely as
+a live alternative rather than a dismissed one.
 
-Heading comparison alone reproduces the original defect in a new coat. This
-repository's `HARNESS.md` has `Consistent markdown formatting`; the template has
-`Consistent formatting`. A pure set difference flags it every session, forever —
-an item declined three times on recorded reasoning.
+What changed between revisions is the cost of being wrong. Revision 1 sustained
+the nudge with a new durable per-project artefact in every adopting project.
+This revision sustains it with a filter over headings the template already tags,
+plus a declined block that is empty in a default project.
 
-So the disposition must live somewhere the mechanism can read. Today it lives in
-commit messages and CHANGELOG entries, which is why the item keeps coming back.
+### 3.4 Why the item set must be filtered
 
-`HARNESS.md` gains a declined block, in the position the marker occupied:
+An unfiltered heading comparison fires on the default install, on day one.
+
+- `/harness-init` documents Affordances as "opt-in (default off)"
+  (`commands/harness-init.md:57`) and replaces an unselected feature's section
+  body with `<!-- Not yet configured. Run /harness-init and select this feature
+  to set up. -->` (`:147`, `:154`).
+- The template's `## Affordances` body carries four headings tagged
+  `<!-- affordance-example -->` (`templates/HARNESS.md:520,535,546,557`).
+- The template carries a literal placeholder heading, `### [Governance
+  constraint name]` (`:194`).
+
+So a default-initialised project is missing template headings *by design*, and
+under an unfiltered rule is nudged about example affordances it was never meant
+to adopt — silenceable only by running the command the nudge advertises.
+
+Running revision 1's rule against this repository — a near-superset of the
+template, the most favourable input available — produced two items:
+
+```text
+Consistent formatting
+Cognitive reservoir  (OPTIONAL — to opt in, remove this `<!--` line and the closing `-->` below)
+```
+
+The second is pure false positive: `templates/HARNESS.md:630` carries
+instructional text on the heading line, which no amount of trimming or
+case-folding reconciles with this repository's `## Cognitive reservoir`
+(`HARNESS.md:1126`). §4.2 fixes it in the template rather than working around
+it in the parser.
+
+### 3.5 The declined-item record, reduced to its residue
+
+Filtering does not catch a genuine specialisation. This repository has
+`Consistent markdown formatting`; the template has `Consistent formatting`.
+Same intent, different name, and no filter can know that.
+
+That case needs a recorded human decision, and it needs one because the decision
+has already been made three times and written only into commit messages — which
+is why the item keeps returning.
+
+`HARNESS.md` gains a declined block. In a default project it is absent or empty;
+in this repository it holds one entry.
 
 ```html
 <!-- template-declined
-     Consistent formatting: specialised here as "Consistent markdown
-       formatting" (deterministic, markdownlint, commit + pr). Adopting the
-       template's unverified placeholder would be a downgrade.
+Consistent formatting :: specialised here as "Consistent markdown formatting" (deterministic, markdownlint, commit + pr); the template's placeholder is unverified
 -->
 ```
 
-One line per declined heading, `Heading: reason`. The hook subtracts these from
-the missing set. `/harness-upgrade` reads them and presents a declined item as
-*previously declined, because …* rather than as new.
+Grammar, stated strictly because revision 1 left it undefined (O3):
 
-The reason text is never parsed. It exists so the next person reads why, and so
-that declining is a considered act rather than a suppression.
+- One entry per line. **No continuation lines** — an indented line is not a
+  continuation, it is a malformed entry. `MD013` is disabled in
+  `.markdownlint.json`, so a long line is permitted.
+- Separator is ` :: ` (space-colon-colon-space). A colon may appear in either
+  field; the first ` :: ` splits.
+- Left field is the template heading, matched by the same normalisation as §4.1.
+- Right field is free prose, never parsed.
+- The reason may not contain `--`. `/harness-upgrade` rejects such a reason and
+  re-prompts rather than writing it. This is not stylistic: the block is an HTML
+  comment, `-->` terminates it early, and comment state is semantically
+  load-bearing in this file.
+- Duplicate left fields are malformed, not last-wins.
+- **A line that does not parse is reported, never skipped.** The tooling names
+  the file and line and treats the entry as absent. A silent skip re-admits a
+  declined item to the missing set, which is indistinguishable from the bug
+  this spec fixes.
 
 ## 4. Design
 
-### 4.1 The hook
+### 4.1 The comparison, in one place
 
-`hooks/scripts/template-currency-check.sh` becomes:
+Revision 1 specified the rule twice — once as bash for the hook, once as prose
+for the command — and asserted they could not disagree. They are two
+implementations, one of them executed by a model, and this repository already
+runs a `Command-prompt sync` GC rule (`HARNESS.md:690`) because that class of
+drift happens here.
+
+The rule is implemented **once**, as `ai-literacy-superpowers/scripts/harness-template-diff.sh`,
+exposed on `PATH` as `harness-template-diff` via the `bin/` shim convention. The
+hook invokes it. `/harness-upgrade` step 2 invokes it and consumes its output
+instead of restating its rules.
 
 ```text
-tpl      = $CLAUDE_PLUGIN_ROOT/templates/HARNESS.md
-proj     = $CLAUDE_PROJECT_DIR/HARNESS.md
+harness-template-diff [--format=text|json]
 
-exit 0 if either file is unreadable          (unchanged: advisory, never blocks)
+  tpl   = $CLAUDE_PLUGIN_ROOT/templates/HARNESS.md
+  proj  = $CLAUDE_PROJECT_DIR/HARNESS.md
 
-tpl_headings   = headings of tpl             (## and ###, incl. commented)
-proj_headings  = headings of proj
-declined       = headings named in proj's template-declined block
+  proj absent            -> exit 0, emit nothing        (not a harness project)
+  tpl absent/unreadable  -> exit 0, emit DEGRADED naming the unreadable path
 
-missing = tpl_headings - proj_headings - declined
+  tpl_headings = ## and ### headings of tpl, including inside HTML comments,
+                 EXCLUDING:
+                   - a heading whose line carries <!-- affordance-example -->
+                   - a heading matching ^\[.*\]$          (literal placeholder)
 
-exit 0 if missing is empty
-emit systemMessage naming the count and up to three headings
+  For each remaining template heading h:
+    skip if h's owning ## section is unconfigured in proj
+           (section body is the "Not yet configured" placeholder marker)
+    skip if normalise(h) is in normalise(proj_headings)
+    skip if normalise(h) is in normalise(declined left-fields)
+    otherwise -> missing
+
+  normalise(h) = trim, collapse internal whitespace, casefold
 ```
 
-Matching is case-insensitive and whitespace-trimmed, identical to
-`/harness-upgrade` step 2, so the hook and the command never disagree about
-what is new.
+The unconfigured-section skip is what makes a default `/harness-init` quiet: a
+project that opted out of Garbage Collection has the `## Garbage Collection`
+heading with a placeholder body, so its twenty-odd `###` children are not
+reported as missing.
 
-### 4.2 The message states what it compared
+### 4.2 The template stops putting instructions on heading lines
 
-> `Template has 2 item(s) your harness does not: "Stakeholders", "Spec conformance". Run /harness-upgrade to review.`
+`templates/HARNESS.md:630` reads:
+
+```text
+<!-- ## Cognitive reservoir  (OPTIONAL — to opt in, remove this `<!--` line and the closing `-->` below)
+```
+
+The instruction moves to the line below the heading. The heading line becomes
+`<!-- ## Cognitive reservoir`.
+
+This is a template fix, not a parser fix, and it is the right layer: the
+template is ours, the comparison runs template→project, and a normalisation
+that strips trailing parentheticals would also collapse `### Affordance recorder
+freshness (LOCAL — per-machine only)` (`:463`) and `### Affordance dead
+inventory (LOCAL — per-machine only)` (`:476`), whose parentheticals are part of
+the heading and appear identically on both sides.
+
+A Layer 0 test asserts no heading line in `templates/HARNESS.md` carries a
+trailing parenthetical, so the class cannot return.
+
+### 4.3 The message states what it compared
+
+> `Template has 1 item your harness does not: "Stakeholders". Run /harness-upgrade to review.`
 
 It names the items it found. A reader can falsify it against their own file
-without running anything — which is the property §1 says was missing.
+without running anything.
 
-### 4.3 `/harness-upgrade`
+On the degraded path (§4.1):
+
+> `Could not read the plugin template at <path> — template currency not checked.`
+
+Silence means checked-and-current. It never means could-not-check. This follows
+the harness decision record in force until 2026-11-23, compiled into
+`skills/advocatus-diaboli/SKILL.md`: a mechanism that could not determine the
+answer reports the degraded state and names the input it could not read. The
+hook still never blocks and never exits non-zero — a `systemMessage` satisfies
+both.
+
+`proj absent` is silent by design and is not a degraded case: a project with no
+`HARNESS.md` has nothing to be current with.
+
+### 4.4 `/harness-upgrade`
 
 - **Step 1** drops the version comparison. Prerequisites keep the HARNESS.md
   existence check and the `git fetch origin main` staleness guard.
-- **Step 3** subtracts declined headings from the *new items* bucket and
-  presents them in a separate **Previously declined** group, each with its
-  recorded reason, so a standing decision is visible without being re-litigated.
+- **Step 2** invokes `harness-template-diff --format=json` rather than
+  restating the matching rules.
+- **Step 3** presents declined items in a separate **Previously declined**
+  group with their recorded reasons, so a standing decision is visible without
+  being re-litigated.
 - **Step 4** gains a **decline** disposition alongside accept/skip/customise.
-  Declining prompts for a one-line reason and writes it to the declined block.
-  **Skip** remains what it is today: not now, ask again next time.
+  Declining prompts for a reason and writes it per §3.5's grammar, rejecting a
+  reason containing `--`.
 - **Step 6** no longer writes a marker or a dismissal file. It removes a
   `template-version` marker if it finds one (§4.5) and writes any new declined
   entries.
 - **Step 7** reports declined items alongside accepted and skipped.
 
-### 4.4 Commented-out blocks parse uniformly
-
-Step 2 currently scopes commented-out blocks to constraints and GC rules, and
-describes sections as plain `## Heading` entries. The template's one commented
-section, `<!-- ## Stakeholders`, matches neither clause.
-
-Both the hook and the command extract headings from inside HTML comments at
-every level. This is the parsing half of the `## Stakeholders` case in §1.
+**Skip semantics, stated rather than assumed.** Skip means *not now, ask again
+next session*. Revision 1 removed the dismissal file, which was the only
+time-boxed silence, without saying so. This revision states it: after filtering,
+the only items that recur are genuinely new template content the project has not
+acted on, and being reminded of those each session is the intended behaviour.
+A user who wants a standing silence declines instead, which costs one sentence
+and leaves a reason for the next reader. No time-boxed skip is added.
 
 ### 4.5 Migration
 
@@ -194,70 +321,151 @@ project that still has one is not broken.
   `.gitignore` entry stays — the file exists on machines that have run the old
   command, and removing the ignore would surface it as untracked.
 
-### 4.6 Surfaces that declare the marker
+### 4.6 Which copy of the template is authoritative
+
+`$CLAUDE_PLUGIN_ROOT/templates/HARNESS.md` — the installed plugin's copy. For a
+consuming project that is the versioned marketplace cache, which advances when
+they upgrade the plugin.
+
+**In this repository the two are coupled.** `sync-to-global-cache.sh` rsyncs
+plugin content into the versioned cache on every `Stop` (`CLAUDE.md`,
+Marketplace Cache Auto-Sync). A maintainer who adds a heading to
+`templates/HARNESS.md` will, in a later session, be told their harness is
+missing the thing they just wrote.
+
+That is correct behaviour reported at a useless moment. It is accepted rather
+than solved: the alternative is teaching the hook to detect that the project
+*is* the plugin source, which is the special-casing §3 exists to avoid. It is
+recorded here so the next person meeting it knows it is known. This coupling is
+also candidate cause 2 in §1.1.
+
+### 4.7 Surfaces that declare or read the marker
+
+Revision 1's table listed seven files and presented the inventory as complete;
+it found seven of ten (O4).
 
 | File | Change |
 | --- | --- |
 | `templates/HARNESS.md:13` | Remove the stale `0.57.0` marker |
 | `templates/HARNESS.md:337-342` | Remove the `Template currency` GC rule |
+| `templates/HARNESS.md:630` | Move the instruction off the heading line (§4.2) |
 | `HARNESS.md:13` | Remove the marker |
 | `HARNESS.md:760-769` | Remove the `Template currency` GC rule |
+| `commands/harness-sync.md:118,206-207,271,294` | **Was missing.** Surface list, checkbox JSON (`"id": "template"`), remediation line, drift-table row |
+| `commands/harness-init.md:184,211` | Stop writing the marker |
+| `commands/harness-upgrade.md:46-47,135-143` | §4.4 |
+| `hooks/scripts/template-currency-check.sh` | Rewritten to call `harness-template-diff` |
 | `skills/harness-audit-engine/SKILL.md:33` | Remove the `Template currency` surface row |
-| `skills/harness-observability/references/observatory-signals.md:127` | `Template version` is marked **required**; remove the row |
+| `skills/harness-observability/references/observatory-signals.md:127` | Remove the `Template version` row — see below |
 | `skills/ai-literacy-assessment/references/habitat-discovery.md:93,141` | Drop the marker from habitat discovery |
 
-`HARNESS.md`'s Status block references the marker. It is owned by
-`/harness-audit` and is corrected by running it, not by hand-editing this PR.
+**The observatory row is enforced.** `commands/observatory-verify.md:16` reads
+the signals reference, and `:42` reports **PARTIAL** when a required field is
+absent. So removing the marker without removing the row degrades every project's
+verification. Removing the row is required, not cosmetic. Archived snapshots
+that carry the field are unaffected — verification reads the reference against
+the *latest* output, not historical ones.
+
+### 4.8 The Status block is corrected in this PR
+
+`HARNESS.md`'s Status block references the marker, and its
+`Garbage collection active:` count changes when the `Template currency` rule is
+removed.
+
+Revision 1 deferred this to "whenever `/harness-audit` next runs", which merges
+a governing document that misstates its own coverage. `/harness-audit` owns the
+block and hand-editing it is worse — so **this PR runs `/harness-audit`** and
+commits its output. That is the third option revision 1 did not consider, and
+this repository's Status block already records the cost of not taking it: "The
+2026-08-13 audit recorded `Drift detected: no` against a tree that already
+carried every failure listed here" (`HARNESS.md:1177`).
 
 ## 5. Acceptance criteria
 
-1. Given a project whose `HARNESS.md` contains every heading in the template,
-   the hook exits 0 and emits nothing — **regardless of plugin version**.
-2. Given a template with a heading the project lacks, the hook emits a message
-   naming that heading.
-3. Given a project whose declined block names that heading, the hook exits 0 and
-   emits nothing.
-4. Given a template heading that appears only inside an HTML comment, it is
-   compared like any other — criteria 1–3 hold for it unchanged.
-5. Given a `HARNESS.md` with no `template-version` marker, no mechanism treats
-   it as `0.0.0` and no mechanism nudges on that basis.
-6. Given a `HARNESS.md` with a `template-version` marker, `/harness-upgrade`
-   removes it and reports having done so.
-7. Heading matching is case-insensitive and whitespace-trimmed in both the hook
-   and the command; a heading differing only in case or surrounding whitespace
-   is not reported as missing.
-8. `/harness-upgrade` presents a previously-declined item under **Previously
-   declined** with its recorded reason, never in the new-items bucket.
-9. The hook never blocks and never exits non-zero.
+### 5.1 `harness-template-diff` — Layer 0 deterministic
 
-Criteria 1–7 and 9 are Layer 0 deterministic tests at
-`tdad_tests/layer0_deterministic/test-template-currency-check.sh`, using
-fixture harnesses under `tdad_tests/layer0_deterministic/fixtures/`. No such
-test exists today; the hook is currently untested.
+Tests at `tdad_tests/layer0_deterministic/test-harness-template-diff.sh`, with
+fixtures under `tdad_tests/layer0_deterministic/fixtures/`.
 
-The *New plugin components must ship with a TDAD scenario* constraint does not
-gate this work — it adds no new `SKILL.md`, `agent.md`, or `command.md`. The
-Layer 0 test is added because the hook is being rewritten, not because a
-constraint demands it.
+1. A project harness containing every non-excluded template heading yields an
+   empty missing set — **regardless of plugin version**.
+2. A template heading absent from the project appears in the missing set.
+3. A heading named in the project's declined block does not appear.
+4. A template heading that appears only inside an HTML comment is treated like
+   any other; criteria 1–3 hold for it unchanged.
+5. A heading tagged `<!-- affordance-example -->` never appears, even when the
+   project lacks it.
+6. A heading matching `^\[.*\]$` never appears.
+7. `###` headings under a project section carrying the "Not yet configured"
+   placeholder never appear.
+8. Matching is trim, whitespace-collapse and casefold on both sides; headings
+   differing only in those respects are not reported.
+9. A malformed declined line is reported with file and line, and its entry is
+   treated as absent — not silently skipped.
+10. A declined reason containing `--` is rejected on write.
+11. Template unreadable → DEGRADED naming the path; exit 0.
+12. Project harness absent → silent; exit 0.
+13. Exit status is 0 on every path.
+
+### 5.2 The real-input assertion
+
+14. Run against this repository's committed `HARNESS.md` and
+    `templates/HARNESS.md`, the missing set is **empty** once §4.2's template fix
+    and the `Consistent formatting` declined entry are in place.
+
+This criterion exists because revision 1 never ran its own algorithm; §3.4
+records what happened when it finally was. It is a Layer 0 test against the real
+files, not fixtures, so template edits that reintroduce a false positive fail CI.
+
+15. No heading line in `templates/HARNESS.md` carries a trailing parenthetical
+    (§4.2).
+
+### 5.3 `/harness-upgrade` — behavioural
+
+Not Layer 0; these are model-executed and belong in a behavioural scenario, not
+in the hook's test file. Revision 1 assigned them to the hook's file in error.
+
+16. Given a `HARNESS.md` with a `template-version` marker, the command removes it
+    and reports having done so.
+17. A previously-declined item is presented under **Previously declined** with
+    its recorded reason, never in the new-items bucket.
+18. **Round trip:** declining an item through the command produces a block that
+    `harness-template-diff` reads back as declined, and the hook then emits
+    nothing. This is the write path revision 1 left untested, and given §3.5 it
+    is where the design is most likely to fail.
+
+The *New plugin components must ship with a TDAD scenario* constraint does gate
+`harness-template-diff.sh` only if it ships as a new skill, agent or command; a
+script is none of those, so the constraint does not apply. The tests are added
+because the behaviour is new, not because a constraint demands them.
 
 ## 6. Rejected alternatives
 
-**Compare the template's own content marker.** It is unmaintained — `d867c7c`
-changed the template without moving it — and nothing reads it. This substitutes
-one unreliable signal for another.
+**Compare the template's own content marker.** Unmaintained — `d867c7c` changed
+the template without moving it — and nothing reads it. Substitutes one unreliable
+signal for another.
 
 **Hash the template and store the hash.** Measures content correctly, but
 reintroduces per-project state that drifts, which is the class of defect being
-removed. Heading comparison needs no state.
+removed.
 
-**Full-text diff instead of heading sets.** Every wording change in the template
-would nudge. The property worth surfacing is a *missing item*, not a reworded
-one; §3 keeps the mechanism aligned with what the message claims.
+**Full-text diff instead of heading sets.** Every wording change would nudge.
+The property worth surfacing is a *missing item*, not a reworded one.
 
-**Record declines in a separate file.** A seventh durable governance artifact,
-in a repository where two committed dashboards went 106 days unread. The
-declined block sits in the file it describes and is read by the two mechanisms
-that need it.
+**Record declines in a separate file.** A new durable governance artefact in a
+repository where two committed dashboards went 106 days unread. The declined
+block sits in the file it describes.
+
+**Normalise trailing parentheticals in the parser** rather than fixing the
+template (§4.2). Rejected: it would also collapse the two `(LOCAL — per-machine
+only)` headings, whose parentheticals are meaningful, and it hides a template
+defect inside a matcher.
+
+**Delete the nudge entirely, keeping `/harness-upgrade` on demand.** Still live,
+and strengthened by §1.1 removing the evidence that favoured keeping it. §3.3
+retains it on judgement and says so; a reviewer who weighs the absence of any
+recorded successful nudge more heavily should take this option, which deletes
+the hook, the shared script, the declined block and §5.1 entirely.
 
 ## 7. Version
 
@@ -266,7 +474,28 @@ five CI-checked locations plus the README plugin-table row.
 
 ## 8. Docs
 
-Same PR, per the docs-site convention:
-`how-to/update-the-plugin.md:16,97`; `how-to/upgrade-your-harness.md:23`;
-`reference/commands.md:128`; `reference/hooks.md:282`;
-`reference/harness-md-format.md:19,41`; `README.md:74,486`.
+Same PR, per the docs-site convention. Revision 1 missed the last two:
+
+`README.md:74,486`; `how-to/update-the-plugin.md:16,97`;
+`how-to/upgrade-your-harness.md:23`; `reference/commands.md:128`;
+`reference/hooks.md:282`; `reference/harness-md-format.md:19,41`;
+`docs/contributing/index.md:195`;
+`docs/plugins/ai-literacy-superpowers/how-to/sync-harness.md` (six references,
+including a drift-table row and a "Template drift" remediation section).
+
+## 9. Objections addressed
+
+| ID | Severity | Where |
+| --- | --- | --- |
+| O1 | critical | §3.4, §4.1 — affordance-example and placeholder exclusions; unconfigured-section skip |
+| O2 | high | §4.2 template fix; §5.2 criterion 14 asserts the real missing set is empty |
+| O3 | high | §3.5 — strict grammar, `::` separator, no continuations, `--` rejected, malformed reported not skipped |
+| O4 | high | §4.7 — `harness-sync.md` added; §8 — `contributing/index.md`, `sync-harness.md` added |
+| O5 | medium | §1.1 withdraws the claim; §3.3 states the nudge is kept on judgement; §6 keeps deletion live |
+| O6 | high | §4.1 — one implementation, `harness-template-diff`, invoked by both |
+| O7 | high | §4.1, §4.3 — degraded path names the unreadable input; §5.1 criteria 11–13 |
+| O8 | medium | §4.4 — skip semantics stated; no time-box added, with reasons |
+| O9 | medium | §5.1/§5.3 split; §5.3 criterion 18 tests the write path round trip |
+| O10 | medium | §3 restructured around the filtered item set |
+| O11 | medium | §4.6 names the authoritative copy and the local coupling; §1.1 stops attributing the Stakeholders case |
+| O12 | medium | §4.8 runs `/harness-audit` in this PR; §4.7 confirms the observatory row is enforced |

--- a/docs/superpowers/specs/2026-08-25-template-currency-measure-content-design.md
+++ b/docs/superpowers/specs/2026-08-25-template-currency-measure-content-design.md
@@ -1,26 +1,24 @@
 # Retire the template-currency nudge — design
 
-**Status:** proposed (revision 3)
+**Status:** proposed (revision 4)
 **Date:** 2026-08-25
 **Issue:** #601
 **Provenance:** `docs/superpowers/specs/2026-04-15-harness-upgrade-design.md`
 introduced the `template-version` marker, the `Template currency` GC rule and
 the SessionStart nudge. This spec retires all three.
 **Revision history:** Revision 1 replaced the version comparison with a heading
-comparison. Revision 2 filtered the compared set. Both were reviewed
-adversarially; the second review returned one critical and eight high
-objections, and its premise objection (O1) observed that the design had grown a
-script, a `PATH` shim, a grammar in the governing document, a fourth command
-disposition, eighteen acceptance criteria and a twelve-file migration in
-support of a mechanism with no recorded successes. Revision 3 takes the option
-both prior revisions listed as live and neither took. §9 records what this
-resolves and what it abandons.
+comparison; revision 2 filtered the compared set; revision 3 deleted the
+mechanism instead. Each was reviewed adversarially. Revision 4 implements the
+dispositions written against revision 3's objection record
+(`docs/superpowers/objections/template-currency-measure-content-design.md`, all
+twelve disposed: 7 accepted, 4 rejected, 1 amend). §9 maps each.
 **Scope:** deletion of the marker, the `Template currency` GC rule, the
 SessionStart hook and the dismissal file, across the plugin, this repository,
-and — by migration — consuming projects. `/harness-upgrade` survives as an
-on-demand command with its version gate removed.
+and — by prompted migration — consuming projects. `/harness-upgrade` survives as
+an on-demand command with its version gate removed.
 **Out of scope:** the declined-item record (§8); `/harness-upgrade`'s adoption
-mechanics beyond step 1 and step 6; the harness evolution loop.
+mechanics beyond step 1 and step 6; the harness evolution loop; the
+`reference/hooks.md:287` documentation defect (§3.3).
 
 ## 1. Problem statement
 
@@ -45,29 +43,30 @@ that cannot establish it, and the false signal reached the governing document:
 `HARNESS.md`'s Status block records "eight minors of unreviewed template
 content" against a template that had not changed.
 
-Five of the last six marker advances adopted nothing. `58d3dda` (2026-07-22)
-and `89b46f9` (2026-08-13) each record "found nothing to adopt", both naming the
-same item — the generic `Consistent formatting` placeholder, declined because
-this repository specialised it into a deterministic markdownlint rule. The
-2026-08-25 run reached the same conclusion about the same item a third time.
+### 1.1 What the run history does and does not show
 
-### 1.1 What the `## Stakeholders` case does not establish
+The hook fires whenever the marker differs from the plugin version
+(`hooks/scripts/template-currency-check.sh:42-45`). Across six recorded marker
+advances it fired six times; five found nothing to adopt (`58d3dda`, `89b46f9`,
+and CHANGELOG entries at `0.35.1`, `0.38.0`, `0.40.0`). Those five were false
+alarms, not correct silence — in each, the template had not changed and the
+hook said it had.
 
-`d867c7c` added a commented-out `## Stakeholders` section to the template on
-2026-08-13 at 09:11. `89b46f9` ran six hours later, reported "byte-identical …
-nothing to adopt", and stamped the marker forward. The block was not adopted
-until twelve days later, by a human who noticed it another way.
+The sixth is `a81c552`, which adopted the commented-out `## Stakeholders`
+section. `d867c7c` added that section to the template on 2026-08-13 at 09:11;
+`89b46f9` ran six hours later, reported "byte-identical … nothing to adopt", and
+stamped the marker forward. The block was not adopted until twelve days later,
+by a human who noticed it another way. There are at least three candidate causes
+— a parsing miss, a cache that had not yet synced, or the section being seen and
+skipped — and the `0.73.2` plugin cache is no longer on the machine that ran it,
+so this cannot be settled.
 
-Revisions 1 and 2 leaned on this as evidence that the expensive failure is *not
-being told*. There are at least three candidate causes and this spec attributes
-none: a genuine parsing miss; a cache that had not yet synced, so `89b46f9`
-compared against a copy predating `d867c7c`; or the section being seen and
-skipped. The `0.73.2` plugin cache is no longer on the machine that ran it, so
-this cannot be settled.
-
-**There is therefore no recorded instance of this nudge producing a useful
-adoption.** Six runs are recorded; five adopted nothing and the sixth cannot be
-attributed.
+**What this history establishes, and what it does not.** It establishes that
+*this* notifier was wrong five times out of six. It does not establish that
+notification is worthless, because a correct notifier has never existed here: in
+the five windows where the template was unchanged, a correct mechanism would
+have been silent and produced no evidence either way. §2 therefore does not rest
+on "it never worked".
 
 ## 2. Decision — delete the nudge
 
@@ -77,46 +76,66 @@ dismissal file are removed. Nothing replaces them.
 `/harness-upgrade` survives, unchanged except for losing its version gate. It
 already performs a real structural comparison in steps 2–3; that comparison was
 never the broken part. `README.md:99` already directs people to run it after
-upgrading the plugin, which becomes the whole of the discovery story.
+upgrading the plugin.
 
 ### 2.1 Why deletion rather than a better comparison
 
-Revisions 1 and 2 tried to keep a nudge and measure the right property. Each
-attempt grew:
+The case is cost and escalating complexity, not absence of value.
 
-| | Revision 1 | Revision 2 | Revision 3 |
+| | Revision 1 | Revision 2 | Revision 3+ |
 | --- | --- | --- | --- |
 | New script + `PATH` shim | — | yes | — |
 | New grammar in `HARNESS.md` | yes | yes (stricter) | — |
 | New `/harness-upgrade` disposition | yes | yes | — |
-| Acceptance criteria | 9 | 18 | 6 |
-| Adversarial review | 1 critical, 5 high | 1 critical, 8 high | — |
+| Acceptance criteria | 9 | 18 | 8 |
+| Adversarial review | 1 critical, 5 high | 1 critical, 8 high | 2 critical, 8 high |
 
-The second review's critical objection was that revision 2's filter still fired
-on a default install, because the template's two OPTIONAL blocks
-(`templates/HARNESS.md:39`, `:630`) are shipped commented out and the rule
-included commented headings by design. Its high objections included an exclusion
-predicate that matched nothing — the `<!-- affordance-example -->` tag sits on
-the line *below* each heading (`:519`/`:520`), verified by
-`grep '^###.*affordance-example'` returning zero matches — and an acceptance
-criterion incapable of detecting that, because it ran against this repository,
-which already contains every heading the exclusions were meant to suppress.
+Revision 2's critical objection was that its filter still fired on a default
+install, because the template's two OPTIONAL blocks (`templates/HARNESS.md:39`,
+`:630`) ship commented out and the rule included commented headings by design.
+Its high objections included an exclusion predicate that matched nothing — the
+`<!-- affordance-example -->` tag sits on the line *below* each heading
+(`:519`/`:520`), verified by `grep '^###.*affordance-example'` returning zero
+matches — and an acceptance criterion structurally incapable of detecting that,
+because it ran against this repository, which already contains every heading the
+exclusions were meant to suppress.
 
-The pattern is that each revision defended a mechanism the evidence does not
-support, and paid for the defence in mechanism. §1.1 removed the last evidence
-in its favour.
+Two revisions spent increasing mechanism defending a notifier, and each returned
+a critical. That is the argument. A correct notifier remains buildable and
+§7 records how.
 
 ### 2.2 What is lost, stated plainly
 
-A project that upgrades the plugin will no longer be told, unprompted, that the
-template gained content. They learn it by running `/harness-upgrade`, which the
-README already tells them to do after an upgrade.
+Four capabilities go, not one:
 
-This is a real reduction in discoverability, and it is accepted on the grounds
-that the mechanism being removed has never demonstrably provided it. If a future
-adopter reports missing template content they would have wanted to know about,
-that is evidence this decision was wrong and is worth reopening on — §7 keeps
-the alternative recorded rather than dismissed.
+1. **The unprompted notification.** A project that upgrades the plugin will no
+   longer be told, at session start, that the template gained content. They
+   learn it by running `/harness-upgrade`.
+2. **The `/harness-sync` monthly drift row.** `commands/harness-sync.md:118,
+   207, 271, 294` surfaces template drift as a `[manual]` item in the monthly
+   sync ritual. That is a pull the user initiated, not an unprompted claim — but
+   it computes from the same broken proxy, so a `drifted` row there is still a
+   false statement. It goes with the rest.
+3. **The `/harness-audit` drift-engine row.** `skills/harness-audit-engine/SKILL.md:33`.
+4. **The required observatory signal.** `observatory-signals.md:127`, with the
+   count arithmetic in §3.2.
+
+**One consumer is deliberately retained.**
+`skills/ai-literacy-assessment/references/habitat-discovery.md:93,141` reads the
+marker as one signal that a project has a harness at all. It is a *reader*, not
+a writer; it is harmless; and per §5 most consuming projects will keep carrying
+the marker for a long time. Deleting the reader before the data is gone would be
+backwards. It stays, and is removed in a later release once the marker is rare.
+
+**A transitional cost, accepted rather than mitigated.** A project whose marker
+has been removed, opened on a machine with an *older* plugin, gets the old hook
+firing every session: an absent marker reads as `0.0.0`
+(`template-currency-check.sh:32-34`), so versions always differ. Previously
+`/harness-upgrade` could silence it by writing the dismissal file; this version
+stops writing it. Mixed versions across machines and teammates are normal, and
+this is accepted as a cost of the transition rather than carried by keeping a
+file nothing in the new plugin reads. Users on stale plugins have other reasons
+to upgrade.
 
 ## 3. What is deleted
 
@@ -124,51 +143,74 @@ the alternative recorded rather than dismissed.
 | --- | --- |
 | SessionStart hook script | `hooks/scripts/template-currency-check.sh` |
 | Hook registration | `hooks/hooks.json` SessionStart entry |
-| Marker (plugin template) | `templates/HARNESS.md:13` |
-| `Template currency` GC rule (plugin template) | `templates/HARNESS.md:335-342` |
-| Marker (this repository) | `HARNESS.md:13` |
-| `Template currency` GC rule (this repository) | `HARNESS.md:760-769` |
-| Marker write | `commands/harness-init.md:184,211` |
-| Version gate + marker/dismissal write | `commands/harness-upgrade.md:46-47,135-143,152` |
-| Template-drift surface | `commands/harness-sync.md:118,206-207,271,294` |
-| Drift surface row | `skills/harness-audit-engine/SKILL.md:33` |
-| `Template version` signal row | `skills/harness-observability/references/observatory-signals.md:127` |
-| Habitat-discovery signal | `skills/ai-literacy-assessment/references/habitat-discovery.md:93,141` |
+| Marker (plugin template) | `templates/HARNESS.md` |
+| `Template currency` GC rule (plugin template) | `templates/HARNESS.md` |
+| Marker (this repository) | `HARNESS.md` |
+| `Template currency` GC rule (this repository) | `HARNESS.md` |
+| Marker write | `commands/harness-init.md` |
+| Version gate, marker + dismissal write | `commands/harness-upgrade.md` |
+| Template-drift surface | `commands/harness-sync.md` |
+| Drift-engine row | `skills/harness-audit-engine/SKILL.md` |
+| `Template version` signal row | `skills/harness-observability/references/observatory-signals.md` |
+
+Line numbers are deliberately omitted: several cited in revisions 1–3 had already
+drifted by one or two lines, and the residue assertion in §6 is what guarantees
+completeness, not the table.
 
 `.claude/.harness-upgrade-dismissed` is no longer written or read. The
 `.gitignore` entry stays — the file exists on machines that ran the old command,
 and removing the ignore would surface it as untracked.
 
-### 3.1 The observatory signal count
+### 3.1 Prose that describes the mechanism without naming it
 
-`observatory-signals.md:127` is a **required** signal, and
-`commands/observatory-verify.md:42` reports **PARTIAL** when a required field is
-absent — so the row must go, not merely be marked optional.
+A term search does not find these, which is why §6 needs a second assertion.
+`docs/plugins/ai-literacy-superpowers/tutorials/first-time-tour.md:564` tells a
+new user "SessionStart hook will prompt you the first time a new version is…",
+and `.../explanation/the-harness-lifecycle.md:88` says "When the plugin has
+shipped new template content, `/harness-upgrade`…". Neither matches
+`template-version`, `template currency` or `template drift`. Both describe
+behaviour that will not exist.
 
-The total is hard-coded in three places and must move 82 → 81:
+### 3.2 Counts that must move
 
-- `skills/harness-observability/references/observatory-signals.md:157`
-- `commands/observatory-verify.md:3` (frontmatter description)
-- `commands/observatory-verify.md:17`
+**Observatory signals: 82 → 81.** `observatory-signals.md:127` is a **required**
+signal and `commands/observatory-verify.md:42` reports **PARTIAL** when a
+required field is absent, so the row must go rather than be marked optional. The
+total is hard-coded at `observatory-signals.md:157`, `observatory-verify.md:3`
+(frontmatter description), `observatory-verify.md:17`, and in the results-table
+template at `observatory-verify.md:89`.
 
-`observatory-verify.md:89` carries `**82**` in a results-table template and moves
-with them. Archived snapshots that carry the field are unaffected: verification
-reads the reference against the latest output, not historical ones.
+**Hooks: 18 → 17, SessionStart 4 → 3.** Verified by parsing `hooks/hooks.json`:
+PreToolUse 1, PostToolUse 2, Stop 11, SessionStart 4. `hooks.json`'s own
+description field also names the template currency check.
+`tdad_tests/layer0_deterministic/test-hooks-doc-parity.sh:19` records what
+happened the last time this count went stale ("hooks.json declares 18; the page
+documented 16"), so the parity test will fail if `reference/hooks.md` is not
+updated with it.
+
+### 3.3 A documentation defect that is not this spec's to fix
+
+`docs/plugins/ai-literacy-superpowers/reference/hooks.md:287` states the hook
+"Exits silently if `HARNESS.md` does not exist **or the marker is absent**." The
+second clause is false today: `template-currency-check.sh:32-34` treats an absent
+marker as `0.0.0` and nudges. This predates the spec and is noted so it is not
+silently absorbed into a change that deletes the page section anyway. It should
+be tracked as its own defect.
 
 ## 4. What survives
 
 `/harness-upgrade` keeps its three-bucket comparison — **new**, **updated** and
-**removed** items (`commands/harness-upgrade.md:74-88`). Revision 2 proposed
-replacing that parse with a missing-set-only script and would have silently
-dropped two buckets; this revision touches neither the parse nor the buckets.
+**removed** items (`commands/harness-upgrade.md:74-88`). Revision 2 would have
+replaced that parse with a missing-set-only script and silently dropped two
+buckets; this revision touches neither the parse nor the buckets.
 
 Changes are confined to two steps:
 
 - **Step 1** drops the version comparison and the "versions match → skip to step
   6" short-circuit. Prerequisites keep the HARNESS.md existence check and the
   `git fetch origin main` staleness guard.
-- **Step 6** stops writing the marker and the dismissal file, and instead
-  performs the migration in §5.
+- **Step 6** stops writing the marker and the dismissal file, and instead offers
+  the migration in §5.
 
 ## 5. Migration for consuming projects
 
@@ -176,25 +218,66 @@ The plugin's template stops shipping the marker and the GC rule. That does not
 reach a project whose `HARNESS.md` already has both — its file is its own.
 
 Left alone, such a project keeps a GC rule declared **deterministic** whose tool
-compares a marker that no longer exists. Under the semantics being deleted, an
-absent marker reads as `0.0.0` (`hooks/scripts/template-currency-check.sh:32-34`),
-so the rule reports drift on every run, permanently, with no way to clear it.
-That would export the defect this spec removes to the entire install base.
+compares a marker that no longer exists. An absent marker reads as `0.0.0`
+(`template-currency-check.sh:32-34`), so the rule reports drift on every run,
+permanently, with no way to clear it.
 
-So `/harness-upgrade` step 6 becomes a migration step. On any run, if the
-project's `HARNESS.md` contains:
+So `/harness-upgrade` step 6 offers a migration. On any run it looks for:
 
-- a `<!-- template-version: … -->` marker, it is removed;
+- a `<!-- template-version: … -->` marker;
 - a `### Template currency` GC rule whose **Tool** field references the
-  template-version comment, it is removed;
+  template-version comment.
 
-and step 7 reports each removal by name. Both removals are idempotent and are
-no-ops on a project that has neither.
+**Each finding is presented for the user to accept or skip**, in the same
+per-item form step 4 uses for every other change (`commands/harness-upgrade.md:104`,
+"Ask the user to choose for each item"). Nothing is removed from a project's
+`HARNESS.md` without a recorded decision. A project may have specialised that
+rule — which is exactly what this repository did with `Consistent formatting` —
+and silently deleting someone's work during a command they ran for an unrelated
+reason is not a thing this command does.
 
-A project that never runs `/harness-upgrade` again keeps an orphaned rule. That
-is not fully solvable from here — the plugin cannot edit a file it is not
-invited into — and it is the reason step 6 does the work on *every* run rather
-than only when something is adopted.
+### 5.1 Near misses are reported, never guessed
+
+If a `### Template currency` heading is present but its **Tool** field does not
+reference the template-version comment, it is **reported and left alone**. The
+same applies to a marker in an unexpected form.
+
+Step 7 distinguishes three outcomes explicitly:
+
+- *removed* — the user accepted a finding
+- *found, not removed* — the user skipped it, or it was a near miss
+- *not found* — the file was read and contained neither
+
+"Nothing reported" must never be able to mean "the file could not be parsed".
+This follows the decision record in force until 2026-11-23: a mechanism that
+could not determine the answer reports that, and does not return the reassuring
+value.
+
+### 5.2 Reach, and the projects this does not touch
+
+The migration only fires when a project runs `/harness-upgrade`. A project that
+never runs it again keeps an orphaned rule.
+
+This is the maximum reach available: the plugin cannot edit files in projects it
+is not invited into, and performing the check on *every* run rather than only on
+adoption is what makes the reach as wide as it can be.
+
+Migrated projects' Status blocks will report one more active GC rule than they
+have. That is `/harness-audit`'s tracked drift surface
+(`skills/harness-audit-engine/SKILL.md:32`) and its normal cadence will catch it;
+this command does not take on keeping every consuming project's Status block
+current.
+
+### 5.3 This migration is one-way
+
+Stated rather than left implied:
+
+- Reverting the plugin does not restore what step 6 removed from files the
+  plugin does not own.
+- There is no rollback path from the plugin side.
+- Reopening on §7's alternative would cost a **second** migration — reintroducing
+  the marker to the template and re-populating it across projects, through the
+  same partially-reaching channel — not merely re-reading a recorded design.
 
 ## 6. Acceptance criteria
 
@@ -203,28 +286,50 @@ than only when something is adopted.
 2. Neither `templates/HARNESS.md` nor this repository's `HARNESS.md` contains a
    `template-version` marker or a `Template currency` GC rule.
 3. `/harness-upgrade` run against a project harness containing a
-   `template-version` marker removes it and names it in the report.
-4. `/harness-upgrade` run against a project harness containing a
-   `Template currency` GC rule whose Tool references the template-version
-   comment removes it and names it in the report.
-5. Both removals are idempotent: a second run reports nothing further and
-   changes nothing.
-6. **Residue assertion.** A repository-wide search for `template-version`,
-   `Template currency`, `template-currency` and `harness-upgrade-dismissed`
-   returns matches only in: `CHANGELOG.md`, `REFLECTION_LOG.md`, `reflections/`,
+   `template-version` marker **presents it for accept/skip** and removes it only
+   on accept.
+4. Same for a `### Template currency` GC rule whose Tool field references the
+   template-version comment.
+5. A near miss — a `### Template currency` heading whose Tool field does not
+   match — is reported and not removed, on accept or skip.
+6. Step 7's report distinguishes *removed*, *found but not removed*, and *not
+   found*.
+7. Both removals are idempotent: a second run finds nothing further.
+8. **Residue assertion**, in two parts:
+
+   **8a — terms.** A **case-insensitive** repository-wide search for
+   `template-version`, `template currency`, `template-currency`,
+   `template drift`, `template version drift` and `harness-upgrade-dismissed`
+   returns matches only in the allow-list below.
+
+   **8b — description.** No file outside the allow-list describes the SessionStart
+   template-currency behaviour in prose. Seeded from a search for `harness-upgrade`
+   co-occurring with `SessionStart` or "new template content", because §3.1
+   demonstrates that prose describing the mechanism need not contain any of 8a's
+   terms.
+
+   **Allow-list:** `CHANGELOG.md`, `REFLECTION_LOG.md`, `reflections/`,
    `assessments/`, `harness/assay/`, `docs/superpowers/{specs,plans,objections}/`,
-   `observability/snapshots/`, and the `.gitignore` line.
+   `observability/snapshots/`, `harness/decisions/`, the `.gitignore` line, and —
+   **exempted by construction, with the reason stated** — `commands/harness-upgrade.md`
+   (which must name the marker and the rule in order to offer their removal) and
+   the test file itself (whose filename and search patterns necessarily contain
+   the terms). `habitat-discovery.md` is exempt per §2.2 until the marker is rare.
 
-Criteria 1, 2 and 6 are Layer 0 deterministic tests at
+   The two exemptions are named individually and deliberately. An implementer
+   must not widen the allow-list further to make the test pass; if a new file
+   legitimately needs an exemption, that is a spec change.
+
+Criteria 1, 2 and 8 are Layer 0 deterministic tests at
 `tdad_tests/layer0_deterministic/test-template-currency-retired.sh`. Criteria
-3–5 are behavioural — they are model-executed command behaviour and do not
-belong in a Layer 0 file.
+3–7 are behavioural — model-executed command behaviour, which does not belong in
+a Layer 0 file.
 
-**Criterion 6 exists because hand enumeration failed twice.** Revision 1's
-surfaces table listed seven files and was presented as complete; revision 2's
-listed twelve and was presented as complete. A `grep` across the tree at the
-time of writing returns **nineteen**. The assertion is cheaper than the table
-and does not depend on the author having remembered everything.
+**Criterion 8 exists because hand enumeration failed three times.** Revision 1's
+table listed seven files; revision 2's twelve; revision 3's nineteen. The
+broadened case-insensitive search returns **twenty-two**, and §3.1 shows two more
+that no term search reaches. The assertion is what guarantees completeness; the
+§3 table is a reader's aid.
 
 The *New plugin components must ship with a TDAD scenario* constraint does not
 gate this work: it names new `SKILL.md`, `agent.md` and `command.md` files, and
@@ -234,30 +339,34 @@ this change adds none.
 
 **Compare heading sets (revision 1).** Fires on a default install: the template
 ships four `<!-- affordance-example -->` headings, a `### [Governance constraint
-name]` placeholder, and two commented OPTIONAL sections that a default project
+name]` placeholder, and two commented OPTIONAL sections a default project
 correctly lacks.
 
-**Filter the compared set (revision 2).** Reduces but does not remove that,
-because the OPTIONAL blocks are `##` sections and the unconfigured-section skip
-cannot reach them; and it buys the reduction with a script, a shim, a grammar
-and a new disposition.
+**Filter the compared set (revision 2).** Reduces but does not remove that — the
+OPTIONAL blocks are `##` sections, which the unconfigured-section skip cannot
+reach — and buys the reduction with a script, a shim, a grammar and a new
+disposition.
 
 **Fix the template's own content marker and read that.** The strongest surviving
-alternative, raised as O7 against revision 2: add a CI assertion that any diff
-touching `templates/HARNESS.md` also moves its `<!-- template-version -->`, and
-have the hook compare that marker rather than `plugin.json`. It measures the
-right property, costs one CI check, and needs no new mechanism.
+alternative: add a CI assertion that any diff touching `templates/HARNESS.md`
+also moves its `<!-- template-version -->`, and have the hook compare that marker
+rather than `plugin.json`. It measures the right property and costs one CI check.
 
-Rejected on §1.1 rather than on cost: it is a cheap way to build a correct
-version of a mechanism with no recorded successes, and the question this spec
-answers is whether to have the mechanism at all. **If the answer to §2.2 turns
-out to be wrong, this is the option to reopen on** — it is recorded here in
-enough detail to be taken up without re-deriving it.
+Rejected on §2.1's cost argument rather than on §1.1: it is a cheap way to build
+a correct version of a mechanism whose value is unevidenced in either direction.
+**If §2.2's losses prove to matter, this is the option to reopen on** — though
+per §5.3, doing so costs a second migration, not merely re-reading this section.
+
+**Delete only the SessionStart hook, keeping the pull-direction surfaces.**
+Considered: the demonstrated harm is specific to the hook, and `/harness-sync`'s
+row is a pull the user initiated at a monthly cadence. Rejected because a
+`drifted` row computed from a broken proxy is still a false statement wherever it
+appears, and leaving one surface reading a marker the rest of the system no
+longer maintains recreates the orphan problem §5 exists to solve.
 
 **Keep the marker but make its absence an opt-out (issue #601 as filed).**
-Leaves the version-as-proxy flaw intact for every project that keeps its marker,
-and silences the nudge for projects that never had one — the population most
-likely to need it.
+Leaves the version-as-proxy flaw intact for projects that keep their marker, and
+silences the nudge for projects that never had one.
 
 ## 8. Out of scope: the declined-item record
 
@@ -267,28 +376,27 @@ into commit messages — would stop being re-presented.
 
 That problem is real and survives this spec. It is out of scope because deleting
 the nudge shrinks it from *every session* to *every deliberate `/harness-upgrade`
-run*, which is a different order of nuisance, and because the record's grammar
-was the source of two objections in the last review. It is worth revisiting on
-its own terms rather than as a dependency of a mechanism being deleted.
+run*, and because the record's grammar generated two objections in the last
+review. It is worth revisiting on its own terms.
 
-## 9. Objections resolved and abandoned
+## 9. Dispositions implemented
 
-Against the revision-2 review (record preserved at commit `6da8b77`):
+Against `docs/superpowers/objections/template-currency-measure-content-design.md`:
 
-| ID | Severity | Outcome |
+| ID | Disposition | Where |
 | --- | --- | --- |
-| O1 | high | **Resolved** — §2.1 takes the deletion option and prices the alternatives in like terms |
-| O2 | critical | **Dissolved** — no comparison, no filter, no OPTIONAL-block false positive |
-| O3 | high | **Dissolved** — no exclusion predicate |
-| O4 | high | **Resolved differently** — §6 criterion 6 asserts residue by grep rather than validating an algorithm against one favourable input |
-| O5 | high | **Resolved** — §4 leaves the three-bucket parse untouched |
-| O6 | high | **Resolved** — §5 migrates consuming projects' orphaned GC rule |
-| O7 | high | **Recorded, not taken** — §7 keeps it as the reopening path if §2.2 proves wrong |
-| O8 | high | **Dissolved** — no SessionStart hook, so no re-fire on resume/clear/compact |
-| O9 | high | **Resolved** — §6 criterion 6; §3's table is grep-derived, and the grep is the test |
-| O10 | medium | **Dissolved** — no comparison, so no project-side comment rule to define |
-| O11 | medium | **Dissolved** — no script, no `--` grammar |
-| O12 | medium | **Dissolved** — no hook, so no silent-failure path to specify |
+| O1 | accepted | §1.1 rewritten — the five were false alarms, not true negatives, and §2.1 now rests the case on cost rather than "never worked" |
+| O2 | accepted | §6 criterion 8a — terms broadened, search made case-insensitive |
+| O3 | accepted | §6 — `harness-upgrade.md` and the test file exempted by name, with the reason and a prohibition on widening further |
+| O4 | accepted | §5 — every finding presented for accept/skip; nothing removed without a recorded decision |
+| O5 | rejected | §5.2 — Status-block accuracy stays `/harness-audit`'s surface and cadence |
+| O6 | rejected | §5.2 — every-run checking is the maximum reach available |
+| O7 | amend | §2.2 — all four losses stated; `habitat-discovery.md` retained as a reader |
+| O8 | rejected | §7 — recorded as considered and rejected, with the reason |
+| O9 | accepted | §5.3 — the one-way property and the true cost of reopening |
+| O10 | rejected | §2.2 — mixed-version cost stated and accepted; §3.3 tracks the docs defect separately |
+| O11 | accepted | §5.1 — near misses reported, three outcomes distinguished |
+| O12 | accepted | §3 regenerated from the broadened grep with line numbers dropped; §3.1 adds the prose surfaces; §3.2 adds the hook arithmetic |
 
 ## 10. The Status block
 
@@ -296,11 +404,10 @@ Removing the `Template currency` GC rule changes the
 `Garbage collection active:` count in `HARNESS.md`'s Status block, which is
 owned by `/harness-audit` and must not be hand-edited.
 
-**This PR runs `/harness-audit`** and commits its output, rather than merging a
-governing document that misstates its own coverage. This repository's Status
-block already records the cost of not doing that: "The 2026-08-13 audit recorded
-`Drift detected: no` against a tree that already carried every failure listed
-here" (`HARNESS.md:1177`).
+**This PR runs `/harness-audit`** and commits its output. This repository's
+Status block already records the cost of not doing that: "The 2026-08-13 audit
+recorded `Drift detected: no` against a tree that already carried every failure
+listed here" (`HARNESS.md:1177`).
 
 ## 11. Version
 
@@ -309,11 +416,16 @@ five CI-checked locations plus the README plugin-table row.
 
 ## 12. Docs
 
-Same PR. Derived from the grep in §6, not by hand:
+Same PR. Derived from criterion 8's two searches, not by hand:
 
-`README.md:74,77,486`; `docs/contributing/index.md:195`;
-`docs/plugins/ai-literacy-superpowers/reference/hooks.md:277,282`;
-`.../reference/commands.md:128,133`; `.../reference/harness-md-format.md:19,41`;
-`.../how-to/update-the-plugin.md:16,97`; `.../how-to/upgrade-your-harness.md:23`;
-`.../how-to/sync-harness.md` (three references, including the drift-table row and
-the "Template drift" remediation section).
+**Term matches:** `README.md`, `docs/contributing/index.md`, `CLAUDE.md`,
+`ai-literacy-superpowers/templates/CLAUDE.md`,
+`docs/plugins/ai-literacy-superpowers/reference/{hooks,commands,harness-md-format,skills}.md`,
+`.../how-to/{update-the-plugin,upgrade-your-harness,sync-harness}.md`.
+
+**Prose matches (§3.1):** `.../tutorials/first-time-tour.md`,
+`.../explanation/the-harness-lifecycle.md`, `.../explanation/harness-md.md`,
+`.../explanation/self-improving-harness.md`, `commands/observatory-verify.md`.
+
+`reference/hooks.md` additionally needs the hook-count update from §3.2, which
+`test-hooks-doc-parity.sh` enforces.

--- a/docs/superpowers/specs/2026-08-25-template-currency-measure-content-design.md
+++ b/docs/superpowers/specs/2026-08-25-template-currency-measure-content-design.md
@@ -1,6 +1,6 @@
 # Retire the template-currency nudge — design
 
-**Status:** proposed (revision 4)
+**Status:** proposed (revision 5)
 **Date:** 2026-08-25
 **Issue:** #601
 **Provenance:** `docs/superpowers/specs/2026-04-15-harness-upgrade-design.md`
@@ -11,7 +11,10 @@ comparison; revision 2 filtered the compared set; revision 3 deleted the
 mechanism instead. Each was reviewed adversarially. Revision 4 implements the
 dispositions written against revision 3's objection record
 (`docs/superpowers/objections/template-currency-measure-content-design.md`, all
-twelve disposed: 7 accepted, 4 rejected, 1 amend). §9 maps each.
+twelve disposed: 7 accepted, 4 rejected, 1 amend). Revision 5 implements the
+choice-story dispositions at
+`docs/superpowers/stories/template-currency-measure-content-design.md` (eight
+stories: 7 accepted, 1 promoted to #606). §9 maps both sets.
 **Scope:** deletion of the marker, the `Template currency` GC rule, the
 SessionStart hook and the dismissal file, across the plugin, this repository,
 and — by prompted migration — consuming projects. `/harness-upgrade` survives as
@@ -101,8 +104,43 @@ because it ran against this repository, which already contains every heading the
 exclusions were meant to suppress.
 
 Two revisions spent increasing mechanism defending a notifier, and each returned
-a critical. That is the argument. A correct notifier remains buildable and
-§7 records how.
+a critical.
+
+**That table is not the load-bearing argument, and revision 4 wrongly made it
+one.** Acceptance-criteria counts and objection counts measure specs and review
+sessions, not the mechanism — the same substitution §1 objects to, one level up.
+They are also mis-attributed: revisions 1 and 2 were *heading-comparison*
+designs, and §7's surviving alternative shares none of their mechanism, so their
+review outcomes are not evidence about it.
+
+**The argument that does bear weight is §2.3.** The cost table stands only as
+what it is: a record that two attempts to keep this notifier grew, which is
+context rather than justification.
+
+### 2.3 The alarm has no defined operator action
+
+Safety engineering has a settled test for retiring a nuisance annunciator, and
+it is the right one here: removal is legitimate when the alarm has **no defined
+operator action** distinct from what the operator would do anyway. The nudge's
+only response was running `/harness-upgrade`, which `README.md:99` already
+directs people to do after every plugin upgrade. The alarm asked for nothing that
+was not already asked for.
+
+That test is also the correct citation for the decision under the record in force
+until 2026-11-23,
+`HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one`.
+Revision 4 cited that record only for §4.3's report format, leaving the larger
+decision uncited. The record's remedy vocabulary is *report unknown and name the
+input you could not read*; deletion also satisfies it, and this is the
+repository's first instance of that move.
+
+**Deletion is the cheapest compliance move that record will ever admit** —
+vacuously satisfying, needing no unknown-state design and no approver's cost
+statement. It is correct here because the no-operator-action test is met. It
+should not be reached for where that test fails, and the fence is stated here
+rather than left to the next reader to infer.
+
+A correct notifier remains buildable and §7 records how, priced.
 
 ### 2.2 What is lost, stated plainly
 
@@ -125,7 +163,31 @@ Four capabilities go, not one:
 marker as one signal that a project has a harness at all. It is a *reader*, not
 a writer; it is harmless; and per §5 most consuming projects will keep carrying
 the marker for a long time. Deleting the reader before the data is gone would be
-backwards. It stays, and is removed in a later release once the marker is rare.
+backwards. It stays, and carries a sunset marker so its removal is on a clock
+rather than on memory:
+
+```html
+<!-- redirect-sunset: 2027-02-25 — retained reader for the template-version
+     marker (spec 2026-08-25-template-currency-measure-content-design §2.2).
+     Remove once consuming projects have migrated. -->
+```
+
+`scripts/check-redirect-sunsets.sh` surfaces it monthly under the `Redirect
+sunset` GC rule. This matters because "once the marker is rare" is unmeasurable
+after this change: the surfaces that could have counted markers in the wild are
+the ones being deleted. A date someone must actively renew is the honest
+substitute. The `.gitignore` entry and the marker left in unmigrated projects are
+genuinely inert and carry no clock.
+
+**This decision is permanent, not conditional.** §7 keeps the buildable correct
+notifier on record and §5.3 prices reopening honestly, but nothing that would
+report the reopening condition survives this change: the four surfaces that could
+have shown unadopted template content are the four being deleted. The only user
+positioned to notice is one who runs `/harness-upgrade` regularly — precisely the
+user who loses nothing here. So a future reader must not read silence as evidence
+that nobody minded; the tree will generate no evidence in either direction, which
+is the same reasoning §1.1 applies to the past, applied forward. Reopening will
+come from someone deciding to, not from being told.
 
 **A transitional cost, accepted rather than mitigated.** A project whose marker
 has been removed, opened on a machine with an *older* plugin, gets the old hook
@@ -228,6 +290,16 @@ So `/harness-upgrade` step 6 offers a migration. On any run it looks for:
 - a `### Template currency` GC rule whose **Tool** field references the
   template-version comment.
 
+**The predicate is deliberately narrow and one-shot.** It covers both objects in
+one place even though only the marker strictly needs it — the marker is an HTML
+comment that no existing parse can see, while the GC rule is a `###` block under
+`## Garbage Collection` that step 2 already matches by heading name. Handling the
+rule through the existing **removed** bucket instead would mean promoting that
+bucket from advisory to actionable, which is a larger change to `/harness-upgrade`
+than this migration should carry. The predicate is deleted alongside the
+habitat-discovery reader at the sunset date in §2.2, not kept as a permanent
+special case.
+
 **Each finding is presented for the user to accept or skip**, in the same
 per-item form step 4 uses for every other change (`commands/harness-upgrade.md:104`,
 "Ask the user to choose for each item"). Nothing is removed from a project's
@@ -316,11 +388,32 @@ Stated rather than left implied:
    the test file itself (whose filename and search patterns necessarily contain
    the terms). `habitat-discovery.md` is exempt per §2.2 until the marker is rare.
 
-   The two exemptions are named individually and deliberately. An implementer
-   must not widen the allow-list further to make the test pass; if a new file
-   legitimately needs an exemption, that is a spec change.
+   **The allow-list lives in one place.** It is declared once, in a data file the
+   Layer 0 test reads — `tdad_tests/layer0_deterministic/fixtures/template-currency-residue-allowlist.txt`
+   — rather than as prose here and again as a shell array in the test. Revision 4
+   stated the list in §6 and forbade widening it, which put the prohibition
+   somewhere the test cannot read: a one-line array edit turning CI green would
+   have satisfied the letter and drawn no reviewer's eye. That is an unenforced
+   lint rule, which is the shape this whole spec exists to remove.
 
-Criteria 1, 2 and 8 are Layer 0 deterministic tests at
+   Each entry in that file carries a one-line reason. Adding one is a reviewable
+   diff to a file whose only purpose is exemptions, and remains a spec change in
+   intent — but it is now visible as one.
+
+9. **Count guards.** The four hard-coded observatory totals
+   (`observatory-signals.md:157`, `observatory-verify.md:3`, `:17`, `:89`) equal
+   the number of signal rows in `observatory-signals.md`.
+
+   §3.2 moves this count by hand while citing `test-hooks-doc-parity.sh` as the
+   reason the *hooks* count must move — which means revision 4 read one guard and
+   never asked why the neighbouring count has none
+   (`test_phase2_observatory_verify.py:67` asserts only that there are at least
+   ten snapshot signals). §6's own argument is that hand enumeration in this tree
+   needs a machine behind it; applying that to terms and not to counts, in the
+   same document, is an inconsistency worth closing rather than recording. It is a
+   `grep -c` and a comparison, in a test file this spec already creates.
+
+Criteria 1, 2, 8 and 9 are Layer 0 deterministic tests at
 `tdad_tests/layer0_deterministic/test-template-currency-retired.sh`. Criteria
 3–7 are behavioural — model-executed command behaviour, which does not belong in
 a Layer 0 file.
@@ -352,8 +445,15 @@ alternative: add a CI assertion that any diff touching `templates/HARNESS.md`
 also moves its `<!-- template-version -->`, and have the hook compare that marker
 rather than `plugin.json`. It measures the right property and costs one CI check.
 
-Rejected on §2.1's cost argument rather than on §1.1: it is a cheap way to build
-a correct version of a mechanism whose value is unevidenced in either direction.
+**Priced directly, since §2.1's counts do not bear on it.** Build: one CI
+assertion that a diff touching `templates/HARNESS.md` also moves its marker, plus
+one line changed in the hook to read that marker instead of `plugin.json`.
+Running cost: near zero — a marker discipline maintainers must keep, enforced by
+the assertion. Against that: keeping it means the nudge survives, and §2.3's test
+says an alarm with no defined operator action should not.
+
+Rejected on §2.3 rather than on cost: it is a cheap way to build a correct
+version of an alarm that asks for nothing the README does not already ask for.
 **If §2.2's losses prove to matter, this is the option to reopen on** — though
 per §5.3, doing so costs a second migration, not merely re-reading this section.
 
@@ -397,6 +497,39 @@ Against `docs/superpowers/objections/template-currency-measure-content-design.md
 | O10 | rejected | §2.2 — mixed-version cost stated and accepted; §3.3 tracks the docs defect separately |
 | O11 | accepted | §5.1 — near misses reported, three outcomes distinguished |
 | O12 | accepted | §3 regenerated from the broadened grep with line numbers dropped; §3.1 adds the prose surfaces; §3.2 adds the hook arithmetic |
+
+Against `docs/superpowers/stories/template-currency-measure-content-design.md`:
+
+| ID | Disposition | Where |
+| --- | --- | --- |
+| #1 | promoted | §9.1 records the channel choice; the loop gap is **#606** |
+| #2 | accepted | §5 — the predicate is narrow, one-shot, and deleted at §2.2's sunset date |
+| #3 | accepted | §2.3 — the HDR cited for the deletion, with the no-operator-action test as the defence and the cheap-compliance fence stated |
+| #4 | accepted | §2.1 demoted to context, §2.3 carries the argument, §7 prices the alternative directly |
+| #5 | accepted | §2.2 — the decision is stated as permanent, with no observer for the reopening condition |
+| #6 | accepted | §2.2 — sunset marker on the retained reader, surfaced monthly by the `Redirect sunset` GC rule |
+| #7 | accepted | §6 — the allow-list moves to one data file the test reads |
+| #8 | accepted | §6 criterion 9 — the four observatory totals are guarded |
+
+## 9.1 Retiring a GC rule: the channel, chosen deliberately
+
+This spec retires the `Template currency` GC rule from this repository's own
+`HARNESS.md` through a feature PR, not through
+`/harness-assay → /harness-propose → /harness-accept`.
+
+That is a choice, and it is recorded here so the next person retiring a GC rule
+inherits a decision rather than a precedent. The loop's vocabulary is
+constraints: `commands/harness-propose.md` and `commands/harness-review.md` do
+not mention garbage collection, HDR classifications route to `HARNESS.md`'s
+constraint section, `AGENTS.md` or an agent skill file, and this rule predates
+the loop so there is no record to expire. Every governed retirement path assumes
+the rule entered through a governed door; this one did not.
+
+The consequence is real: `harness/decisions/index.md` and `/harness-timeline`
+will show `Garbage collection active:` moving 19 → 18 with no entry saying why.
+**That gap is #606**, promoted from story #1 of the choice-story record. It is
+not a blocker for this change — it is the finding this change surfaced, and it
+is bigger than this change.
 
 ## 10. The Status block
 

--- a/docs/superpowers/specs/2026-08-25-template-currency-measure-content-design.md
+++ b/docs/superpowers/specs/2026-08-25-template-currency-measure-content-design.md
@@ -1,0 +1,272 @@
+# Template currency measures content — design
+
+**Status:** proposed
+**Date:** 2026-08-25
+**Issue:** #601
+**Provenance:** `docs/superpowers/specs/2026-04-15-harness-upgrade-design.md`,
+which introduced the `template-version` marker and decided that a missing
+marker means "treat as `0.0.0`". This spec retires the marker outright. The
+issue as filed proposed making the marker optional; the approach here is
+broader and is argued for in §3.
+**Scope:** the SessionStart template-currency hook, `/harness-upgrade` step 1
+and step 6, `/harness-init`'s marker write, the `Template currency` GC rule,
+and the declined-item record that makes the new comparison quiet.
+**Out of scope:** `/harness-upgrade`'s adoption mechanics (steps 2–5) beyond
+the parsing fix in §4.4; the harness evolution loop; whether
+`/harness-upgrade` should route adopted items through `/harness-propose`.
+
+## 1. Problem statement
+
+The `template-version` marker claims to track template content. It tracks the
+plugin version, which moves for reasons unrelated to the template.
+
+Verified on 2026-08-25:
+
+- The template shipped at plugin `0.79.0` and the template shipped at `0.89.0`
+  are byte-identical (`diff`, exit 0). The `0.89.0` cache copy is byte-identical
+  to `ai-literacy-superpowers/templates/HARNESS.md`.
+- The last change to `templates/HARNESS.md` is `d867c7c`, 2026-08-13 — twelve
+  days *before* `a81c552` stamped this repository's marker to `0.79.0`.
+- The plugin moved ten minor versions across that window. The template moved
+  zero bytes.
+- The template carries its own content marker, `<!-- template-version: 0.57.0 -->`,
+  last moved 2026-06-17 (`52e114a`). `d867c7c` changed the template's content
+  without moving it. No mechanism reads it.
+
+The consequence is a SessionStart hook that asserts `Plugin template has been
+updated` on evidence that cannot establish it. The false signal reached the
+governing document: `HARNESS.md`'s Status block records "eight minors of
+unreviewed template content" against a template that had not changed.
+
+The failure has two halves, and fixing only one leaves the mechanism broken.
+
+**It cries wolf.** Five of the last six marker advances adopted nothing.
+`58d3dda` (2026-07-22) and `89b46f9` (2026-08-13) each record "found nothing to
+adopt", both naming the same item — the generic `Consistent formatting`
+placeholder, declined because this repository has specialised it into a
+deterministic markdownlint rule. The 2026-08-25 run reached the same conclusion
+about the same item a third time.
+
+**It may also be silent when it matters.** `d867c7c` added a commented-out
+`## Stakeholders` section to the template on 2026-08-13 at 09:11. `89b46f9` ran
+six hours later, reported "byte-identical … nothing to adopt", and stamped the
+marker forward. The block was not adopted until twelve days later, by a human
+who noticed it another way. This cannot be settled now — the `0.73.2` plugin
+cache is no longer on the machine that ran it — but §4.4 addresses the parsing
+asymmetry that makes the "genuinely missed it" reading plausible.
+
+## 2. The property that should be measured
+
+The nudge names one property: *the template contains something your harness
+does not*. The marker measures a different one: *the plugin has been released
+since you last stamped a number*. These come apart on every release that does
+not touch the template, which is nearly all of them.
+
+`/harness-upgrade` already computes the real property. Steps 2–3 parse both
+files into named items and diff them. Step 1's version gate is a pre-filter in
+front of a comparison that does not need it, and the pre-filter is the part
+that is wrong.
+
+## 3. Decision — compare headings, retire the marker
+
+The hook and the command compare **heading sets** between the plugin's
+`templates/HARNESS.md` and the project's `HARNESS.md`. There is no marker, no
+`plugin.json` read, and no stored version state.
+
+### 3.1 Why not the narrower change in #601
+
+The issue proposed keeping the marker as an optional feature and treating its
+absence as opt-out. That silences the false alarm for projects that remove the
+marker and leaves it intact for everyone who keeps it — the version-as-proxy
+flaw survives, and the projects most likely to need a nudge (those that never
+had a marker) go permanently quiet. Opting out of a broken signal is not the
+same as fixing it.
+
+### 3.2 Why not an explicit `none` sentinel
+
+Considered and rejected. A declared opt-out fits this repository's
+declare-don't-infer culture, but it is additional mechanism in service of a
+signal §1 shows is unreliable in both directions. Retiring the signal is
+cheaper than governing it.
+
+### 3.3 Why not delete the nudge entirely
+
+Considered. `/harness-upgrade` survives as an on-demand command either way, and
+the README already directs people to run it after a plugin upgrade. Rejected
+because the `## Stakeholders` case suggests the failure mode that actually costs
+something is *not being told*, and a nudge that measures the right property is
+cheap enough to keep.
+
+### 3.4 The declined-item record is load-bearing
+
+Heading comparison alone reproduces the original defect in a new coat. This
+repository's `HARNESS.md` has `Consistent markdown formatting`; the template has
+`Consistent formatting`. A pure set difference flags it every session, forever —
+an item declined three times on recorded reasoning.
+
+So the disposition must live somewhere the mechanism can read. Today it lives in
+commit messages and CHANGELOG entries, which is why the item keeps coming back.
+
+`HARNESS.md` gains a declined block, in the position the marker occupied:
+
+```html
+<!-- template-declined
+     Consistent formatting: specialised here as "Consistent markdown
+       formatting" (deterministic, markdownlint, commit + pr). Adopting the
+       template's unverified placeholder would be a downgrade.
+-->
+```
+
+One line per declined heading, `Heading: reason`. The hook subtracts these from
+the missing set. `/harness-upgrade` reads them and presents a declined item as
+*previously declined, because …* rather than as new.
+
+The reason text is never parsed. It exists so the next person reads why, and so
+that declining is a considered act rather than a suppression.
+
+## 4. Design
+
+### 4.1 The hook
+
+`hooks/scripts/template-currency-check.sh` becomes:
+
+```text
+tpl      = $CLAUDE_PLUGIN_ROOT/templates/HARNESS.md
+proj     = $CLAUDE_PROJECT_DIR/HARNESS.md
+
+exit 0 if either file is unreadable          (unchanged: advisory, never blocks)
+
+tpl_headings   = headings of tpl             (## and ###, incl. commented)
+proj_headings  = headings of proj
+declined       = headings named in proj's template-declined block
+
+missing = tpl_headings - proj_headings - declined
+
+exit 0 if missing is empty
+emit systemMessage naming the count and up to three headings
+```
+
+Matching is case-insensitive and whitespace-trimmed, identical to
+`/harness-upgrade` step 2, so the hook and the command never disagree about
+what is new.
+
+### 4.2 The message states what it compared
+
+> `Template has 2 item(s) your harness does not: "Stakeholders", "Spec conformance". Run /harness-upgrade to review.`
+
+It names the items it found. A reader can falsify it against their own file
+without running anything — which is the property §1 says was missing.
+
+### 4.3 `/harness-upgrade`
+
+- **Step 1** drops the version comparison. Prerequisites keep the HARNESS.md
+  existence check and the `git fetch origin main` staleness guard.
+- **Step 3** subtracts declined headings from the *new items* bucket and
+  presents them in a separate **Previously declined** group, each with its
+  recorded reason, so a standing decision is visible without being re-litigated.
+- **Step 4** gains a **decline** disposition alongside accept/skip/customise.
+  Declining prompts for a one-line reason and writes it to the declined block.
+  **Skip** remains what it is today: not now, ask again next time.
+- **Step 6** no longer writes a marker or a dismissal file. It removes a
+  `template-version` marker if it finds one (§4.5) and writes any new declined
+  entries.
+- **Step 7** reports declined items alongside accepted and skipped.
+
+### 4.4 Commented-out blocks parse uniformly
+
+Step 2 currently scopes commented-out blocks to constraints and GC rules, and
+describes sections as plain `## Heading` entries. The template's one commented
+section, `<!-- ## Stakeholders`, matches neither clause.
+
+Both the hook and the command extract headings from inside HTML comments at
+every level. This is the parsing half of the `## Stakeholders` case in §1.
+
+### 4.5 Migration
+
+The marker becomes inert on the release that ships this. Nothing reads it, so a
+project that still has one is not broken.
+
+- `/harness-init` stops writing it.
+- `/harness-upgrade` removes it when it next runs, and says so in its report.
+- This repository removes its own in this PR, along with the `Template currency`
+  GC rule.
+- `.claude/.harness-upgrade-dismissed` is no longer written or read. The
+  `.gitignore` entry stays — the file exists on machines that have run the old
+  command, and removing the ignore would surface it as untracked.
+
+### 4.6 Surfaces that declare the marker
+
+| File | Change |
+| --- | --- |
+| `templates/HARNESS.md:13` | Remove the stale `0.57.0` marker |
+| `templates/HARNESS.md:337-342` | Remove the `Template currency` GC rule |
+| `HARNESS.md:13` | Remove the marker |
+| `HARNESS.md:760-769` | Remove the `Template currency` GC rule |
+| `skills/harness-audit-engine/SKILL.md:33` | Remove the `Template currency` surface row |
+| `skills/harness-observability/references/observatory-signals.md:127` | `Template version` is marked **required**; remove the row |
+| `skills/ai-literacy-assessment/references/habitat-discovery.md:93,141` | Drop the marker from habitat discovery |
+
+`HARNESS.md`'s Status block references the marker. It is owned by
+`/harness-audit` and is corrected by running it, not by hand-editing this PR.
+
+## 5. Acceptance criteria
+
+1. Given a project whose `HARNESS.md` contains every heading in the template,
+   the hook exits 0 and emits nothing — **regardless of plugin version**.
+2. Given a template with a heading the project lacks, the hook emits a message
+   naming that heading.
+3. Given a project whose declined block names that heading, the hook exits 0 and
+   emits nothing.
+4. Given a template heading that appears only inside an HTML comment, it is
+   compared like any other — criteria 1–3 hold for it unchanged.
+5. Given a `HARNESS.md` with no `template-version` marker, no mechanism treats
+   it as `0.0.0` and no mechanism nudges on that basis.
+6. Given a `HARNESS.md` with a `template-version` marker, `/harness-upgrade`
+   removes it and reports having done so.
+7. Heading matching is case-insensitive and whitespace-trimmed in both the hook
+   and the command; a heading differing only in case or surrounding whitespace
+   is not reported as missing.
+8. `/harness-upgrade` presents a previously-declined item under **Previously
+   declined** with its recorded reason, never in the new-items bucket.
+9. The hook never blocks and never exits non-zero.
+
+Criteria 1–7 and 9 are Layer 0 deterministic tests at
+`tdad_tests/layer0_deterministic/test-template-currency-check.sh`, using
+fixture harnesses under `tdad_tests/layer0_deterministic/fixtures/`. No such
+test exists today; the hook is currently untested.
+
+The *New plugin components must ship with a TDAD scenario* constraint does not
+gate this work — it adds no new `SKILL.md`, `agent.md`, or `command.md`. The
+Layer 0 test is added because the hook is being rewritten, not because a
+constraint demands it.
+
+## 6. Rejected alternatives
+
+**Compare the template's own content marker.** It is unmaintained — `d867c7c`
+changed the template without moving it — and nothing reads it. This substitutes
+one unreliable signal for another.
+
+**Hash the template and store the hash.** Measures content correctly, but
+reintroduces per-project state that drifts, which is the class of defect being
+removed. Heading comparison needs no state.
+
+**Full-text diff instead of heading sets.** Every wording change in the template
+would nudge. The property worth surfacing is a *missing item*, not a reworded
+one; §3 keeps the mechanism aligned with what the message claims.
+
+**Record declines in a separate file.** A seventh durable governance artifact,
+in a repository where two committed dashboards went 106 days unread. The
+declined block sits in the file it describes and is read by the two mechanisms
+that need it.
+
+## 7. Version
+
+Behavioural change to plugin files: **minor**, `0.89.0` → `0.90.0`, across the
+five CI-checked locations plus the README plugin-table row.
+
+## 8. Docs
+
+Same PR, per the docs-site convention:
+`how-to/update-the-plugin.md:16,97`; `how-to/upgrade-your-harness.md:23`;
+`reference/commands.md:128`; `reference/hooks.md:282`;
+`reference/harness-md-format.md:19,41`; `README.md:74,486`.

--- a/docs/superpowers/specs/2026-08-25-template-currency-measure-content-design.md
+++ b/docs/superpowers/specs/2026-08-25-template-currency-measure-content-design.md
@@ -1,25 +1,26 @@
-# Template currency measures content — design
+# Retire the template-currency nudge — design
 
-**Status:** proposed (revision 2)
+**Status:** proposed (revision 3)
 **Date:** 2026-08-25
 **Issue:** #601
-**Provenance:** `docs/superpowers/specs/2026-04-15-harness-upgrade-design.md`,
-which introduced the `template-version` marker and decided that a missing
-marker means "treat as `0.0.0`". This spec retires the marker outright. The
-issue as filed proposed making the marker optional; the approach here is
-broader and is argued for in §3.1.
-**Revision 2** rewrites §3 and §4 against
-`docs/superpowers/objections/template-currency-measure-content-design.md`.
-The comparison is now over a *filtered* item set (O10), which removes the
-false-positive load that O1 and O2 identified and shrinks the declined-item
-mechanism to the one case that needs it. §11 maps every objection to what
-changed.
-**Scope:** the SessionStart template-currency hook, `/harness-upgrade` step 1
-and step 6, `/harness-init`'s marker write, the `Template currency` GC rule,
-the `/harness-sync` template-drift surface, and the declined-item record.
-**Out of scope:** `/harness-upgrade`'s adoption mechanics (steps 2–5) beyond
-the parsing changes in §4; the harness evolution loop; whether
-`/harness-upgrade` should route adopted items through `/harness-propose`.
+**Provenance:** `docs/superpowers/specs/2026-04-15-harness-upgrade-design.md`
+introduced the `template-version` marker, the `Template currency` GC rule and
+the SessionStart nudge. This spec retires all three.
+**Revision history:** Revision 1 replaced the version comparison with a heading
+comparison. Revision 2 filtered the compared set. Both were reviewed
+adversarially; the second review returned one critical and eight high
+objections, and its premise objection (O1) observed that the design had grown a
+script, a `PATH` shim, a grammar in the governing document, a fourth command
+disposition, eighteen acceptance criteria and a twelve-file migration in
+support of a mechanism with no recorded successes. Revision 3 takes the option
+both prior revisions listed as live and neither took. §9 records what this
+resolves and what it abandons.
+**Scope:** deletion of the marker, the `Template currency` GC rule, the
+SessionStart hook and the dismissal file, across the plugin, this repository,
+and — by migration — consuming projects. `/harness-upgrade` survives as an
+on-demand command with its version gate removed.
+**Out of scope:** the declined-item record (§8); `/harness-upgrade`'s adoption
+mechanics beyond step 1 and step 6; the harness evolution loop.
 
 ## 1. Problem statement
 
@@ -39,463 +40,281 @@ Verified on 2026-08-25:
   last moved 2026-06-17 (`52e114a`). `d867c7c` changed the template's content
   without moving it. No mechanism reads it.
 
-The consequence is a SessionStart hook that asserts `Plugin template has been
-updated` on evidence that cannot establish it. The false signal reached the
-governing document: `HARNESS.md`'s Status block records "eight minors of
-unreviewed template content" against a template that had not changed.
+So the SessionStart hook asserts `Plugin template has been updated` on evidence
+that cannot establish it, and the false signal reached the governing document:
+`HARNESS.md`'s Status block records "eight minors of unreviewed template
+content" against a template that had not changed.
 
 Five of the last six marker advances adopted nothing. `58d3dda` (2026-07-22)
-and `89b46f9` (2026-08-13) each record "found nothing to adopt", both naming
-the same item — the generic `Consistent formatting` placeholder, declined
-because this repository has specialised it into a deterministic markdownlint
-rule. The 2026-08-25 run reached the same conclusion about the same item a
-third time.
+and `89b46f9` (2026-08-13) each record "found nothing to adopt", both naming the
+same item — the generic `Consistent formatting` placeholder, declined because
+this repository specialised it into a deterministic markdownlint rule. The
+2026-08-25 run reached the same conclusion about the same item a third time.
 
-### 1.1 The `## Stakeholders` case, and what it does not establish
+### 1.1 What the `## Stakeholders` case does not establish
 
 `d867c7c` added a commented-out `## Stakeholders` section to the template on
 2026-08-13 at 09:11. `89b46f9` ran six hours later, reported "byte-identical …
 nothing to adopt", and stamped the marker forward. The block was not adopted
 until twelve days later, by a human who noticed it another way.
 
-Revision 1 presented this as evidence that the nudge's valuable failure mode is
-*not being told*, and presented §4's parsing fix as its explanation. Both
-overstated it. There are at least three candidate causes and this spec
-attributes none of them:
-
-1. The run genuinely missed a commented-out section (a parsing gap).
-2. The cache had not yet synced, so `89b46f9` compared against a copy predating
-   `d867c7c` — plausible, because in this repository the cache is rsynced from
-   the working tree on `Stop` (§4.6).
-3. The section was seen and skipped.
-
-The `0.73.2` plugin cache is no longer on the machine that ran it, so this
-cannot be settled. §3.3 no longer rests on it.
-
-## 2. The property that should be measured
-
-The nudge names one property: *the template contains something your harness
-does not*. The marker measures a different one: *the plugin has been released
-since you last stamped a number*. These come apart on every release that does
-not touch the template, which is nearly all of them.
-
-`/harness-upgrade` already computes something close to the real property. Steps
-2–3 parse both files into named items and diff them. Step 1's version gate is a
-pre-filter in front of a comparison that does not need it, and the pre-filter is
-the part that is wrong.
-
-## 3. Decision — compare a filtered item set, retire the marker
-
-The hook and the command compare **heading sets** between the plugin's
-`templates/HARNESS.md` and the project's `HARNESS.md`. There is no marker, no
-`plugin.json` read, and no stored version state.
-
-The comparison is over a filtered set. Revision 1 compared every `##` and `###`
-heading in the template, which produces false positives by construction — see
-§3.4. The filter is what makes the mechanism quiet; the declined-item record
-(§3.5) handles only the residue.
-
-### 3.1 Why not the narrower change in #601
-
-The issue proposed keeping the marker as an optional feature and treating its
-absence as opt-out. That silences the false alarm for projects that remove the
-marker and leaves it intact for everyone who keeps it — the version-as-proxy
-flaw survives, and the projects most likely to need a nudge (those that never
-had a marker) go permanently quiet. Opting out of a broken signal is not the
-same as fixing it.
-
-### 3.2 Why not an explicit `none` sentinel
-
-Considered and rejected. A declared opt-out fits this repository's
-declare-don't-infer culture, but it is additional mechanism in service of a
-signal §1 shows is unreliable in both directions. Retiring the signal is
-cheaper than governing it.
-
-### 3.3 Why keep a nudge at all — on judgement, not on data
-
-Stated plainly, because §1.1 removed the evidence revision 1 leaned on: **there
-is no recorded instance of this nudge producing a useful adoption.** Six runs
-are recorded; five adopted nothing, and the sixth cannot be attributed.
-
-The nudge is retained on the judgement that a project which never learns its
-template gained content has no other path to finding out, and that a correctly
-filtered comparison costs two greps at session start. That is a judgement, and
-a reviewer is entitled to reject it — §6 records deleting the nudge entirely as
-a live alternative rather than a dismissed one.
-
-What changed between revisions is the cost of being wrong. Revision 1 sustained
-the nudge with a new durable per-project artefact in every adopting project.
-This revision sustains it with a filter over headings the template already tags,
-plus a declined block that is empty in a default project.
-
-### 3.4 Why the item set must be filtered
-
-An unfiltered heading comparison fires on the default install, on day one.
-
-- `/harness-init` documents Affordances as "opt-in (default off)"
-  (`commands/harness-init.md:57`) and replaces an unselected feature's section
-  body with `<!-- Not yet configured. Run /harness-init and select this feature
-  to set up. -->` (`:147`, `:154`).
-- The template's `## Affordances` body carries four headings tagged
-  `<!-- affordance-example -->` (`templates/HARNESS.md:520,535,546,557`).
-- The template carries a literal placeholder heading, `### [Governance
-  constraint name]` (`:194`).
-
-So a default-initialised project is missing template headings *by design*, and
-under an unfiltered rule is nudged about example affordances it was never meant
-to adopt — silenceable only by running the command the nudge advertises.
-
-Running revision 1's rule against this repository — a near-superset of the
-template, the most favourable input available — produced two items:
-
-```text
-Consistent formatting
-Cognitive reservoir  (OPTIONAL — to opt in, remove this `<!--` line and the closing `-->` below)
-```
-
-The second is pure false positive: `templates/HARNESS.md:630` carries
-instructional text on the heading line, which no amount of trimming or
-case-folding reconciles with this repository's `## Cognitive reservoir`
-(`HARNESS.md:1126`). §4.2 fixes it in the template rather than working around
-it in the parser.
-
-### 3.5 The declined-item record, reduced to its residue
-
-Filtering does not catch a genuine specialisation. This repository has
-`Consistent markdown formatting`; the template has `Consistent formatting`.
-Same intent, different name, and no filter can know that.
-
-That case needs a recorded human decision, and it needs one because the decision
-has already been made three times and written only into commit messages — which
-is why the item keeps returning.
-
-`HARNESS.md` gains a declined block. In a default project it is absent or empty;
-in this repository it holds one entry.
-
-```html
-<!-- template-declined
-Consistent formatting :: specialised here as "Consistent markdown formatting" (deterministic, markdownlint, commit + pr); the template's placeholder is unverified
--->
-```
-
-Grammar, stated strictly because revision 1 left it undefined (O3):
-
-- One entry per line. **No continuation lines** — an indented line is not a
-  continuation, it is a malformed entry. `MD013` is disabled in
-  `.markdownlint.json`, so a long line is permitted.
-- Separator is ` :: ` (space-colon-colon-space). A colon may appear in either
-  field; the first ` :: ` splits.
-- Left field is the template heading, matched by the same normalisation as §4.1.
-- Right field is free prose, never parsed.
-- The reason may not contain `--`. `/harness-upgrade` rejects such a reason and
-  re-prompts rather than writing it. This is not stylistic: the block is an HTML
-  comment, `-->` terminates it early, and comment state is semantically
-  load-bearing in this file.
-- Duplicate left fields are malformed, not last-wins.
-- **A line that does not parse is reported, never skipped.** The tooling names
-  the file and line and treats the entry as absent. A silent skip re-admits a
-  declined item to the missing set, which is indistinguishable from the bug
-  this spec fixes.
-
-## 4. Design
-
-### 4.1 The comparison, in one place
-
-Revision 1 specified the rule twice — once as bash for the hook, once as prose
-for the command — and asserted they could not disagree. They are two
-implementations, one of them executed by a model, and this repository already
-runs a `Command-prompt sync` GC rule (`HARNESS.md:690`) because that class of
-drift happens here.
-
-The rule is implemented **once**, as `ai-literacy-superpowers/scripts/harness-template-diff.sh`,
-exposed on `PATH` as `harness-template-diff` via the `bin/` shim convention. The
-hook invokes it. `/harness-upgrade` step 2 invokes it and consumes its output
-instead of restating its rules.
-
-```text
-harness-template-diff [--format=text|json]
-
-  tpl   = $CLAUDE_PLUGIN_ROOT/templates/HARNESS.md
-  proj  = $CLAUDE_PROJECT_DIR/HARNESS.md
-
-  proj absent            -> exit 0, emit nothing        (not a harness project)
-  tpl absent/unreadable  -> exit 0, emit DEGRADED naming the unreadable path
-
-  tpl_headings = ## and ### headings of tpl, including inside HTML comments,
-                 EXCLUDING:
-                   - a heading whose line carries <!-- affordance-example -->
-                   - a heading matching ^\[.*\]$          (literal placeholder)
-
-  For each remaining template heading h:
-    skip if h's owning ## section is unconfigured in proj
-           (section body is the "Not yet configured" placeholder marker)
-    skip if normalise(h) is in normalise(proj_headings)
-    skip if normalise(h) is in normalise(declined left-fields)
-    otherwise -> missing
-
-  normalise(h) = trim, collapse internal whitespace, casefold
-```
-
-The unconfigured-section skip is what makes a default `/harness-init` quiet: a
-project that opted out of Garbage Collection has the `## Garbage Collection`
-heading with a placeholder body, so its twenty-odd `###` children are not
-reported as missing.
-
-### 4.2 The template stops putting instructions on heading lines
-
-`templates/HARNESS.md:630` reads:
-
-```text
-<!-- ## Cognitive reservoir  (OPTIONAL — to opt in, remove this `<!--` line and the closing `-->` below)
-```
-
-The instruction moves to the line below the heading. The heading line becomes
-`<!-- ## Cognitive reservoir`.
-
-This is a template fix, not a parser fix, and it is the right layer: the
-template is ours, the comparison runs template→project, and a normalisation
-that strips trailing parentheticals would also collapse `### Affordance recorder
-freshness (LOCAL — per-machine only)` (`:463`) and `### Affordance dead
-inventory (LOCAL — per-machine only)` (`:476`), whose parentheticals are part of
-the heading and appear identically on both sides.
-
-A Layer 0 test asserts no heading line in `templates/HARNESS.md` carries a
-trailing parenthetical, so the class cannot return.
-
-### 4.3 The message states what it compared
-
-> `Template has 1 item your harness does not: "Stakeholders". Run /harness-upgrade to review.`
-
-It names the items it found. A reader can falsify it against their own file
-without running anything.
-
-On the degraded path (§4.1):
-
-> `Could not read the plugin template at <path> — template currency not checked.`
-
-Silence means checked-and-current. It never means could-not-check. This follows
-the harness decision record in force until 2026-11-23, compiled into
-`skills/advocatus-diaboli/SKILL.md`: a mechanism that could not determine the
-answer reports the degraded state and names the input it could not read. The
-hook still never blocks and never exits non-zero — a `systemMessage` satisfies
-both.
-
-`proj absent` is silent by design and is not a degraded case: a project with no
-`HARNESS.md` has nothing to be current with.
-
-### 4.4 `/harness-upgrade`
-
-- **Step 1** drops the version comparison. Prerequisites keep the HARNESS.md
-  existence check and the `git fetch origin main` staleness guard.
-- **Step 2** invokes `harness-template-diff --format=json` rather than
-  restating the matching rules.
-- **Step 3** presents declined items in a separate **Previously declined**
-  group with their recorded reasons, so a standing decision is visible without
-  being re-litigated.
-- **Step 4** gains a **decline** disposition alongside accept/skip/customise.
-  Declining prompts for a reason and writes it per §3.5's grammar, rejecting a
-  reason containing `--`.
-- **Step 6** no longer writes a marker or a dismissal file. It removes a
-  `template-version` marker if it finds one (§4.5) and writes any new declined
-  entries.
-- **Step 7** reports declined items alongside accepted and skipped.
-
-**Skip semantics, stated rather than assumed.** Skip means *not now, ask again
-next session*. Revision 1 removed the dismissal file, which was the only
-time-boxed silence, without saying so. This revision states it: after filtering,
-the only items that recur are genuinely new template content the project has not
-acted on, and being reminded of those each session is the intended behaviour.
-A user who wants a standing silence declines instead, which costs one sentence
-and leaves a reason for the next reader. No time-boxed skip is added.
-
-### 4.5 Migration
-
-The marker becomes inert on the release that ships this. Nothing reads it, so a
-project that still has one is not broken.
-
-- `/harness-init` stops writing it.
-- `/harness-upgrade` removes it when it next runs, and says so in its report.
-- This repository removes its own in this PR, along with the `Template currency`
-  GC rule.
-- `.claude/.harness-upgrade-dismissed` is no longer written or read. The
-  `.gitignore` entry stays — the file exists on machines that have run the old
-  command, and removing the ignore would surface it as untracked.
-
-### 4.6 Which copy of the template is authoritative
-
-`$CLAUDE_PLUGIN_ROOT/templates/HARNESS.md` — the installed plugin's copy. For a
-consuming project that is the versioned marketplace cache, which advances when
-they upgrade the plugin.
-
-**In this repository the two are coupled.** `sync-to-global-cache.sh` rsyncs
-plugin content into the versioned cache on every `Stop` (`CLAUDE.md`,
-Marketplace Cache Auto-Sync). A maintainer who adds a heading to
-`templates/HARNESS.md` will, in a later session, be told their harness is
-missing the thing they just wrote.
-
-That is correct behaviour reported at a useless moment. It is accepted rather
-than solved: the alternative is teaching the hook to detect that the project
-*is* the plugin source, which is the special-casing §3 exists to avoid. It is
-recorded here so the next person meeting it knows it is known. This coupling is
-also candidate cause 2 in §1.1.
-
-### 4.7 Surfaces that declare or read the marker
-
-Revision 1's table listed seven files and presented the inventory as complete;
-it found seven of ten (O4).
-
-| File | Change |
+Revisions 1 and 2 leaned on this as evidence that the expensive failure is *not
+being told*. There are at least three candidate causes and this spec attributes
+none: a genuine parsing miss; a cache that had not yet synced, so `89b46f9`
+compared against a copy predating `d867c7c`; or the section being seen and
+skipped. The `0.73.2` plugin cache is no longer on the machine that ran it, so
+this cannot be settled.
+
+**There is therefore no recorded instance of this nudge producing a useful
+adoption.** Six runs are recorded; five adopted nothing and the sixth cannot be
+attributed.
+
+## 2. Decision — delete the nudge
+
+The marker, the `Template currency` GC rule, the SessionStart hook and the
+dismissal file are removed. Nothing replaces them.
+
+`/harness-upgrade` survives, unchanged except for losing its version gate. It
+already performs a real structural comparison in steps 2–3; that comparison was
+never the broken part. `README.md:99` already directs people to run it after
+upgrading the plugin, which becomes the whole of the discovery story.
+
+### 2.1 Why deletion rather than a better comparison
+
+Revisions 1 and 2 tried to keep a nudge and measure the right property. Each
+attempt grew:
+
+| | Revision 1 | Revision 2 | Revision 3 |
+| --- | --- | --- | --- |
+| New script + `PATH` shim | — | yes | — |
+| New grammar in `HARNESS.md` | yes | yes (stricter) | — |
+| New `/harness-upgrade` disposition | yes | yes | — |
+| Acceptance criteria | 9 | 18 | 6 |
+| Adversarial review | 1 critical, 5 high | 1 critical, 8 high | — |
+
+The second review's critical objection was that revision 2's filter still fired
+on a default install, because the template's two OPTIONAL blocks
+(`templates/HARNESS.md:39`, `:630`) are shipped commented out and the rule
+included commented headings by design. Its high objections included an exclusion
+predicate that matched nothing — the `<!-- affordance-example -->` tag sits on
+the line *below* each heading (`:519`/`:520`), verified by
+`grep '^###.*affordance-example'` returning zero matches — and an acceptance
+criterion incapable of detecting that, because it ran against this repository,
+which already contains every heading the exclusions were meant to suppress.
+
+The pattern is that each revision defended a mechanism the evidence does not
+support, and paid for the defence in mechanism. §1.1 removed the last evidence
+in its favour.
+
+### 2.2 What is lost, stated plainly
+
+A project that upgrades the plugin will no longer be told, unprompted, that the
+template gained content. They learn it by running `/harness-upgrade`, which the
+README already tells them to do after an upgrade.
+
+This is a real reduction in discoverability, and it is accepted on the grounds
+that the mechanism being removed has never demonstrably provided it. If a future
+adopter reports missing template content they would have wanted to know about,
+that is evidence this decision was wrong and is worth reopening on — §7 keeps
+the alternative recorded rather than dismissed.
+
+## 3. What is deleted
+
+| Artefact | Location |
 | --- | --- |
-| `templates/HARNESS.md:13` | Remove the stale `0.57.0` marker |
-| `templates/HARNESS.md:337-342` | Remove the `Template currency` GC rule |
-| `templates/HARNESS.md:630` | Move the instruction off the heading line (§4.2) |
-| `HARNESS.md:13` | Remove the marker |
-| `HARNESS.md:760-769` | Remove the `Template currency` GC rule |
-| `commands/harness-sync.md:118,206-207,271,294` | **Was missing.** Surface list, checkbox JSON (`"id": "template"`), remediation line, drift-table row |
-| `commands/harness-init.md:184,211` | Stop writing the marker |
-| `commands/harness-upgrade.md:46-47,135-143` | §4.4 |
-| `hooks/scripts/template-currency-check.sh` | Rewritten to call `harness-template-diff` |
-| `skills/harness-audit-engine/SKILL.md:33` | Remove the `Template currency` surface row |
-| `skills/harness-observability/references/observatory-signals.md:127` | Remove the `Template version` row — see below |
-| `skills/ai-literacy-assessment/references/habitat-discovery.md:93,141` | Drop the marker from habitat discovery |
+| SessionStart hook script | `hooks/scripts/template-currency-check.sh` |
+| Hook registration | `hooks/hooks.json` SessionStart entry |
+| Marker (plugin template) | `templates/HARNESS.md:13` |
+| `Template currency` GC rule (plugin template) | `templates/HARNESS.md:335-342` |
+| Marker (this repository) | `HARNESS.md:13` |
+| `Template currency` GC rule (this repository) | `HARNESS.md:760-769` |
+| Marker write | `commands/harness-init.md:184,211` |
+| Version gate + marker/dismissal write | `commands/harness-upgrade.md:46-47,135-143,152` |
+| Template-drift surface | `commands/harness-sync.md:118,206-207,271,294` |
+| Drift surface row | `skills/harness-audit-engine/SKILL.md:33` |
+| `Template version` signal row | `skills/harness-observability/references/observatory-signals.md:127` |
+| Habitat-discovery signal | `skills/ai-literacy-assessment/references/habitat-discovery.md:93,141` |
 
-**The observatory row is enforced.** `commands/observatory-verify.md:16` reads
-the signals reference, and `:42` reports **PARTIAL** when a required field is
-absent. So removing the marker without removing the row degrades every project's
-verification. Removing the row is required, not cosmetic. Archived snapshots
-that carry the field are unaffected — verification reads the reference against
-the *latest* output, not historical ones.
+`.claude/.harness-upgrade-dismissed` is no longer written or read. The
+`.gitignore` entry stays — the file exists on machines that ran the old command,
+and removing the ignore would surface it as untracked.
 
-### 4.8 The Status block is corrected in this PR
+### 3.1 The observatory signal count
 
-`HARNESS.md`'s Status block references the marker, and its
-`Garbage collection active:` count changes when the `Template currency` rule is
-removed.
+`observatory-signals.md:127` is a **required** signal, and
+`commands/observatory-verify.md:42` reports **PARTIAL** when a required field is
+absent — so the row must go, not merely be marked optional.
 
-Revision 1 deferred this to "whenever `/harness-audit` next runs", which merges
-a governing document that misstates its own coverage. `/harness-audit` owns the
-block and hand-editing it is worse — so **this PR runs `/harness-audit`** and
-commits its output. That is the third option revision 1 did not consider, and
-this repository's Status block already records the cost of not taking it: "The
-2026-08-13 audit recorded `Drift detected: no` against a tree that already
-carried every failure listed here" (`HARNESS.md:1177`).
+The total is hard-coded in three places and must move 82 → 81:
 
-## 5. Acceptance criteria
+- `skills/harness-observability/references/observatory-signals.md:157`
+- `commands/observatory-verify.md:3` (frontmatter description)
+- `commands/observatory-verify.md:17`
 
-### 5.1 `harness-template-diff` — Layer 0 deterministic
+`observatory-verify.md:89` carries `**82**` in a results-table template and moves
+with them. Archived snapshots that carry the field are unaffected: verification
+reads the reference against the latest output, not historical ones.
 
-Tests at `tdad_tests/layer0_deterministic/test-harness-template-diff.sh`, with
-fixtures under `tdad_tests/layer0_deterministic/fixtures/`.
+## 4. What survives
 
-1. A project harness containing every non-excluded template heading yields an
-   empty missing set — **regardless of plugin version**.
-2. A template heading absent from the project appears in the missing set.
-3. A heading named in the project's declined block does not appear.
-4. A template heading that appears only inside an HTML comment is treated like
-   any other; criteria 1–3 hold for it unchanged.
-5. A heading tagged `<!-- affordance-example -->` never appears, even when the
-   project lacks it.
-6. A heading matching `^\[.*\]$` never appears.
-7. `###` headings under a project section carrying the "Not yet configured"
-   placeholder never appear.
-8. Matching is trim, whitespace-collapse and casefold on both sides; headings
-   differing only in those respects are not reported.
-9. A malformed declined line is reported with file and line, and its entry is
-   treated as absent — not silently skipped.
-10. A declined reason containing `--` is rejected on write.
-11. Template unreadable → DEGRADED naming the path; exit 0.
-12. Project harness absent → silent; exit 0.
-13. Exit status is 0 on every path.
+`/harness-upgrade` keeps its three-bucket comparison — **new**, **updated** and
+**removed** items (`commands/harness-upgrade.md:74-88`). Revision 2 proposed
+replacing that parse with a missing-set-only script and would have silently
+dropped two buckets; this revision touches neither the parse nor the buckets.
 
-### 5.2 The real-input assertion
+Changes are confined to two steps:
 
-14. Run against this repository's committed `HARNESS.md` and
-    `templates/HARNESS.md`, the missing set is **empty** once §4.2's template fix
-    and the `Consistent formatting` declined entry are in place.
+- **Step 1** drops the version comparison and the "versions match → skip to step
+  6" short-circuit. Prerequisites keep the HARNESS.md existence check and the
+  `git fetch origin main` staleness guard.
+- **Step 6** stops writing the marker and the dismissal file, and instead
+  performs the migration in §5.
 
-This criterion exists because revision 1 never ran its own algorithm; §3.4
-records what happened when it finally was. It is a Layer 0 test against the real
-files, not fixtures, so template edits that reintroduce a false positive fail CI.
+## 5. Migration for consuming projects
 
-15. No heading line in `templates/HARNESS.md` carries a trailing parenthetical
-    (§4.2).
+The plugin's template stops shipping the marker and the GC rule. That does not
+reach a project whose `HARNESS.md` already has both — its file is its own.
 
-### 5.3 `/harness-upgrade` — behavioural
+Left alone, such a project keeps a GC rule declared **deterministic** whose tool
+compares a marker that no longer exists. Under the semantics being deleted, an
+absent marker reads as `0.0.0` (`hooks/scripts/template-currency-check.sh:32-34`),
+so the rule reports drift on every run, permanently, with no way to clear it.
+That would export the defect this spec removes to the entire install base.
 
-Not Layer 0; these are model-executed and belong in a behavioural scenario, not
-in the hook's test file. Revision 1 assigned them to the hook's file in error.
+So `/harness-upgrade` step 6 becomes a migration step. On any run, if the
+project's `HARNESS.md` contains:
 
-16. Given a `HARNESS.md` with a `template-version` marker, the command removes it
-    and reports having done so.
-17. A previously-declined item is presented under **Previously declined** with
-    its recorded reason, never in the new-items bucket.
-18. **Round trip:** declining an item through the command produces a block that
-    `harness-template-diff` reads back as declined, and the hook then emits
-    nothing. This is the write path revision 1 left untested, and given §3.5 it
-    is where the design is most likely to fail.
+- a `<!-- template-version: … -->` marker, it is removed;
+- a `### Template currency` GC rule whose **Tool** field references the
+  template-version comment, it is removed;
 
-The *New plugin components must ship with a TDAD scenario* constraint does gate
-`harness-template-diff.sh` only if it ships as a new skill, agent or command; a
-script is none of those, so the constraint does not apply. The tests are added
-because the behaviour is new, not because a constraint demands them.
+and step 7 reports each removal by name. Both removals are idempotent and are
+no-ops on a project that has neither.
 
-## 6. Rejected alternatives
+A project that never runs `/harness-upgrade` again keeps an orphaned rule. That
+is not fully solvable from here — the plugin cannot edit a file it is not
+invited into — and it is the reason step 6 does the work on *every* run rather
+than only when something is adopted.
 
-**Compare the template's own content marker.** Unmaintained — `d867c7c` changed
-the template without moving it — and nothing reads it. Substitutes one unreliable
-signal for another.
+## 6. Acceptance criteria
 
-**Hash the template and store the hash.** Measures content correctly, but
-reintroduces per-project state that drifts, which is the class of defect being
-removed.
+1. `hooks/scripts/template-currency-check.sh` does not exist, and `hooks.json`
+   contains no SessionStart entry referencing it.
+2. Neither `templates/HARNESS.md` nor this repository's `HARNESS.md` contains a
+   `template-version` marker or a `Template currency` GC rule.
+3. `/harness-upgrade` run against a project harness containing a
+   `template-version` marker removes it and names it in the report.
+4. `/harness-upgrade` run against a project harness containing a
+   `Template currency` GC rule whose Tool references the template-version
+   comment removes it and names it in the report.
+5. Both removals are idempotent: a second run reports nothing further and
+   changes nothing.
+6. **Residue assertion.** A repository-wide search for `template-version`,
+   `Template currency`, `template-currency` and `harness-upgrade-dismissed`
+   returns matches only in: `CHANGELOG.md`, `REFLECTION_LOG.md`, `reflections/`,
+   `assessments/`, `harness/assay/`, `docs/superpowers/{specs,plans,objections}/`,
+   `observability/snapshots/`, and the `.gitignore` line.
 
-**Full-text diff instead of heading sets.** Every wording change would nudge.
-The property worth surfacing is a *missing item*, not a reworded one.
+Criteria 1, 2 and 6 are Layer 0 deterministic tests at
+`tdad_tests/layer0_deterministic/test-template-currency-retired.sh`. Criteria
+3–5 are behavioural — they are model-executed command behaviour and do not
+belong in a Layer 0 file.
 
-**Record declines in a separate file.** A new durable governance artefact in a
-repository where two committed dashboards went 106 days unread. The declined
-block sits in the file it describes.
+**Criterion 6 exists because hand enumeration failed twice.** Revision 1's
+surfaces table listed seven files and was presented as complete; revision 2's
+listed twelve and was presented as complete. A `grep` across the tree at the
+time of writing returns **nineteen**. The assertion is cheaper than the table
+and does not depend on the author having remembered everything.
 
-**Normalise trailing parentheticals in the parser** rather than fixing the
-template (§4.2). Rejected: it would also collapse the two `(LOCAL — per-machine
-only)` headings, whose parentheticals are meaningful, and it hides a template
-defect inside a matcher.
+The *New plugin components must ship with a TDAD scenario* constraint does not
+gate this work: it names new `SKILL.md`, `agent.md` and `command.md` files, and
+this change adds none.
 
-**Delete the nudge entirely, keeping `/harness-upgrade` on demand.** Still live,
-and strengthened by §1.1 removing the evidence that favoured keeping it. §3.3
-retains it on judgement and says so; a reviewer who weighs the absence of any
-recorded successful nudge more heavily should take this option, which deletes
-the hook, the shared script, the declined block and §5.1 entirely.
+## 7. Rejected alternatives
 
-## 7. Version
+**Compare heading sets (revision 1).** Fires on a default install: the template
+ships four `<!-- affordance-example -->` headings, a `### [Governance constraint
+name]` placeholder, and two commented OPTIONAL sections that a default project
+correctly lacks.
+
+**Filter the compared set (revision 2).** Reduces but does not remove that,
+because the OPTIONAL blocks are `##` sections and the unconfigured-section skip
+cannot reach them; and it buys the reduction with a script, a shim, a grammar
+and a new disposition.
+
+**Fix the template's own content marker and read that.** The strongest surviving
+alternative, raised as O7 against revision 2: add a CI assertion that any diff
+touching `templates/HARNESS.md` also moves its `<!-- template-version -->`, and
+have the hook compare that marker rather than `plugin.json`. It measures the
+right property, costs one CI check, and needs no new mechanism.
+
+Rejected on §1.1 rather than on cost: it is a cheap way to build a correct
+version of a mechanism with no recorded successes, and the question this spec
+answers is whether to have the mechanism at all. **If the answer to §2.2 turns
+out to be wrong, this is the option to reopen on** — it is recorded here in
+enough detail to be taken up without re-deriving it.
+
+**Keep the marker but make its absence an opt-out (issue #601 as filed).**
+Leaves the version-as-proxy flaw intact for every project that keeps its marker,
+and silences the nudge for projects that never had one — the population most
+likely to need it.
+
+## 8. Out of scope: the declined-item record
+
+Revisions 1 and 2 proposed recording declined template items in `HARNESS.md`, so
+that `Consistent formatting` — declined three times on reasoning written only
+into commit messages — would stop being re-presented.
+
+That problem is real and survives this spec. It is out of scope because deleting
+the nudge shrinks it from *every session* to *every deliberate `/harness-upgrade`
+run*, which is a different order of nuisance, and because the record's grammar
+was the source of two objections in the last review. It is worth revisiting on
+its own terms rather than as a dependency of a mechanism being deleted.
+
+## 9. Objections resolved and abandoned
+
+Against `docs/superpowers/objections/template-currency-measure-content-design.md`
+(revision 2's record):
+
+| ID | Severity | Outcome |
+| --- | --- | --- |
+| O1 | high | **Resolved** — §2.1 takes the deletion option and prices the alternatives in like terms |
+| O2 | critical | **Dissolved** — no comparison, no filter, no OPTIONAL-block false positive |
+| O3 | high | **Dissolved** — no exclusion predicate |
+| O4 | high | **Resolved differently** — §6 criterion 6 asserts residue by grep rather than validating an algorithm against one favourable input |
+| O5 | high | **Resolved** — §4 leaves the three-bucket parse untouched |
+| O6 | high | **Resolved** — §5 migrates consuming projects' orphaned GC rule |
+| O7 | high | **Recorded, not taken** — §7 keeps it as the reopening path if §2.2 proves wrong |
+| O8 | high | **Dissolved** — no SessionStart hook, so no re-fire on resume/clear/compact |
+| O9 | high | **Resolved** — §6 criterion 6; §3's table is grep-derived, and the grep is the test |
+| O10 | medium | **Dissolved** — no comparison, so no project-side comment rule to define |
+| O11 | medium | **Dissolved** — no script, no `--` grammar |
+| O12 | medium | **Dissolved** — no hook, so no silent-failure path to specify |
+
+## 10. The Status block
+
+Removing the `Template currency` GC rule changes the
+`Garbage collection active:` count in `HARNESS.md`'s Status block, which is
+owned by `/harness-audit` and must not be hand-edited.
+
+**This PR runs `/harness-audit`** and commits its output, rather than merging a
+governing document that misstates its own coverage. This repository's Status
+block already records the cost of not doing that: "The 2026-08-13 audit recorded
+`Drift detected: no` against a tree that already carried every failure listed
+here" (`HARNESS.md:1177`).
+
+## 11. Version
 
 Behavioural change to plugin files: **minor**, `0.89.0` → `0.90.0`, across the
 five CI-checked locations plus the README plugin-table row.
 
-## 8. Docs
+## 12. Docs
 
-Same PR, per the docs-site convention. Revision 1 missed the last two:
+Same PR. Derived from the grep in §6, not by hand:
 
-`README.md:74,486`; `how-to/update-the-plugin.md:16,97`;
-`how-to/upgrade-your-harness.md:23`; `reference/commands.md:128`;
-`reference/hooks.md:282`; `reference/harness-md-format.md:19,41`;
-`docs/contributing/index.md:195`;
-`docs/plugins/ai-literacy-superpowers/how-to/sync-harness.md` (six references,
-including a drift-table row and a "Template drift" remediation section).
-
-## 9. Objections addressed
-
-| ID | Severity | Where |
-| --- | --- | --- |
-| O1 | critical | §3.4, §4.1 — affordance-example and placeholder exclusions; unconfigured-section skip |
-| O2 | high | §4.2 template fix; §5.2 criterion 14 asserts the real missing set is empty |
-| O3 | high | §3.5 — strict grammar, `::` separator, no continuations, `--` rejected, malformed reported not skipped |
-| O4 | high | §4.7 — `harness-sync.md` added; §8 — `contributing/index.md`, `sync-harness.md` added |
-| O5 | medium | §1.1 withdraws the claim; §3.3 states the nudge is kept on judgement; §6 keeps deletion live |
-| O6 | high | §4.1 — one implementation, `harness-template-diff`, invoked by both |
-| O7 | high | §4.1, §4.3 — degraded path names the unreadable input; §5.1 criteria 11–13 |
-| O8 | medium | §4.4 — skip semantics stated; no time-box added, with reasons |
-| O9 | medium | §5.1/§5.3 split; §5.3 criterion 18 tests the write path round trip |
-| O10 | medium | §3 restructured around the filtered item set |
-| O11 | medium | §4.6 names the authoritative copy and the local coupling; §1.1 stops attributing the Stakeholders case |
-| O12 | medium | §4.8 runs `/harness-audit` in this PR; §4.7 confirms the observatory row is enforced |
+`README.md:74,77,486`; `docs/contributing/index.md:195`;
+`docs/plugins/ai-literacy-superpowers/reference/hooks.md:277,282`;
+`.../reference/commands.md:128,133`; `.../reference/harness-md-format.md:19,41`;
+`.../how-to/update-the-plugin.md:16,97`; `.../how-to/upgrade-your-harness.md:23`;
+`.../how-to/sync-harness.md` (three references, including the drift-table row and
+the "Template drift" remediation section).

--- a/docs/superpowers/specs/2026-08-25-template-currency-measure-content-design.md
+++ b/docs/superpowers/specs/2026-08-25-template-currency-measure-content-design.md
@@ -273,8 +273,7 @@ its own terms rather than as a dependency of a mechanism being deleted.
 
 ## 9. Objections resolved and abandoned
 
-Against `docs/superpowers/objections/template-currency-measure-content-design.md`
-(revision 2's record):
+Against the revision-2 review (record preserved at commit `6da8b77`):
 
 | ID | Severity | Outcome |
 | --- | --- | --- |

--- a/docs/superpowers/stories/template-currency-measure-content-design.md
+++ b/docs/superpowers/stories/template-currency-measure-content-design.md
@@ -1,0 +1,534 @@
+---
+spec: docs/superpowers/specs/2026-08-25-template-currency-measure-content-design.md
+date: 2026-08-25
+mode: spec
+cartographer_model: claude-opus-5[1m]
+stories:
+  - id: 1
+    lens: [defaults, patterns]
+    title: Retiring a GC rule outside the governed loop
+    disposition: pending
+    disposition_rationale: null
+  - id: 2
+    lens: [alternatives, patterns]
+    title: A bespoke predicate beside a general bucket
+    disposition: pending
+    disposition_rationale: null
+  - id: 3
+    lens: [patterns, consequences]
+    title: Deletion as the honest-status rule's converse
+    disposition: pending
+    disposition_rationale: null
+  - id: 4
+    lens: [coherence, forces]
+    title: A spec against proxies, argued by proxy
+    disposition: pending
+    disposition_rationale: null
+  - id: 5
+    lens: [consequences, forces]
+    title: A trigger only the deleted sensor could pull
+    disposition: pending
+    disposition_rationale: null
+  - id: 6
+    lens: [consequences, alternatives]
+    title: Three residues, none of them on a clock
+    disposition: pending
+    disposition_rationale: null
+  - id: 7
+    lens: [alternatives, consequences]
+    title: The test becomes the inventory
+    disposition: pending
+    disposition_rationale: null
+  - id: 8
+    lens: [coherence, defaults]
+    title: Two counts, two standards of proof
+    disposition: pending
+    disposition_rationale: null
+---
+
+# Choice stories — Retire the template-currency nudge
+
+Eight stories against revision 4 of a spec that has already been through three
+adversarial passes. The twelve objections on
+`docs/superpowers/objections/template-currency-measure-content-design.md` are all
+disposed, and none of them is restated here: the survivorship argument (O1), the
+blind residue search (O2), the missing allow-list exemptions (O3), the
+unconsented migration (O4), Status-block accuracy in consuming projects (O5),
+the migration's reach (O6), the unpriced losses (O7), the delete-less
+alternative (O8), one-way-ness (O9), the mixed-version nudge (O10), the
+unchecked predicate (O11) and the incomplete enumerations (O12) are all
+adjudicated and out of scope for this record.
+
+These eight sit where that coverage stops. Four of them turn on one fact the
+objection record never had to look at: revision 4 is the first change in this
+repository to **retire** a piece of harness machinery, and the repository's
+governance apparatus — the evolution loop, the decision records, the sunset
+markers, the count guards — is built almost entirely for **adding** things.
+
+**Read-mode note.** `REFLECTION_LOG.md` was read bounded (header, opening
+entries, plus a targeted search for prior surprises about retirement, deletion
+and orphaned state — none found). `AGENTS.md`, `HARNESS.md`, the objection
+record, `commands/harness-upgrade.md` and
+`harness/decisions/HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one.md`
+were read in full or in the sections cited.
+
+## Story #1 — Retiring a GC rule outside the governed loop
+
+**Source:** spec §3 (the "Marker (this repository)" and "`Template currency` GC rule (this repository)" rows), §10
+**Lens:** defaults, patterns
+**Refs:** O4
+
+**Context.** The spec deletes the `Template currency` GC rule from this
+repository's own `HARNESS.md` (`HARNESS.md:760-769`) as one row of a deletion
+table, inside a feature PR. `CLAUDE.md`'s *Changing a Harness Rule* section says
+that once a harness exists, changing it goes through
+`/harness-assay → /harness-propose → /harness-accept → /harness-check`, with
+`/harness-review` when a rule lapses, and closes with: "hand edits are how a
+governing document becomes the least governed thing in the repository." The spec
+mentions the loop nowhere. §10 addresses only the arithmetic consequence — the
+`Garbage collection active:` count, which `/harness-audit` owns.
+
+**Forces.** The spec is retiring a rule that has *lapsed* in precisely the sense
+`/harness-review` names: its **Tool** field promises to compare template content
+and compares plugin versions instead. That is the loop's canonical trigger. Set
+against it: the loop's vocabulary is constraints, not GC rules.
+`commands/harness-propose.md` and `commands/harness-review.md` contain no
+mention of garbage collection; the HDR classifications route to `HARNESS.md`'s
+constraint section, `AGENTS.md`, or an agent skill file. And this rule predates
+the loop — it entered with the 2026-04-15 harness-upgrade spec, so there is no
+decision record to expire. Every governed retirement path the repository has
+assumes the rule entered through a governed door.
+
+**Options not taken.**
+
+- Run `/harness-review` on the lapsed rule and let `/harness-propose` draft a
+  retirement record, accepting that the loop would need extending to GC rules —
+  which is itself the finding.
+- Write the retirement as an HDR with a cost the approver states in their own
+  words, matching what every rule accepted since the loop shipped has paid.
+- Say in the spec that GC rules are outside the loop's scope and that the
+  feature-PR channel is therefore deliberate, so the next person retiring one
+  inherits a decision rather than a precedent.
+
+**Choice as written.** The spec chose the feature-PR channel by silence. It is
+the path of least resistance and it is almost certainly correct — but nothing in
+the document records that a channel was chosen, or that a different one exists
+and was considered.
+
+**Consequences.** The reasoning for retiring a governance rule lands in
+`docs/superpowers/specs/` rather than `harness/decisions/`, so
+`harness/decisions/index.md` and `/harness-timeline`, which reads it
+(`commands/harness-timeline.md:92`), will show the GC count moving 19 → 18 with
+no entry explaining why. A future reader asking "when did we stop checking
+template currency, and who agreed?" finds the answer only by knowing which spec
+to open. This is also the repository's first GC-rule retirement, so whatever
+happens here becomes the pattern: the loop's gap gets filled by precedent rather
+than by amendment.
+
+Note the diaboli quoted this exact `CLAUDE.md` line at O4 and aimed it at
+*consuming projects'* `HARNESS.md` files. The disposition — per-item consent —
+is right and is implemented in §5. The same sentence pointed at this
+repository's own governing document was never fired.
+
+**Pattern.** Chesterton's Fence read from the removal side. The spec does the
+archaeology the fence-remover is supposed to do — §1's verification is unusually
+good — and then removes the fence through a gate that keeps no register of
+fence-removals. The register exists (`harness/decisions/`); it is not addressed
+to this species of fence.
+
+## Story #2 — A bespoke predicate beside a general bucket
+
+**Source:** spec §4, §5, §5.1
+**Lens:** alternatives, patterns
+**Refs:** O4, O11
+
+**Context.** §4 keeps `/harness-upgrade`'s three-bucket comparison — **new**,
+**updated** and **removed** — untouched, and rightly treats that restraint as a
+virtue. §5 then adds a hand-written predicate in step 6 that looks for a
+`<!-- template-version: … -->` marker and a `### Template currency` GC rule
+whose **Tool** field references the template-version comment. But once the
+template stops shipping that rule, the existing parse already sees it: step 2
+matches `###` blocks under `## Garbage Collection` by heading name
+(case-insensitive, trimmed), and step 3 puts anything present in the user's file
+and absent from the template into the **removed** bucket.
+
+**Forces.** Specificity against generality. The marker genuinely needs a bespoke
+predicate — it is an HTML comment, not a `###` item, so nothing in the existing
+parse can see it. The GC rule does not: it is exactly the shape the parser
+already handles. The spec added one predicate covering both, which is the
+simpler thing to write and the harder thing to reconcile with the machinery
+beside it.
+
+**Options not taken.**
+
+- Bespoke predicate for the marker only; promote the **removed** bucket from
+  advisory to actionable for the rule, so one mechanism handles one class of
+  object.
+- Make the **removed** bucket offer removal generally, with the `Template
+  currency` rule as its first customer — the migration then costs no new
+  predicate at all and every future template retirement inherits it.
+- State that the bespoke predicate is deliberately narrow and one-shot, deleted
+  in the release that removes the habitat-discovery reader (see #6).
+
+**Choice as written.** Two mechanisms now see the same object under two
+vocabularies, in the same run. Step 4 lists it as a *removed item* — "Advisory
+only… No action required" — and step 6 asks the user to accept or skip its
+removal. §5.1's *near miss* is a third vocabulary for the case where the
+heading matches and the Tool field does not; under the generic parse that same
+file is an ordinary removed item, reported without ceremony. The predicates also
+disagree in strictness: the command matches by heading name, the migration
+requires heading *and* Tool field.
+
+**Consequences.** The user of a project that has customised the rule can be told
+about it twice in one command run, once as advisory and once as a decision to
+make, with no cross-reference between them. Step 3's short-circuit inherits an
+awkward line too: "Your harness already contains all current template content.
+Then skip to step 6" now routes directly into a step that removes content. None
+of this breaks; all of it costs a reader. And the general improvement — an
+actionable removed bucket — that this change had the best occasion in the
+project's history to make, goes unmade and unmentioned.
+
+**Pattern.** Special case beside a general mechanism, the classic prelude to
+divergence: the two will be maintained by different people at different times
+and will drift on the matching rule first. The counter-pattern the spec is one
+step away from is Open/Closed — extend the bucket, don't branch beside it.
+
+## Story #3 — Deletion as the honest-status rule's converse
+
+**Source:** spec §1, §2, §5.1
+**Lens:** patterns, consequences
+**Refs:** O1
+
+**Context.** §5.1 cites "the decision record in force until 2026-11-23" for the
+migration report's three outcomes. That record is
+`HDR-2026-08-25-four-mechanisms-report-the-reassuring-answer-when-they-cannot-determine-the-real-one`,
+accepted the same day as this spec. Its rule: a mechanism that reports a status
+must have a defined value for the case where it could not determine the answer,
+and that value may not be the passing one — "a mechanism that fails toward the
+reassuring answer is worse than an absent one, because the next reader stops
+looking." The hook this spec deletes fails in the mirror direction: it reports
+the *alarming* value on evidence that cannot establish it.
+
+**Forces.** The HDR's remedy vocabulary is *report unknown and name the input
+you could not read*. The spec's remedy is *remove the reporter*. Both satisfy
+the rule; only one of them is in the rule's text. The unspoken force is that a
+false alarm and a false all-clear are not symmetric harms — the HDR grounds
+itself on "the next reader stops looking", and §1 documents the opposite harm,
+where a false alarm was believed and written into `HARNESS.md`'s Status block as
+"eight minors of unreviewed template content", then copied forward into the next
+block without being re-checked (`HARNESS.md:1185`). The spec demonstrates that
+the alarming direction is also load-bearing and does not say so.
+
+**Options not taken.**
+
+- Have the hook report what it can actually establish — "the plugin version
+  moved; whether the template changed is unknown from here" — which is the
+  HDR's prescribed shape and a true statement.
+- §7's third alternative, which makes the input readable rather than the report
+  honest about being unreadable.
+- Cite the HDR for the deletion as well as for the report, and record that
+  deletion is a legitimate compliance move under it.
+
+**Choice as written.** The spec chose removal, and cited the record for the
+small decision (§5.1's three outcomes) while leaving the large one uncited. That
+is the correct call on the merits and an unrecorded one on the reasoning.
+
+**Consequences.** This is the first worked instance in the repository of "delete
+it" as an answer to the reassuring-answer rule, and deletion is the cheapest
+compliance move available for anything that rule ever catches — vacuously
+satisfying, requires no unknown-state design, and needs no approver's cost
+statement. It is right here; it will be reached for again on weaker facts.
+Second, and more concretely: the HDR's own validation criterion is to read the
+objection records written before 2026-11-23 and look for objections the rule
+produced and dispositions that acted on them, with no such objections meaning
+retirement. A defect removed before a diaboli pass can object to it produces no
+entry in that trail. This change quietly makes the HDR marginally harder to
+validate at expiry.
+
+**Pattern.** Alarm rationalisation from safety engineering (EEMUA 191 and its
+lineage): a nuisance annunciator is addressed by removal, re-ranging or
+suppression, and removal is legitimate specifically when the alarm has **no
+defined operator action**. That test is met here — the nudge's only response was
+running a command `README.md:99` already recommends after every plugin upgrade —
+and naming it gives the decision a defence stronger than the cost argument in
+§2.1. The same literature carries the caution worth recording alongside it: an
+annunciator removed for nuisance is rarely reinstated once the underlying signal
+becomes measurable, which is #5's subject.
+
+## Story #4 — A spec against proxies, argued by proxy
+
+**Source:** spec §1, §2.1, §9 (O1 row)
+**Lens:** coherence, forces
+**Refs:** O1, O8
+
+**Context.** §1's case is that `plugin.json`'s version is a broken proxy for
+template content: it moves for reasons unrelated to the thing it claims to
+measure. §2.1's case — which §9 records as the disposition to O1, and which is
+now the load-bearing justification for the whole decision — is a table of
+revisions scored on **acceptance criteria count** (9, 18, 8) and **adversarial
+review outcomes** (1 critical / 5 high, 1 critical / 8 high, 2 critical / 8
+high). Those are measurements of specs and of review sessions, not of the
+mechanism.
+
+**Forces.** Cost arguments need a number, and the only numbers this project
+generates about design work are pipeline artefacts: criteria counts, objection
+counts, severity mixes. The alternative measurement — what a correct notifier
+would cost to build and run — is stated in §7 and is small: one CI assertion.
+The spec resolves toward the numbers it has rather than the number that bears on
+the question, and never remarks on the substitution.
+
+**Options not taken.**
+
+- Price the surviving alternative directly against the deletion: one CI check
+  and a marker discipline, versus a permanent capability loss and a one-way
+  migration. §7 supplies both halves; nothing multiplies them out.
+- Attribute the review cost to its actual cause. Revisions 1 and 2 were
+  *heading-comparison* designs; §7's third alternative shares none of their
+  mechanism, so their objection counts are not evidence about it.
+- Keep both legs and say so — cost *and* the survivorship-limited history —
+  rather than transplanting the entire weight onto one.
+
+**Choice as written.** The spec chose to measure the mechanism's worth by the
+expense of specifying it. The symmetry with §1 is exact and unremarked: version
+count stood in for template content; objection count now stands in for design
+cost. A document whose opening move is *this number does not measure what it
+claims* closes on a number that does not measure what it claims.
+
+**Consequences.** The argument form generalises further than the spec wants:
+"three revisions and two criticals" is available against anything the pipeline
+finds hard to specify, which is not the same set as things not worth building.
+Revision 4 adds a fourth round to the tally it cites, so the metric grows with
+each attempt to answer the objections raised against it. Note also what changed
+in the argument's *role*: the diaboli's "explicitly not objecting to" section
+called §2.1 "strong on its own terms" while it was one leg of two. It was never
+reviewed carrying the whole weight, and the disposition that gave it that weight
+is the last word written on it.
+
+**Pattern.** Goodhart's law inside a review pipeline — a measure of the review
+process adopted as a measure of the thing reviewed. The adjacent human pattern
+is the sunk-cost-to-abandonment flip: effort spent on X reframed as evidence
+against X.
+
+## Story #5 — A trigger only the deleted sensor could pull
+
+**Source:** spec §2.2, §5.3, §7
+**Lens:** consequences, forces
+**Refs:** O1, O9, #3, #4
+
+**Context.** §7 keeps the reopening path warm: "**If §2.2's losses prove to
+matter, this is the option to reopen on**", and §5.3 (the O9 disposition) prices
+reopening honestly as a second migration. What neither section names is how
+anyone would learn that the losses matter. The four things that could have
+surfaced unadopted template content — the SessionStart hook, the `/harness-sync`
+monthly drift row, the `/harness-audit` drift-engine row and the required
+observatory signal — are the four things §2.2 deletes.
+
+**Forces.** Reversibility against evidence. The spec did the harder half: it
+faced up to reversibility (§5.3) after O9 pushed. The easier half went
+unexamined — a decision recorded as conditional needs an observer for its
+condition, and the deletion removes every observer. §1.1 states this class of
+problem with real care about the past: "in the five windows where the template
+was unchanged, a correct mechanism would have been silent and produced no
+evidence either way." The same reasoning applied forward gives the answer, and
+the spec does not apply it forward.
+
+**Options not taken.**
+
+- Name a review date rather than a trigger — reread this decision at the next
+  quarterly `/governance-audit`, whatever the evidence — matching the
+  `expires:` discipline every HDR carries.
+- Ask adopters directly. The objection record routes exactly this to the
+  Convener's consultation record ("Someone should ask adopters before removing a
+  capability from their projects"); a consultation is the only remaining channel
+  through which the evidence could arrive.
+- Build §7's third alternative *as the instrument rather than the notifier* —
+  silent when correct, recording adoptions where anyone could count them —
+  which is the version of it that generates the evidence the reopening decision
+  needs.
+
+**Choice as written.** The spec chose, by silence, that the reopening condition
+is met when a user independently notices something nobody told them about. The
+only user positioned to notice is one who runs `/harness-upgrade` regularly —
+which is precisely the user who lost nothing when the nudge went away.
+
+**Consequences.** The decision joins the class §1.1 describes with such
+precision: a proposition about a mechanism's value about which the tree will
+generate no evidence in either direction. §7's design stays legible and
+re-buildable; the hand that would reach for it does not exist. The honest
+reading is that this is a permanent decision written in provisional language,
+and the record should say so rather than leaving a future reader to conclude
+that nobody complained. Routing note: no failure class goes undetected by this
+— the mechanism being removed detected nothing real. What goes undetected is
+whether the removal was right.
+
+**Pattern.** A revisit clause with no observer — the ADR failure mode Nygard's
+format invites and does not prevent, since "Status: accepted" carries no
+expiry. The contrast inside this repository is sharp and worth citing: the HDR
+of #3 names an expiry date, a validation criterion, and the artefact that
+carries the evidence trail. This spec names a condition and none of the three.
+
+## Story #6 — Three residues, none of them on a clock
+
+**Source:** spec §2.2 ("One consumer is deliberately retained"), §3 (`.gitignore` paragraph), §5.2
+**Lens:** consequences, alternatives
+**Refs:** O7, O10
+
+**Context.** The change leaves three pieces of transitional state behind, each
+deliberately and each with a different implied lifetime.
+`skills/ai-literacy-assessment/references/habitat-discovery.md:93,141` keeps
+reading the marker and "is removed in a later release once the marker is rare".
+The `.gitignore` entry for `.claude/.harness-upgrade-dismissed` stays for a file
+nothing writes or reads. And the marker itself persists in every consuming
+project that never runs `/harness-upgrade` again (§5.2). Not one of the three
+has a date, an owner, or a measurable condition — "rare" is undefined and, after
+this change, unmeasurable, since the surfaces that could have counted markers in
+the wild are the ones being deleted.
+
+**Forces.** Deleting a reader before its data is gone is backwards, which O7
+established and §2.2 correctly implements. Against that: unclocked transitional
+state is the exact failure this spec exists to correct — a marker that outlived
+what it measured, kept because removing it was nobody's job.
+
+**Options not taken.**
+
+- A `<!-- redirect-sunset: YYYY-MM-DD -->`-style marker on the retained reader.
+  The repository already runs `scripts/check-redirect-sunsets.sh` monthly under
+  the `Redirect sunset` GC rule for precisely this class of expiring
+  transitional state.
+- An issue filed for the reader's removal, as §3.3 does for the
+  `reference/hooks.md:287` docs defect and §8 does for the declined-item record.
+  The spec has a deferral vocabulary; it does not use it here.
+- Define "rare" as something a person can check — say, review at the next
+  quarterly `/governance-audit`, which `CLAUDE.md` already schedules.
+
+**Choice as written.** The spec chose deliberate, indefinite residue. The
+retention decisions are all sound; the absence of a clock on any of them is
+unremarked, and it is a decision, because the repository has two established
+idioms for putting one on — the sunset marker and the HDR `expires:` field,
+about which the harness-evolution page is explicit: "An expired rule still in
+force fails CI, so retiring a rule never depends on anyone remembering."
+
+**Consequences.** After this PR the tree carries three artefacts whose only
+removal trigger is memory, and it removes a GC rule while creating state that a
+GC rule is this repository's normal answer for. The follow-up work is also now
+harder to scope than it is today: whoever removes the habitat-discovery reader
+in "a later release" has to re-derive what it read and why it was kept, from a
+spec that will by then be one of many in `docs/superpowers/specs/`.
+
+**Pattern.** Tombstone / vestigial field. The lifecycle shape is Strangler Fig
+(Fowler) with the cut-over left unstated — the old path is kept alive
+deliberately, and the condition for killing it is qualitative.
+
+## Story #7 — The test becomes the inventory
+
+**Source:** spec §3 (line-number paragraph), §6 criterion 8, §12
+**Lens:** alternatives, consequences
+**Refs:** O2, O12
+
+**Context.** §3 drops line numbers on purpose and says outright that "the
+residue assertion in §6 is what guarantees completeness, not the table"; §6
+adds that "Criterion 8 exists because hand enumeration failed three times" and
+supplies the count that damns the tables (7, then 12, then 19, against a real
+22 plus two prose surfaces no term search reaches). Authority over *what this
+change touched* moves from a curated inventory in the spec to an executable
+assertion in `tdad_tests/layer0_deterministic/test-template-currency-retired.sh`.
+
+**Forces.** Inventories rot silently and had been wrong three times running.
+Assertions run on every commit — but only answer the question someone encoded.
+"Is there residue now?" and "what did this change touch?" are different
+questions, and only the first is executable. The spec resolves toward the
+executable one and demotes the other to "a reader's aid" in the same breath.
+
+**Options not taken.**
+
+- Generate the §3 table from the search at implementation time, so the
+  inventory *is* the test's output and cannot disagree with it.
+- Keep the inventory authoritative and accept line-number drift as the cheap
+  cost it is — the objection record already dismisses drift as "normal spec
+  decay".
+- Put the allow-list in one place that both the spec and the test read, rather
+  than in prose in §6 and again in shell in the test.
+
+**Choice as written.** The spec chose test-as-source-of-truth and said so
+plainly, which is more than most specs manage. It also chose, by silence, that
+the allow-list lives in two disagreeing-capable copies: §6 states the list and
+forbids widening it ("An implementer must not widen the allow-list further to
+make the test pass; if a new file legitimately needs an exemption, that is a
+spec change"), while the runtime list is the shell array in the test file. That
+prohibition is written where the test cannot read it and the reviewer of a
+one-line array edit is unlikely to look.
+
+**Consequences.** The durable record of this change's scope becomes a Layer 0
+shell script, and §3 and §12 are explicitly non-authoritative from the day they
+are committed. Someone in six months asking why `reference/hooks.md` lost a
+section reads a table the spec itself disclaims. The allow-list can be widened
+by an edit that turns CI green with no mechanism comparing it back to §6 — the
+governance equivalent of what `CLAUDE.md` says about hand edits, one layer down.
+None of this is a failure of the change as specified; it is where the knowledge
+will live afterwards, which is a choice worth having made on purpose.
+
+**Pattern.** Executable specification (Fowler; Adzic's *Specification by
+Example*), with its known cost: the test encodes what someone thought to assert,
+and the prose that explains *why* those terms and not others degrades to
+commentary. The allow-list half is a policy expressed as prose against an
+artefact whose violation is a one-line diff — the same shape as an unenforced
+lint rule.
+
+## Story #8 — Two counts, two standards of proof
+
+**Source:** spec §3.2
+**Lens:** coherence, defaults
+**Refs:** O12, #7
+
+**Context.** §3.2 does two arithmetics, both correctly, and treats them
+identically. Hooks 18 → 17 and SessionStart 4 → 3 is guarded:
+`tdad_tests/layer0_deterministic/test-hooks-doc-parity.sh` fails if
+`reference/hooks.md` is not updated, and the spec cites both the test and the
+history of the count going stale ("hooks.json declares 18; the page documented
+16"). Observatory signals 82 → 81 is not guarded: the total is hard-coded at
+`observatory-signals.md:157`, `observatory-verify.md:3` (frontmatter), `:17`,
+and the results-table template at `:89`, and nothing pins it —
+`tdad_tests/tests/test_phase2_observatory_verify.py:67` asserts only that there
+are at least ten snapshot signals.
+
+**Forces.** Completeness against scope. The spec had every reason to stop at
+"move the counts": O12 asked only for the arithmetic and the disposition
+delivered it. Against that, §6's whole argument is that hand enumeration in this
+tree has a track record and needs a machine behind it. The spec applies that
+standard to *terms* and not to *counts*, in the same document, without noticing
+that it noticed the difference — it cites the hooks parity test as the reason
+one count must move, which means it read the guard and did not ask why the other
+count has none.
+
+**Options not taken.**
+
+- Extend criterion 8's Layer 0 test with an assertion that the four hard-coded
+  observatory totals agree with the number of signal rows. It is a `grep -c`
+  and a comparison, in a test file this spec is already creating.
+- Derive the total rather than hard-code it in four places, retiring the
+  arithmetic instead of performing it.
+- Say explicitly that guarding the total is out of scope, as §3.3 does for the
+  `hooks.md:287` defect — a sentence, and the next reader inherits a decision
+  rather than an oversight.
+
+**Choice as written.** The spec chose to pay the four-place arithmetic by hand
+and leave the guard unbuilt, and treated the presence of a test for one count
+and its absence for the other as a fact about which files to edit rather than as
+a question about which counts can be trusted.
+
+**Consequences.** The next change to the observatory signal set pays the same
+four-place tax, with the same reliance on someone remembering all four
+locations, and `observatory-verify.md`'s frontmatter description — the least
+likely of the four to be re-read — is where it will go stale. Routing note: this
+change moves all four correctly, so no failure is left undetected here; what is
+left unrecorded is why the residue assertion's own logic ("hands missed this
+three times, so assert it") stopped at the section boundary. Story #7's
+observation applies with the sign reversed — there, authority moved to the test
+and the prose was demoted; here, the count stayed in prose and the test that
+could have held it was not extended.
+
+**Pattern.** Magic number duplicated across artefacts, with a single-point-of-
+truth fix available and unexercised. The coherence reading is Alexander's:
+inside one section, two decisions about the same kind of object made on
+different principles, where the principle governing the first is written in
+§6 and simply not carried across.

--- a/docs/superpowers/stories/template-currency-measure-content-design.md
+++ b/docs/superpowers/stories/template-currency-measure-content-design.md
@@ -7,43 +7,43 @@ stories:
   - id: 1
     lens: [defaults, patterns]
     title: Retiring a GC rule outside the governed loop
-    disposition: pending
-    disposition_rationale: null
+    disposition: promoted
+    disposition_rationale: "The feature-PR channel stands, but the finding under it is bigger than this spec: the evolution loop has no retirement path for a GC rule, and /harness-review and /harness-propose do not mention garbage collection at all. Promoted to its own issue. The spec gains a sentence recording that the channel was chosen deliberately, so the next person retiring a GC rule inherits a decision rather than a precedent."
   - id: 2
     lens: [alternatives, patterns]
     title: A bespoke predicate beside a general bucket
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Keep the single predicate and say so: section 5 states it deliberately covers both the marker and the rule, is one-shot, and is deleted alongside the habitat-discovery reader. Splitting it would mean promoting the removed bucket from advisory to actionable, which is a larger change to /harness-upgrade than this migration should carry."
   - id: 3
     lens: [patterns, consequences]
     title: Deletion as the honest-status rule's converse
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Cite the HDR for the deletion itself, not only for the report format, and add the alarm-rationalisation test as the defence: removal is legitimate where the alarm has no defined operator action, which is true here since the nudge's only response was a command the README already recommends after every plugin upgrade. That is a stronger argument than the cost table and it fences the cheap version of 'delete it' at the same time."
   - id: 4
     lens: [coherence, forces]
     title: A spec against proxies, argued by proxy
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "The decision stands; the argument for it does not. Section 2.1's objection-count table stops being the load-bearing justification, replaced by story 3's alarm test and a direct price comparison against section 7's alternative. Also record that revisions 1 and 2 were heading-comparison designs, so their review outcomes are not evidence about an alternative that shares none of their mechanism."
   - id: 5
     lens: [consequences, forces]
     title: A trigger only the deleted sensor could pull
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Say plainly that this is permanent. Sections 2.2 and 7 state that the decision is one-way and that no mechanism remains which would report the reopening condition, so a future reader does not read silence as nobody having complained. A conditional recorded without an observer is a permanent decision in provisional language, and the record should not pretend otherwise."
   - id: 6
     lens: [consequences, alternatives]
     title: Three residues, none of them on a clock
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Put a sunset marker on the retained habitat-discovery reader so check-redirect-sunsets.sh surfaces it monthly under the Redirect sunset GC rule. The repository already has the idiom, and 'once the marker is rare' is unmeasurable after this change deletes the surfaces that could have counted markers in the wild. The gitignore entry and the marker in unmigrated projects are genuinely inert and are left."
   - id: 7
     lens: [alternatives, consequences]
     title: The test becomes the inventory
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "The allow-list lives in one declared location that the test reads and the spec points at, rather than as prose in section 6 and a shell array in the test. Test-as-source-of-truth is the right call, but a no-widening rule written where the test cannot read it is an unenforced lint rule, and a one-line array edit that turns CI green would not draw a reviewer's eye."
   - id: 8
     lens: [coherence, defaults]
     title: Two counts, two standards of proof
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Extend criterion 8's Layer 0 test to assert the four hard-coded observatory totals match the number of signal rows. Section 6's own argument is that hand enumeration in this tree needs a machine behind it; applying that to terms and not to counts, in a document that cites the hooks parity test as the reason one count must move, is an inconsistency worth closing rather than recording."
 ---
 
 # Choice stories — Retire the template-currency nudge


### PR DESCRIPTION
Closes #601 for the design half. **Spec only — no plugin files change, so no version bump. Implementation follows separately.**

## What this lands

A spec to retire the `template-version` marker, the `Template currency` GC rule, the SessionStart template-currency hook and the dismissal file. `/harness-upgrade` survives on demand, losing only its version gate and keeping its three-bucket parse intact.

## Why

The marker claims to track template content. It tracks the plugin version.

- The templates shipped at plugin `0.79.0` and `0.89.0` are **byte-identical** (`diff`, exit 0), and the `0.89.0` cache copy is byte-identical to the repo's own.
- `templates/HARNESS.md` last changed at `d867c7c`, 2026-08-13 — twelve days *before* `a81c552` stamped the marker to `0.79.0`.
- Ten minor versions moved. The template moved zero bytes.

So the hook asserted `Plugin template has been updated` on evidence that cannot establish it, and the false claim was transcribed into `HARNESS.md`'s Status block as "eight minors of unreviewed template content".

## How it got here

Three adversarial reviews, three revisions:

| | Rev 1 | Rev 2 | Rev 3 → 4 |
| --- | --- | --- | --- |
| Approach | compare heading sets | filter the compared set | delete the mechanism |
| New script + `PATH` shim | — | yes | — |
| New grammar in `HARNESS.md` | yes | yes | — |
| New `/harness-upgrade` disposition | yes | yes | — |
| Review outcome | 1 critical, 5 high | 1 critical, 8 high | 2 critical, 8 high |

Revisions 1 and 2 each paid more mechanism to defend a notifier, and each returned a critical. Revision 2's filter still fired on a default install, because the template's two OPTIONAL blocks ship commented out; and its `<!-- affordance-example -->` exclusion matched nothing, because the tag sits on the line *below* each heading (`grep '^###.*affordance-example'` returns zero).

**The case for deletion is cost and escalating complexity, not absence of value.** §1.1 states plainly that the run history damns *this* notifier — five false alarms in six firings — and cannot tell us whether a correct one would earn its keep, because one has never existed. §7 records the buildable correct version as the option to reopen on.

## Review trail

`docs/superpowers/objections/template-currency-measure-content-design.md` — **all twelve objections disposed: 7 accepted, 4 rejected, 1 amend.** Zero pending, zero null rationales.

Both criticals accepted:

- **O2** — the residue assertion's terms missed the phrasings actually in use. Now broadened and case-insensitive, and split into 8a (terms) and 8b (prose), because `first-time-tour.md:564` and `the-harness-lifecycle.md:88` describe the hook without naming it and no term search reaches them.
- **O4** — the migration deleted from a project's `HARNESS.md` unconditionally, inside a command built on per-item consent (`harness-upgrade.md:104`). Step 6 now presents each finding for accept/skip.

Rejected with reasons recorded: **O8** (delete only the hook — a drifted row from a broken proxy is still a false statement), **O5**, **O6**, **O10**.

Earlier records remain readable at `8e55729` (rev 1) and `6da8b77` (rev 2).

## Notes for review

- **Hand enumeration failed three times** — 7 surfaces, then 12, then 19. The broadened search returns 22, plus two prose surfaces no term search reaches. §3's table is now a reader's aid; criterion 8 is what guarantees completeness.
- **A defect that is not ours:** `reference/hooks.md:287` claims the hook "exits silently if… the marker is absent". It doesn't — `:32-34` treats absent as `0.0.0` and nudges. Pre-existing; §3.3 records it so it isn't silently absorbed.
- **The choice-story constraint** wants a record at `docs/superpowers/stories/` for specs dated after 2026-04-27. Not present here — `harness-enforcer` has no CI job, so this won't block, but it is an open gap rather than an exemption claim. Happy to run `/choice-cartograph` if you want it before merge.

## Follow-ups

- #603 — remove `/harness-sync` (lands after this)
- #602 — closed as superseded by #603
